### PR TITLE
optimize: performance for concurrent UDP requests

### DIFF
--- a/cipherstream/aead.go
+++ b/cipherstream/aead.go
@@ -28,24 +28,21 @@ func secretKey(password []byte) *[32]byte {
 }
 
 type AEADCipherImpl struct {
-	aead  cipher.AEAD
-	nonce []byte
+	aead cipher.AEAD
 }
 
 // Encrypt encrypts data using 256-bit AEAD.  This both hides the content of
 // the data and provides a check that it hasn't been altered. Output takes the
 // form nonce|ciphertext|tag where '|' indicates concatenation.
 func (aci *AEADCipherImpl) Encrypt(plaintext []byte) (ciphertext []byte, err error) {
-	if len(aci.nonce) == 0 {
-		aci.nonce = make([]byte, aci.aead.NonceSize())
-	}
+	nonce := make([]byte, aci.aead.NonceSize())
 
-	_, err = io.ReadFull(rand.Reader, aci.nonce)
+	_, err = io.ReadFull(rand.Reader, nonce)
 	if err != nil {
 		return nil, err
 	}
 
-	return aci.aead.Seal(aci.nonce, aci.nonce, plaintext, nil), nil
+	return aci.aead.Seal(nonce, nonce, plaintext, nil), nil
 }
 
 // Decrypt decrypts data using 256-bit AEAD.  This both hides the content of

--- a/cipherstream/aead.go
+++ b/cipherstream/aead.go
@@ -12,12 +12,12 @@ import (
 
 type AEADCipher interface {
 	Encrypt(plaintext []byte) (ciphertext []byte, err error)
+	EncryptTo(dst, plaintext []byte) (ciphertext []byte, err error)
 	Decrypt(ciphertext []byte) (plaintext []byte, err error)
 	NonceSize() int
 	Overhead() int
 }
 
-// secretKey generates a random 256-bit key
 func secretKey(password []byte) *[32]byte {
 	key := [32]byte{}
 
@@ -43,6 +43,53 @@ func (aci *AEADCipherImpl) Encrypt(plaintext []byte) (ciphertext []byte, err err
 	}
 
 	return aci.aead.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// EncryptTo encrypts data using 256-bit AEAD and appends to dst.
+// The dst buffer must have enough capacity to hold nonce+ciphertext+tag.
+// If dst is nil, it behaves like Encrypt (allocates new buffer).
+func (aci *AEADCipherImpl) EncryptTo(dst, plaintext []byte) (ciphertext []byte, err error) {
+	nonceSize := aci.aead.NonceSize()
+
+	// Ensure dst has space for nonce
+	if cap(dst)-len(dst) < nonceSize {
+		// If capacity is not enough, we have to append (which might reallocate)
+		// Or we could panic/error if we strictly require pre-allocated buffer.
+		// For safety and compatibility with standard append semantics:
+		newDst := make([]byte, len(dst)+nonceSize)
+		copy(newDst, dst)
+		dst = newDst
+	} else {
+		// Expand dst to include nonce space
+		dst = dst[:len(dst)+nonceSize]
+	}
+
+	// The nonce is at the end of the current dst
+	nonce := dst[len(dst)-nonceSize:]
+
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	// Seal appends ciphertext+tag to the start of nonce (which is dst[len(dst)-nonceSize:])
+	// Wait, Seal(dst, nonce, plaintext, additionalData)
+	// The first argument to Seal is 'dst', where the result is appended.
+	// We want the result to be appended to the buffer *before* the nonce? No.
+	// Standard AEAD: nonce is IV. Output is usually nonce + ciphertext + tag.
+	// So we want:
+	// 1. Append nonce to dst.
+	// 2. Call Seal, passing (dst, nonce, plaintext, nil).
+	// Seal will append ciphertext+tag to dst.
+	// So final dst will be: original_dst + nonce + ciphertext + tag.
+
+	// Let's adjust logic:
+	// We appended nonce to dst above. So 'dst' now includes the nonce at the end.
+	// But Seal needs the 'dst' slice *before* the ciphertext is added.
+	// So Seal(dst, nonce, ...) will append ciphertext to dst.
+	// Correct.
+
+	return aci.aead.Seal(dst, nonce, plaintext, nil), nil
 }
 
 // Decrypt decrypts data using 256-bit AEAD.  This both hides the content of

--- a/cipherstream/aead.go
+++ b/cipherstream/aead.go
@@ -12,12 +12,12 @@ import (
 
 type AEADCipher interface {
 	Encrypt(plaintext []byte) (ciphertext []byte, err error)
-	EncryptTo(dst, plaintext []byte) (ciphertext []byte, err error)
 	Decrypt(ciphertext []byte) (plaintext []byte, err error)
 	NonceSize() int
 	Overhead() int
 }
 
+// secretKey generates a random 256-bit key
 func secretKey(password []byte) *[32]byte {
 	key := [32]byte{}
 
@@ -43,53 +43,6 @@ func (aci *AEADCipherImpl) Encrypt(plaintext []byte) (ciphertext []byte, err err
 	}
 
 	return aci.aead.Seal(nonce, nonce, plaintext, nil), nil
-}
-
-// EncryptTo encrypts data using 256-bit AEAD and appends to dst.
-// The dst buffer must have enough capacity to hold nonce+ciphertext+tag.
-// If dst is nil, it behaves like Encrypt (allocates new buffer).
-func (aci *AEADCipherImpl) EncryptTo(dst, plaintext []byte) (ciphertext []byte, err error) {
-	nonceSize := aci.aead.NonceSize()
-
-	// Ensure dst has space for nonce
-	if cap(dst)-len(dst) < nonceSize {
-		// If capacity is not enough, we have to append (which might reallocate)
-		// Or we could panic/error if we strictly require pre-allocated buffer.
-		// For safety and compatibility with standard append semantics:
-		newDst := make([]byte, len(dst)+nonceSize)
-		copy(newDst, dst)
-		dst = newDst
-	} else {
-		// Expand dst to include nonce space
-		dst = dst[:len(dst)+nonceSize]
-	}
-
-	// The nonce is at the end of the current dst
-	nonce := dst[len(dst)-nonceSize:]
-
-	_, err = io.ReadFull(rand.Reader, nonce)
-	if err != nil {
-		return nil, err
-	}
-
-	// Seal appends ciphertext+tag to the start of nonce (which is dst[len(dst)-nonceSize:])
-	// Wait, Seal(dst, nonce, plaintext, additionalData)
-	// The first argument to Seal is 'dst', where the result is appended.
-	// We want the result to be appended to the buffer *before* the nonce? No.
-	// Standard AEAD: nonce is IV. Output is usually nonce + ciphertext + tag.
-	// So we want:
-	// 1. Append nonce to dst.
-	// 2. Call Seal, passing (dst, nonce, plaintext, nil).
-	// Seal will append ciphertext+tag to dst.
-	// So final dst will be: original_dst + nonce + ciphertext + tag.
-
-	// Let's adjust logic:
-	// We appended nonce to dst above. So 'dst' now includes the nonce at the end.
-	// But Seal needs the 'dst' slice *before* the ciphertext is added.
-	// So Seal(dst, nonce, ...) will append ciphertext to dst.
-	// Correct.
-
-	return aci.aead.Seal(dst, nonce, plaintext, nil), nil
 }
 
 // Decrypt decrypts data using 256-bit AEAD.  This both hides the content of

--- a/cipherstream/cipherstream.go
+++ b/cipherstream/cipherstream.go
@@ -118,13 +118,10 @@ func (cs *CipherStream) ReadFrom(r io.Reader) (n int64, err error) {
 	buf := bytespool.Get(MaxCipherRelaySize)
 	defer bytespool.MustPut(buf)
 
-	wbuf := bytespool.Get(MaxPayloadSize + cs.NonceSize() + cs.Overhead())
-	defer bytespool.MustPut(wbuf)
+	payloadBuf := bytespool.Get(MaxPayloadSize + cs.NonceSize() + cs.Overhead())
+	defer bytespool.MustPut(payloadBuf)
 
 	for {
-		buf = buf[:0]
-		payloadBuf := wbuf[:MaxPayloadSize]
-
 		nr, er := r.Read(payloadBuf)
 		if nr > 0 {
 			err = errors.Join(func() error {

--- a/cipherstream/cipherstream.go
+++ b/cipherstream/cipherstream.go
@@ -73,7 +73,7 @@ func (cs *CipherStream) WriteFrame(f *Frame) error {
 	buf := bytespool.Get(MaxCipherRelaySize)
 	defer bytespool.MustPut(buf)
 
-	frameBytes, err := f.EncodeWithCipher(buf)
+	frameBytes, err := f.EncodeWithCipher(buf[:0])
 	if err != nil {
 		log.Error("[CIPHERSTREAM] encode frame with cipher", "err", err)
 		return err
@@ -118,23 +118,27 @@ func (cs *CipherStream) ReadFrom(r io.Reader) (n int64, err error) {
 	buf := bytespool.Get(MaxCipherRelaySize)
 	defer bytespool.MustPut(buf)
 
-	payloadBuf := bytespool.Get(MaxPayloadSize + cs.NonceSize() + cs.Overhead())
-	defer bytespool.MustPut(payloadBuf)
+	wbuf := bytespool.Get(MaxPayloadSize + cs.NonceSize() + cs.Overhead())
+	defer bytespool.MustPut(wbuf)
 
 	for {
+		buf = buf[:0]
+		payloadBuf := wbuf[:MaxPayloadSize]
+
 		nr, er := r.Read(payloadBuf)
 		if nr > 0 {
 			err = errors.Join(func() error {
 				frame := NewFrame(cs.frameType, payloadBuf[:nr], cs.flag, cs.AEADCipher)
 				defer frame.Release()
 
-				frameBytes, er := frame.EncodeWithCipher(buf)
+				var er error
+				buf, er = frame.EncodeWithCipher(buf)
 				if er != nil {
 					log.Error("[CIPHERSTREAM] encode frame with cipher", "err", er)
 					return er
 				}
 
-				if _, ew := cs.Conn.Write(frameBytes); ew != nil {
+				if _, ew := cs.Conn.Write(buf); ew != nil {
 					if !errors.Is(ew, netpipe.ErrPipeClosed) {
 						log.Warn("[CIPHERSTREAM] write cipher data to cipher stream failed", "err", ew)
 					}

--- a/cipherstream/cipherstream.go
+++ b/cipherstream/cipherstream.go
@@ -118,10 +118,13 @@ func (cs *CipherStream) ReadFrom(r io.Reader) (n int64, err error) {
 	buf := bytespool.Get(MaxCipherRelaySize)
 	defer bytespool.MustPut(buf)
 
-	payloadBuf := bytespool.Get(MaxPayloadSize + cs.NonceSize() + cs.Overhead())
-	defer bytespool.MustPut(payloadBuf)
+	wbuf := bytespool.Get(MaxPayloadSize + cs.NonceSize() + cs.Overhead())
+	defer bytespool.MustPut(wbuf)
 
 	for {
+		buf = buf[:0]
+		payloadBuf := wbuf[:MaxPayloadSize]
+
 		nr, er := r.Read(payloadBuf)
 		if nr > 0 {
 			err = errors.Join(func() error {

--- a/cipherstream/frame.go
+++ b/cipherstream/frame.go
@@ -262,20 +262,19 @@ func NewFrame(ft FrameType, payload []byte, flag uint8, cipher AEADCipher) *Fram
 }
 
 func (f *Frame) EncodeWithCipher(buf []byte) ([]byte, error) {
-	buf = buf[:0]
-	var err error
-	
-	// Encrypt header and append to buf
-	buf, err = f.cipher.EncryptTo(buf, f.header)
+	headerCipher, err := f.cipher.Encrypt(f.header)
 	if err != nil {
 		return nil, err
 	}
 
-	// Encrypt payload and append to buf
-	buf, err = f.cipher.EncryptTo(buf, f.FramePayload())
+	payloadCipher, err := f.cipher.Encrypt(f.FramePayload())
 	if err != nil {
 		return nil, err
 	}
+
+	buf = buf[:0]
+	buf = append(buf, headerCipher...)
+	buf = append(buf, payloadCipher...)
 
 	return buf, nil
 }

--- a/cipherstream/frame.go
+++ b/cipherstream/frame.go
@@ -262,19 +262,20 @@ func NewFrame(ft FrameType, payload []byte, flag uint8, cipher AEADCipher) *Fram
 }
 
 func (f *Frame) EncodeWithCipher(buf []byte) ([]byte, error) {
-	headerCipher, err := f.cipher.Encrypt(f.header)
-	if err != nil {
-		return nil, err
-	}
-
-	payloadCipher, err := f.cipher.Encrypt(f.FramePayload())
-	if err != nil {
-		return nil, err
-	}
-
 	buf = buf[:0]
-	buf = append(buf, headerCipher...)
-	buf = append(buf, payloadCipher...)
+	var err error
+	
+	// Encrypt header and append to buf
+	buf, err = f.cipher.EncryptTo(buf, f.header)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encrypt payload and append to buf
+	buf, err = f.cipher.EncryptTo(buf, f.FramePayload())
+	if err != nil {
+		return nil, err
+	}
 
 	return buf, nil
 }

--- a/direct_udp.go
+++ b/direct_udp.go
@@ -72,10 +72,16 @@ func (ss *Easyss) directUDPRelay(s *socks5.Server, laddr *net.UDPAddr, d *socks5
 	var src = laddr.String()
 	var exchKey = src + dst + DirectSuffix
 
+	iue, ok := s.UDPExchanges.Get(exchKey)
+	if ok {
+		ue = iue.(*DirectUDPExchange)
+		return send(ue, d.Data, uAddr)
+	}
+
 	ss.lockKey(exchKey)
 	defer ss.unlockKey(exchKey)
 
-	iue, ok := s.UDPExchanges.Get(exchKey)
+	iue, ok = s.UDPExchanges.Get(exchKey)
 	if ok {
 		ue = iue.(*DirectUDPExchange)
 		return send(ue, d.Data, uAddr)

--- a/local_udp.go
+++ b/local_udp.go
@@ -124,10 +124,17 @@ func (ss *Easyss) UDPHandle(s *socks5.Server, addr *net.UDPAddr, d *socks5.Datag
 
 	var ue *UDPExchange
 	var exchKey = addr.String() + dst
+
+	iue, ok := s.UDPExchanges.Get(exchKey)
+	if ok {
+		ue = iue.(*UDPExchange)
+		return send(ue, d.Data)
+	}
+
 	ss.lockKey(exchKey)
 	defer ss.unlockKey(exchKey)
 
-	iue, ok := s.UDPExchanges.Get(exchKey)
+	iue, ok = s.UDPExchanges.Get(exchKey)
 	if ok {
 		ue = iue.(*UDPExchange)
 		return send(ue, d.Data)

--- a/local_udp.go
+++ b/local_udp.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -21,7 +22,7 @@ import (
 const (
 	MaxUDPDataSize   = 65507
 	DefaultDNSServer = "8.8.8.8:53"
-	MaxUDPConnCount  = 20
+	MaxUDPConnCount  = 16
 )
 
 const DefaultDNSTimeout = 5 * time.Second
@@ -33,6 +34,7 @@ type UDPExchange struct {
 	mu         sync.Mutex
 	cond       *sync.Cond
 	Pending    int
+	ActiveReqs int32
 }
 
 func (ss *Easyss) UDPHandle(s *socks5.Server, addr *net.UDPAddr, d *socks5.Datagram) error {
@@ -42,143 +44,130 @@ func (ss *Easyss) UDPHandle(s *socks5.Server, addr *net.UDPAddr, d *socks5.Datag
 	rewrittenDst := dst
 
 	msg := &dns.Msg{}
-	err := msg.Unpack(d.Data)
-	isDNSReq := isDNSRequest(msg)
-	if err == nil && isDNSReq {
-		question := msg.Question[0]
-
-		rule := ss.MatchHostRule(strings.TrimSuffix(question.Name, "."))
-		if rule == HostRuleBlock {
-			return responseBlockedDNSMsg(s.UDPConn, addr, msg, d.Address())
+	if err := msg.Unpack(d.Data); err == nil && isDNSRequest(msg) {
+		handled, err := ss.handleDNS(s, addr, d, msg)
+		if err != nil {
+			return err
 		}
-		if ss.ShouldIPV6Disable() && question.Qtype == dns.TypeAAAA {
-			return responseEmptyDNSMsg(s.UDPConn, addr, msg, d.Address())
-		}
-
-		isDirect := rule == HostRuleDirect
-
-		// find from dns cache first
-		msgCache := ss.DNSCache(question.Name, dns.TypeToString[question.Qtype], isDirect)
-		if msgCache != nil {
-			msgCache.Id = msg.Id
-			log.Info("[DNS_CACHE] find from cache", "domain", question.Name, "qtype", dns.TypeToString[question.Qtype])
-			if err := responseDNSMsg(s.UDPConn, addr, msgCache, d.Address()); err != nil {
-				log.Error("[DNS_CACHE] write msg back", "err", err)
-				return err
-			}
-			if strings.TrimSuffix(question.Name, ".") != ss.Server() {
-				log.Debug("[DNS_CACHE] renew cache for", "domain", question.Name)
-				ss.RenewDNSCache(question.Name, dns.TypeToString[question.Qtype], isDirect)
-			}
+		if handled {
 			return nil
 		}
-
-		if isDirect {
-			log.Info("[DNS_DIRECT]", "domain", question.Name, "qtype", dns.TypeToString[question.Qtype])
-			return ss.directUDPRelay(s, addr, d, true)
-		}
-
-		log.Info("[DNS_PROXY]", "domain", msg.Question[0].Name, "qtype", dns.TypeToString[msg.Question[0].Qtype])
-
 		log.Debug("[DNS_PROXY] rewrite dns dst to", "server", DefaultDNSServer)
 		rewrittenDst = DefaultDNSServer
 	}
 
 	dstHost, port, _ := net.SplitHostPort(rewrittenDst)
 	if ss.MatchHostRule(dstHost) == HostRuleDirect {
-		return ss.directUDPRelay(s, addr, d, isDNSReq)
+		return ss.directUDPRelay(s, addr, d, isDNSRequest(msg))
 	}
 
-	if port == "443" && ss.DisableQUIC() { // disable quic proto
+	if err := ss.validateUDPProxyReq(dstHost, port, rewrittenDst); err != nil {
+		return err
+	}
+
+	ch, hasAssoc := ss.getAssociatedChan(s, addr, d)
+	ue, exchKey := ss.getOrCreateUDPExchange(s, addr, dst)
+	atomic.AddInt32(&ue.ActiveReqs, 1)
+	defer atomic.AddInt32(&ue.ActiveReqs, -1)
+
+	conn := ss.getConnFromPool(ue, rewrittenDst, dst, ch, hasAssoc, isDNSRequest(msg), exchKey, s)
+	if conn == nil {
+		return errors.New("get conn from pool failed")
+	}
+
+	return ss.sendUDPData(conn, d.Data, ch, addr)
+}
+
+func (ss *Easyss) handleDNS(s *socks5.Server, addr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg) (bool, error) {
+	question := msg.Question[0]
+	rule := ss.MatchHostRule(strings.TrimSuffix(question.Name, "."))
+
+	if rule == HostRuleBlock {
+		return true, responseBlockedDNSMsg(s.UDPConn, addr, msg, d.Address())
+	}
+	if ss.ShouldIPV6Disable() && question.Qtype == dns.TypeAAAA {
+		return true, responseEmptyDNSMsg(s.UDPConn, addr, msg, d.Address())
+	}
+
+	isDirect := rule == HostRuleDirect
+	if msgCache := ss.DNSCache(question.Name, dns.TypeToString[question.Qtype], isDirect); msgCache != nil {
+		msgCache.Id = msg.Id
+		log.Info("[DNS_CACHE] find from cache", "domain", question.Name, "qtype", dns.TypeToString[question.Qtype])
+		if err := responseDNSMsg(s.UDPConn, addr, msgCache, d.Address()); err != nil {
+			log.Error("[DNS_CACHE] write msg back", "err", err)
+			return true, err
+		}
+		if strings.TrimSuffix(question.Name, ".") != ss.Server() {
+			log.Debug("[DNS_CACHE] renew cache for", "domain", question.Name)
+			ss.RenewDNSCache(question.Name, dns.TypeToString[question.Qtype], isDirect)
+		}
+		return true, nil
+	}
+
+	if isDirect {
+		log.Info("[DNS_DIRECT]", "domain", question.Name, "qtype", dns.TypeToString[question.Qtype])
+		return true, ss.directUDPRelay(s, addr, d, true)
+	}
+
+	log.Info("[DNS_PROXY]", "domain", msg.Question[0].Name, "qtype", dns.TypeToString[msg.Question[0].Qtype])
+	return false, nil
+}
+
+func (ss *Easyss) validateUDPProxyReq(dstHost, port, rewrittenDst string) error {
+	if port == "443" && ss.DisableQUIC() {
 		log.Info("[UDP_PROXY] quic is disabled", "dst", rewrittenDst)
 		return errors.New("quic is disabled")
 	}
 	if !ss.disableValidateAddr {
 		if err := ss.validateAddr(rewrittenDst); err != nil {
-			log.Warn("[UDP_PROXY] validate", "dst", dst, "err", err)
+			log.Warn("[UDP_PROXY] validate", "dst", rewrittenDst, "err", err)
 			return errors.New("dst addr is invalid")
 		}
 	}
+	return nil
+}
 
-	var ch chan struct{}
-	var hasAssoc bool
-
+func (ss *Easyss) getAssociatedChan(s *socks5.Server, addr *net.UDPAddr, d *socks5.Datagram) (chan struct{}, bool) {
 	portStr := strconv.FormatInt(int64(addr.Port), 10)
 	asCh, ok := s.AssociatedUDP.Get(portStr)
 	if ok {
-		hasAssoc = true
-		ch = asCh.(chan struct{})
 		log.Debug("[UDP_PROXY] found the associate with tcp", "src", addr.String(), "dst", d.Address())
-	} else {
-		ch = make(chan struct{}, 2)
-		log.Debug("[UDP_PROXY] the addr doesn't associate with tcp", "addr", addr.String(), "dst", d.Address())
+		return asCh.(chan struct{}), true
+	}
+	log.Debug("[UDP_PROXY] the addr doesn't associate with tcp", "addr", addr.String(), "dst", d.Address())
+	return make(chan struct{}, 2), false
+}
+
+func (ss *Easyss) getOrCreateUDPExchange(s *socks5.Server, addr *net.UDPAddr, dst string) (*UDPExchange, string) {
+	exchKey := addr.String() + dst
+	if iue, ok := s.UDPExchanges.Get(exchKey); ok {
+		return iue.(*UDPExchange), exchKey
 	}
 
-	send := func(conn net.Conn, data []byte) error {
-		select {
-		case <-ch:
-			return fmt.Errorf("the tcp that udp address %s associated closed", addr.String())
-		default:
-		}
-		_, err := conn.Write(data)
-		if err != nil {
-			return err
-		}
-		log.Debug("[UDP_PROXY] sent data to remote", "from", addr.String())
-		return nil
+	ss.lockKey(exchKey)
+	defer ss.unlockKey(exchKey)
+
+	if iue, ok := s.UDPExchanges.Get(exchKey); ok {
+		return iue.(*UDPExchange), exchKey
 	}
 
-	var ue *UDPExchange
-	var exchKey = addr.String() + dst
-
-	iue, ok := s.UDPExchanges.Get(exchKey)
-	if ok {
-		ue = iue.(*UDPExchange)
-	} else {
-		ss.lockKey(exchKey)
-		iue, ok = s.UDPExchanges.Get(exchKey)
-		if ok {
-			ue = iue.(*UDPExchange)
-		} else {
-			ue = &UDPExchange{
-				ClientAddr: addr,
-			}
-			ue.cond = sync.NewCond(&ue.mu)
-			s.UDPExchanges.Set(exchKey, ue, -1)
-		}
-		ss.unlockKey(exchKey)
+	ue := &UDPExchange{
+		ClientAddr: addr,
 	}
+	ue.cond = sync.NewCond(&ue.mu)
+	s.UDPExchanges.Set(exchKey, ue, -1)
+	return ue, exchKey
+}
 
+func (ss *Easyss) getConnFromPool(ue *UDPExchange, rewrittenDst, dst string, ch chan struct{}, hasAssoc, isDNSReq bool, exchKey string, s *socks5.Server) net.Conn {
 	ue.mu.Lock()
+	defer ue.mu.Unlock()
+
 	if len(ue.Conns) == 0 {
 		for len(ue.Conns) == 0 {
 			if ue.Pending < MaxUDPConnCount {
 				ue.Pending++
-				go func() {
-					defer func() {
-						ue.mu.Lock()
-						ue.Pending--
-						ue.cond.Broadcast()
-						ue.mu.Unlock()
-					}()
-
-					flag := cipherstream.FlagUDP
-					if isDNSReq {
-						flag |= cipherstream.FlagDNS
-					}
-					csStream, err := ss.handShakeWithRemote(rewrittenDst, flag)
-					if err != nil {
-						log.Error("[UDP_PROXY] handshake with remote server", "err", err)
-						if csStream != nil {
-							if cs, ok := csStream.(*cipherstream.CipherStream); ok {
-								cs.MarkConnUnusable()
-							}
-							_ = csStream.Close()
-						}
-						return
-					}
-					ss.addRemoteConn(ue, csStream, dst, ch, hasAssoc, isDNSReq, exchKey, s)
-				}()
+				go ss.handshakeAndAddConn(ue, rewrittenDst, dst, ch, hasAssoc, isDNSReq, exchKey, s)
 			}
 			ue.cond.Wait()
 		}
@@ -186,28 +175,51 @@ func (ss *Easyss) UDPHandle(s *socks5.Server, addr *net.UDPAddr, d *socks5.Datag
 
 	connCount := len(ue.Conns)
 	conn := ue.Conns[rand.Intn(connCount)]
-	if connCount+ue.Pending < MaxUDPConnCount {
+	if connCount+ue.Pending < MaxUDPConnCount && atomic.LoadInt32(&ue.ActiveReqs) >= int32(connCount) {
 		ue.Pending++
-		go func() {
-			defer func() {
-				ue.mu.Lock()
-				ue.Pending--
-				ue.cond.Broadcast()
-				ue.mu.Unlock()
-			}()
-			flag := cipherstream.FlagUDP
-			if isDNSReq {
-				flag |= cipherstream.FlagDNS
-			}
-			csStream, err := ss.handShakeWithRemote(rewrittenDst, flag)
-			if err == nil {
-				ss.addRemoteConn(ue, csStream, dst, ch, hasAssoc, isDNSReq, exchKey, s)
-			}
-		}()
+		go ss.handshakeAndAddConn(ue, rewrittenDst, dst, ch, hasAssoc, isDNSReq, exchKey, s)
 	}
-	ue.mu.Unlock()
+	return conn
+}
 
-	return send(conn, d.Data)
+func (ss *Easyss) handshakeAndAddConn(ue *UDPExchange, rewrittenDst, dst string, ch chan struct{}, hasAssoc, isDNSReq bool, exchKey string, s *socks5.Server) {
+	defer func() {
+		ue.mu.Lock()
+		ue.Pending--
+		ue.cond.Broadcast()
+		ue.mu.Unlock()
+	}()
+
+	flag := cipherstream.FlagUDP
+	if isDNSReq {
+		flag |= cipherstream.FlagDNS
+	}
+	csStream, err := ss.handShakeWithRemote(rewrittenDst, flag)
+	if err != nil {
+		log.Error("[UDP_PROXY] handshake with remote server", "err", err)
+		if csStream != nil {
+			if cs, ok := csStream.(*cipherstream.CipherStream); ok {
+				cs.MarkConnUnusable()
+			}
+			_ = csStream.Close()
+		}
+		return
+	}
+	ss.addRemoteConn(ue, csStream, dst, ch, hasAssoc, isDNSReq, exchKey, s)
+}
+
+func (ss *Easyss) sendUDPData(conn net.Conn, data []byte, ch chan struct{}, addr *net.UDPAddr) error {
+	select {
+	case <-ch:
+		return fmt.Errorf("the tcp that udp address %s associated closed", addr.String())
+	default:
+	}
+	_, err := conn.Write(data)
+	if err != nil {
+		return err
+	}
+	log.Debug("[UDP_PROXY] sent data to remote", "from", addr.String())
+	return nil
 }
 
 func (ss *Easyss) addRemoteConn(ue *UDPExchange, conn net.Conn, dst string, ch chan struct{}, hasAssoc bool, isDNSReq bool, exchKey string, s *socks5.Server) {
@@ -216,132 +228,127 @@ func (ss *Easyss) addRemoteConn(ue *UDPExchange, conn net.Conn, dst string, ch c
 	ue.cond.Broadcast()
 	ue.mu.Unlock()
 
-	var monitorCh = make(chan bool)
-	// monitor the assoc tcp connection to be closed and try to reuse the underlying connection
-	go func() {
-		var tryReuse bool
-		select {
-		case <-ch:
-			if err := expireConn(conn); err != nil {
-				log.Error("[UDP_PROXY] expire remote conn", "err", err)
-			}
-			tryReuse = <-monitorCh
-		case tryReuse = <-monitorCh:
-		}
-		if err := conn.SetReadDeadline(time.Time{}); err != nil {
-			tryReuse = false
-		}
+	monitorCh := make(chan bool)
+	go ss.monitorConnReuse(conn, ch, monitorCh)
+	go ss.copyRemoteToLocal(ue, conn, dst, ch, hasAssoc, isDNSReq, exchKey, s, monitorCh)
+}
 
-		if tryReuse {
-			log.Debug("[UDP_PROXY] request is finished, try to reuse underlying tcp connection")
-			reuse := tryReuseInClient(conn, ss.Timeout())
-			if reuse != nil {
-				if cs, ok := conn.(*cipherstream.CipherStream); ok {
-					cs.MarkConnUnusable()
-				}
-				log.Warn("[UDP_PROXY] underlying proxy connection is unhealthy, need close it", "reuse", reuse)
-			} else {
-				log.Debug("[UDP_PROXY] underlying proxy connection is healthy, so reuse it")
-			}
-		} else {
+func (ss *Easyss) monitorConnReuse(conn net.Conn, ch chan struct{}, monitorCh chan bool) {
+	var tryReuse bool
+	select {
+	case <-ch:
+		if err := expireConn(conn); err != nil {
+			log.Error("[UDP_PROXY] expire remote conn", "err", err)
+		}
+		tryReuse = <-monitorCh
+	case tryReuse = <-monitorCh:
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		tryReuse = false
+	}
+
+	if tryReuse {
+		log.Debug("[UDP_PROXY] request is finished, try to reuse underlying tcp connection")
+		reuse := tryReuseInClient(conn, ss.Timeout())
+		if reuse != nil {
 			if cs, ok := conn.(*cipherstream.CipherStream); ok {
 				cs.MarkConnUnusable()
 			}
+			log.Warn("[UDP_PROXY] underlying proxy connection is unhealthy, need close it", "reuse", reuse)
+		} else {
+			log.Debug("[UDP_PROXY] underlying proxy connection is healthy, so reuse it")
 		}
-
-		_ = conn.Close()
-	}()
-
-	go func(ue *UDPExchange, conn net.Conn, dst string) {
-		var tryReuse = true
-		if !ss.IsNativeOutboundProto() {
-			tryReuse = false
+	} else {
+		if cs, ok := conn.(*cipherstream.CipherStream); ok {
+			cs.MarkConnUnusable()
 		}
+	}
 
-		defer func() {
-			ue.mu.Lock()
-			defer ue.mu.Unlock()
+	_ = conn.Close()
+}
 
-			// remove the conn from the list
-			for i, c := range ue.Conns {
-				if c == conn {
-					ue.Conns = append(ue.Conns[:i], ue.Conns[i+1:]...)
-					break
-				}
+func (ss *Easyss) copyRemoteToLocal(ue *UDPExchange, conn net.Conn, dst string, ch chan struct{}, hasAssoc, isDNSReq bool, exchKey string, s *socks5.Server, monitorCh chan bool) {
+	var tryReuse = true
+	if !ss.IsNativeOutboundProto() {
+		tryReuse = false
+	}
+
+	defer func() {
+		ue.mu.Lock()
+		defer ue.mu.Unlock()
+
+		// remove the conn from the list
+		for i, c := range ue.Conns {
+			if c == conn {
+				ue.Conns = append(ue.Conns[:i], ue.Conns[i+1:]...)
+				break
 			}
-			ue.cond.Broadcast()
+		}
+		ue.cond.Broadcast()
 
-			// We need to signal the monitor goroutine for THIS connection
-			monitorCh <- tryReuse
+		monitorCh <- tryReuse
 
-			if len(ue.Conns) == 0 {
-				ss.lockKey(exchKey)
-				// double check inside lock to be safe, though we hold ue.mu
-				// actually we should hold lockKey before checking len if we want to be 100% atomic with creating
-				// but here we are deleting.
+		if len(ue.Conns) == 0 {
+			ss.lockKey(exchKey)
+			s.UDPExchanges.Delete(exchKey)
+			ss.unlockKey(exchKey)
 
-				s.UDPExchanges.Delete(exchKey)
-				ss.unlockKey(exchKey)
-
-				// Notify association
-				select {
-				case ch <- struct{}{}:
-				default:
-				}
-			}
-		}()
-
-		var buf = bytespool.Get(MaxUDPDataSize)
-		defer bytespool.MustPut(buf)
-		for {
 			select {
-			case <-ch:
-				log.Info("[UDP_PROXY] the tcp that udp address associated closed", "udp_addr", ue.ClientAddr.String())
-				return
+			case ch <- struct{}{}:
 			default:
 			}
+		}
+	}()
 
-			if !hasAssoc {
-				var err error
-				if isDNSReq {
-					err = conn.SetReadDeadline(time.Now().Add(DefaultDNSTimeout))
-				} else {
-					err = conn.SetReadDeadline(time.Now().Add(ss.Timeout()))
-				}
-				if err != nil {
-					log.Error("[UDP_PROXY] set the deadline for remote conn err", "err", err)
-					tryReuse = false
-					return
-				}
+	buf := bytespool.Get(MaxUDPDataSize)
+	defer bytespool.MustPut(buf)
+	for {
+		select {
+		case <-ch:
+			log.Info("[UDP_PROXY] the tcp that udp address associated closed", "udp_addr", ue.ClientAddr.String())
+			return
+		default:
+		}
+
+		if !hasAssoc {
+			var err error
+			if isDNSReq {
+				err = conn.SetReadDeadline(time.Now().Add(DefaultDNSTimeout))
+			} else {
+				err = conn.SetReadDeadline(time.Now().Add(ss.Timeout()))
 			}
-			n, err := conn.Read(buf[:])
 			if err != nil {
-				if !errors.Is(err, cipherstream.ErrTimeout) {
-					tryReuse = false
-					log.Debug("[UDP_PROXY] remote conn read", "err", err)
-				}
-				return
-			}
-			log.Debug("[UDP_PROXY] got data from remote", "client", ue.ClientAddr.String(), "data_len", len(buf[0:n]))
-
-			// if is dns response, set result to dns cache
-			_msg := ss.SetDNSCacheIfNeeded(buf[0:n], false)
-
-			a, addr, port, err := socks5.ParseAddress(dst)
-			if err != nil {
-				log.Error("[UDP_PROXY] parse dst address", "err", err)
-				return
-			}
-			data := buf[0:n]
-			if _msg != nil {
-				data, _ = _msg.Pack()
-			}
-			d1 := socks5.NewDatagram(a, addr, port, data)
-			if _, err := s.UDPConn.WriteToUDP(d1.Bytes(), ue.ClientAddr); err != nil {
+				log.Error("[UDP_PROXY] set the deadline for remote conn err", "err", err)
+				tryReuse = false
 				return
 			}
 		}
-	}(ue, conn, dst)
+		n, err := conn.Read(buf[:])
+		if err != nil {
+			if !errors.Is(err, cipherstream.ErrTimeout) {
+				tryReuse = false
+				log.Debug("[UDP_PROXY] remote conn read", "err", err)
+			}
+			return
+		}
+		log.Debug("[UDP_PROXY] got data from remote", "client", ue.ClientAddr.String(), "data_len", len(buf[0:n]))
+
+		_msg := ss.SetDNSCacheIfNeeded(buf[0:n], false)
+
+		a, addr, port, err := socks5.ParseAddress(dst)
+		if err != nil {
+			log.Error("[UDP_PROXY] parse dst address", "err", err)
+			return
+		}
+		data := buf[0:n]
+		if _msg != nil {
+			data, _ = _msg.Pack()
+		}
+		d1 := socks5.NewDatagram(a, addr, port, data)
+		if _, err := s.UDPConn.WriteToUDP(d1.Bytes(), ue.ClientAddr); err != nil {
+			return
+		}
+	}
 }
 
 func (ss *Easyss) lockKey(key string) {


### PR DESCRIPTION
对于类似QUIC这样的请求，底层是相同端口的大量并发udp请求，原有的实现对于大量并发的udp请求，性能较低，因为在local_udp.go中有一个全局的锁，对于相同端口的udp请求，本质上是串行的。 考虑支持并行发送，以优化性能。

由于这样改动后，底层的CipherStream就会出现并发调用，因此需要改为支持并发调用。

Fixes: #78