### PR TITLE
fix: remove stale FIFO and socket files before creating in SpawnTunHelper

### DIFF
--- a/cmd/easyss/root_darwin.go
+++ b/cmd/easyss/root_darwin.go
@@ -204,14 +204,3 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 		}
 	}
 }
-
-type fifoWriter struct {
-	*os.File
-	path string
-}
-
-func (w *fifoWriter) Close() error {
-	err := w.File.Close()
-	os.Remove(w.path) //nolint:errcheck
-	return err
-}

--- a/cmd/easyss/root_darwin.go
+++ b/cmd/easyss/root_darwin.go
@@ -78,8 +78,9 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 		return nil, nil, fmt.Errorf("get executable: %w", err)
 	}
 
-	// Create a named FIFO for lifecycle signalling.
+	// Create a named FIFO for lifecycle signalling. Clean stale file first.
 	fifoPath := fmt.Sprintf("/tmp/easyss-tun-ctrl-%d.fifo", os.Getpid())
+	os.Remove(fifoPath) //nolint:errcheck
 	if err := unix.Mkfifo(fifoPath, 0600); err != nil {
 		return nil, nil, fmt.Errorf("mkfifo %s: %w", fifoPath, err)
 	}
@@ -96,7 +97,8 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 		fifoCh <- fifoResult{f, err}
 	}()
 
-	// Create the Unix socket for fd passing.
+	// Create the Unix socket for fd passing. Clean stale socket first.
+	os.Remove(fdSocketPath) //nolint:errcheck
 	fdListener, err := net.Listen("unix", fdSocketPath)
 	if err != nil {
 		// Clean up the FIFO on failure. The goroutine will unblock when we
@@ -169,7 +171,7 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 				os.Remove(fdSocketPath)     //nolint:errcheck
 				return nil, nil, fmt.Errorf("open fifo write: %w", r.err)
 			}
-			return r.f, fdListener, nil
+			return &fifoWriter{File: r.f, path: fifoPath}, fdListener, nil
 		case err := <-osaCh:
 			if err == nil {
 				// osascript succeeded; the helper may spawn a moment after
@@ -201,4 +203,15 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 			return nil, nil, fmt.Errorf("timeout waiting for tun helper (user may have cancelled)")
 		}
 	}
+}
+
+type fifoWriter struct {
+	*os.File
+	path string
+}
+
+func (w *fifoWriter) Close() error {
+	err := w.File.Close()
+	os.Remove(w.path) //nolint:errcheck
+	return err
 }

--- a/cmd/easyss/root_linux.go
+++ b/cmd/easyss/root_linux.go
@@ -88,8 +88,9 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 		return nil, nil, fmt.Errorf("get executable: %w", err)
 	}
 
-	// Create a named FIFO for lifecycle signalling.
+	// Create a named FIFO for lifecycle signalling. Clean stale file first.
 	fifoPath := fmt.Sprintf("/tmp/easyss-tun-ctrl-%d.fifo", os.Getpid())
+	os.Remove(fifoPath) //nolint:errcheck
 	if err := unix.Mkfifo(fifoPath, 0600); err != nil {
 		return nil, nil, fmt.Errorf("mkfifo %s: %w", fifoPath, err)
 	}
@@ -180,7 +181,7 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 				os.Remove(fifoPath)      //nolint:errcheck
 				return nil, nil, fmt.Errorf("open fifo write: %w", r.err)
 			}
-			return r.f, fdListener, nil
+			return &fifoWriter{File: r.f, path: fifoPath}, fdListener, nil
 		case err := <-pkexecCh:
 			if err == nil {
 				// pkexec succeeded; the helper may spawn a moment after

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -556,11 +556,10 @@ func (a *TrayApp) closeTun2socks() error {
 	// 3. The helper coordinates with any previous instance via a file lock
 	//    (/tmp/easyss-tun.lock). No need to wait here — the next helper
 	//    will block on the lock until this one exits and releases it.
+	//    The FIFO file itself is removed when tunHelperStdin is closed
+	//    (see fifoWriter.Close).
 
-	// 4. Clean up the FIFO and clear the HTTP /tun config.
-	fifoPath := fmt.Sprintf("/tmp/easyss-tun-ctrl-%d.fifo", os.Getpid())
-	os.Remove(fifoPath) //nolint:errcheck
-
+	// 4. Clear the HTTP /tun config.
 	if a.core != nil && a.core.HTTPServer != nil {
 		a.core.HTTPServer.ClearTunConfig()
 	}

--- a/cmd/easyss/tun_helper_unix.go
+++ b/cmd/easyss/tun_helper_unix.go
@@ -254,6 +254,20 @@ func flockWait(f *os.File, timeout time.Duration) error {
 	}
 }
 
+// fifoWriter wraps the FIFO write end and removes the FIFO file when closed,
+// so stale files never accumulate on retry or toggle-off. The FIFO is used
+// for lifecycle signalling: closing the writer (EOF) tells the helper to exit.
+type fifoWriter struct {
+	*os.File
+	path string
+}
+
+func (w *fifoWriter) Close() error {
+	err := w.File.Close()
+	os.Remove(w.path) //nolint:errcheck
+	return err
+}
+
 // ReceiveFd accepts a single connection on the Unix domain socket listener and
 // receives a file descriptor via SCM_RIGHTS. It does not read any data from
 // the connection — the fd is passed purely as ancillary data.


### PR DESCRIPTION
### Summary
When spawning the elevated TUN helper on macOS, `unix.Mkfifo` fails with `EEXIST` if a stale FIFO file from a previous run or cancelled authorization dialog already exists at `/tmp/easyss-tun-ctrl-<pid>.fifo`.

### Solution
- Call `os.Remove(fifoPath)` and `os.Remove(fdSocketPath)` before creation to ensure idempotency.
- Wrap returned FIFO file handle in a `fifoWriter` struct that automatically removes the FIFO file when closed.