### PR TITLE
fix: prevent removing system TMPDIR in helper script cleanup

### DIFF
--- a/cmd/easyss/tun_helper_darwin.go
+++ b/cmd/easyss/tun_helper_darwin.go
@@ -5,7 +5,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/nange/easyss/v3/scripts"
 	"github.com/nange/easyss/v3/util"
@@ -79,7 +78,7 @@ func runCreateScript(device, tunIP, tunGW, localGateway,
 	if err != nil {
 		return fmt.Errorf("write create script: %w", err)
 	}
-	defer os.RemoveAll(filepath.Dir(namePath)) //nolint:errcheck
+	defer os.Remove(namePath) //nolint:errcheck
 
 	_, err = util.Command("sh", namePath, device, tunIP, tunGW, localGateway,
 		tunIPV6Sub, tunGWV6, serverIPV6, localGatewayV6)
@@ -100,7 +99,7 @@ func runCloseScript(device, tunGW, localGateway, tunGWV6, serverIPV6, localGatew
 	if err != nil {
 		return nil
 	}
-	defer os.RemoveAll(filepath.Dir(namePath)) //nolint:errcheck
+	defer os.Remove(namePath) //nolint:errcheck
 
 	_, _ = util.Command("sh", namePath, device, tunGW, localGateway, tunGWV6, serverIPV6, localGatewayV6)
 	return nil

--- a/cmd/easyss/tun_helper_linux.go
+++ b/cmd/easyss/tun_helper_linux.go
@@ -5,7 +5,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/nange/easyss/v3/scripts"
@@ -75,7 +74,7 @@ func runCreateScript(device, tunIP, tunGW, localGateway,
 	if err != nil {
 		return fmt.Errorf("write create script: %w", err)
 	}
-	defer os.RemoveAll(filepath.Dir(namePath)) //nolint:errcheck
+	defer os.Remove(namePath) //nolint:errcheck
 
 	_, err = util.Command("bash", namePath, device, tunIP, tunGW, localGateway,
 		tunIPV6Sub, tunGWV6, serverIPV6, localGatewayV6)
@@ -96,7 +95,7 @@ func runCloseScript(device, tunGW, localGateway, tunGWV6, serverIPV6, localGatew
 	if err != nil {
 		return nil
 	}
-	defer os.RemoveAll(filepath.Dir(namePath)) //nolint:errcheck
+	defer os.Remove(namePath) //nolint:errcheck
 
 	_, _ = util.Command("bash", namePath, device, tunGW, localGateway, tunGWV6, serverIPV6, localGatewayV6)
 	return nil

--- a/util/file.go
+++ b/util/file.go
@@ -75,12 +75,17 @@ func DirFileList(dir string) ([]string, error) {
 }
 
 func WriteToTemp(filename string, content []byte) (namePath string, err error) {
-	tf, err := os.CreateTemp("", filename)
+	ext := filepath.Ext(filename)
+	base := strings.TrimSuffix(filename, ext)
+	pattern := base + "_*" + ext
+	tf, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", err
 	}
 
 	if _, err := tf.Write(content); err != nil {
+		tf.Close()           //nolint:errcheck
+		os.Remove(tf.Name()) //nolint:errcheck
 		return "", err
 	}
 


### PR DESCRIPTION
### Summary
In `tun_helper_darwin.go` and `tun_helper_linux.go`, `defer os.RemoveAll(filepath.Dir(namePath))` was accidentally deleting the entire system `/var/folders/ns/m50lfdwx31d0rpry09xd61dc0000gn/T/` (`/var/folders/.../T`) directory after executing scripts. This caused subsequent temporary file creation calls to fail with `open /var/folders/.../T/...: no such file or directory`.

### Solution
- Replace `defer os.RemoveAll(filepath.Dir(namePath))` with `defer os.Remove(namePath)` to delete only the script file itself.
- Enhance `util.WriteToTemp` to preserve the file extension pattern (`base_*.ext`) and cleanup partial file on write errors.