### PR TITLE
fix: add replay protection and fix proxy core race/leak issues

### DIFF
--- a/client/proxy/http_proxy.go
+++ b/client/proxy/http_proxy.go
@@ -235,7 +235,6 @@ func (s *HTTPProxyServer) isSelfTarget(r *http.Request) bool {
 	if target == s.listenAddr {
 		return true
 	}
-	// Handle localhost aliases (e.g. 127.0.0.1 vs localhost vs ::1).
 	th, tp, err := net.SplitHostPort(target)
 	if err != nil {
 		return false
@@ -247,7 +246,63 @@ func (s *HTTPProxyServer) isSelfTarget(r *http.Request) bool {
 	if tp != lp {
 		return false
 	}
-	return th == "127.0.0.1" || th == "localhost" || th == "::1"
+	if th == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(th)
+	if ip == nil {
+		// Never resolve domain names here: the lookup would go through the
+		// proxied DNS path and could deadlock or recurse.
+		return false
+	}
+	_, local := localIPSet()[ip.String()]
+	return ip.IsLoopback() || local
+}
+
+const localIPsCacheTTL = 60 * time.Second
+
+var localIPsCache = struct {
+	sync.Mutex
+	updated time.Time
+	set     map[string]struct{}
+}{}
+
+// localIPSet returns the set of IP addresses currently assigned to local
+// interfaces, cached for localIPsCacheTTL. It detects requests targeting the
+// proxy host itself: when listening on [::]:port, a request to a LAN address
+// of this host (e.g. 192.168.1.5:port) would otherwise be tunneled to the
+// server and potentially loop back into this proxy, creating an infinite
+// forwarding loop.
+func localIPSet() map[string]struct{} {
+	localIPsCache.Lock()
+	defer localIPsCache.Unlock()
+	if time.Since(localIPsCache.updated) < localIPsCacheTTL && localIPsCache.set != nil {
+		return localIPsCache.set
+	}
+	set := make(map[string]struct{})
+	if ifaces, err := net.Interfaces(); err == nil {
+		for _, ifc := range ifaces {
+			addrs, err := ifc.Addrs()
+			if err != nil {
+				continue
+			}
+			for _, a := range addrs {
+				var ip net.IP
+				switch v := a.(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+				if ip != nil {
+					set[ip.String()] = struct{}{}
+				}
+			}
+		}
+	}
+	localIPsCache.set = set
+	localIPsCache.updated = time.Now()
+	return set
 }
 
 func (s *HTTPProxyServer) authOK(r *http.Request) bool {

--- a/client/proxy/http_proxy_self_test.go
+++ b/client/proxy/http_proxy_self_test.go
@@ -1,0 +1,59 @@
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsSelfTarget(t *testing.T) {
+	s := &HTTPProxyServer{listenAddr: "[::]:8080"}
+
+	tests := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		{"精确匹配 listenAddr", "[::]:8080", true},
+		{"IPv4 环回", "127.0.0.1:8080", true},
+		{"localhost", "localhost:8080", true},
+		{"IPv6 环回", "[::1]:8080", true},
+		{"端口不同", "127.0.0.1:9090", false},
+		{"域名", "example.com:8080", false},
+		{"缺少端口", "127.0.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "http://"+tt.target+"/", nil)
+			if got := s.isSelfTarget(r); got != tt.want {
+				t.Errorf("isSelfTarget(%q) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSelfTarget_LocalInterfaceIP(t *testing.T) {
+	var local string
+	for ip := range localIPSet() {
+		if ip != "127.0.0.1" && ip != "::1" {
+			local = ip
+			break
+		}
+	}
+	if local == "" {
+		t.Skip("no non-loopback local IP found")
+	}
+
+	s := &HTTPProxyServer{listenAddr: "[::]:8080"}
+	r := httptest.NewRequest(http.MethodGet, "http://"+net.JoinHostPort(local, "8080")+"/", nil)
+	if !s.isSelfTarget(r) {
+		t.Errorf("isSelfTarget(%s:8080) should be true (local interface IP)", local)
+	}
+
+	r = httptest.NewRequest(http.MethodGet, "http://"+net.JoinHostPort(local, "9090")+"/", nil)
+	if s.isSelfTarget(r) {
+		t.Errorf("isSelfTarget(%s:9090) should be false (different port)", local)
+	}
+}

--- a/client/proxy/stream.go
+++ b/client/proxy/stream.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nange/easyss/v3/config"
@@ -399,7 +400,7 @@ type UDPExchange struct {
 	tx       shaper.Shaper
 	reader   *crypto.DecryptedReader
 	target   string
-	lastSeen time.Time
+	lastSeen atomic.Int64 // UnixNano, written by Send/Receive, read by LastSeen
 	mu       sync.Mutex
 }
 
@@ -438,19 +439,20 @@ func (h *StreamHandler) OpenUDPExchange(ctx context.Context, target string, meth
 	dr := crypto.NewDecryptedReader(stream, aadS2C, s2cEnc, s2cCounter)
 
 	log.Debug("[UDP_EXCHANGE] opened", "target", target)
-	return &UDPExchange{
-		stream:   stream,
-		tx:       shaper.New(c2sWriter, h.shaperCfg),
-		reader:   dr,
-		target:   target,
-		lastSeen: time.Now(),
-	}, nil
+	ue := &UDPExchange{
+		stream: stream,
+		tx:     shaper.New(c2sWriter, h.shaperCfg),
+		reader: dr,
+		target: target,
+	}
+	ue.lastSeen.Store(time.Now().UnixNano())
+	return ue, nil
 }
 
 func (ue *UDPExchange) Send(data []byte) error {
 	ue.mu.Lock()
 	defer ue.mu.Unlock()
-	ue.lastSeen = time.Now()
+	ue.lastSeen.Store(time.Now().UnixNano())
 	frame := protocol.NewFrameDATAGRAM(data)
 	if err := ue.tx.PushFrame(frame); err != nil {
 		return err
@@ -459,22 +461,24 @@ func (ue *UDPExchange) Send(data []byte) error {
 }
 
 func (ue *UDPExchange) Receive() ([]byte, error) {
-	frame, err := ue.reader.ReadFrame()
-	if err != nil {
-		return nil, err
-	}
-	ue.lastSeen = time.Now()
-	switch frame.Type {
-	case protocol.FrameDATAGRAM:
-		return frame.Payload, nil
-	case protocol.FrameFIN:
-		return nil, io.EOF
-	case protocol.FrameRST:
-		return nil, fmt.Errorf("udp stream reset")
-	case protocol.FramePADDING, protocol.FrameCOVER:
-		return ue.Receive()
-	default:
-		return nil, fmt.Errorf("unexpected frame type: %d", frame.Type)
+	for {
+		frame, err := ue.reader.ReadFrame()
+		if err != nil {
+			return nil, err
+		}
+		ue.lastSeen.Store(time.Now().UnixNano())
+		switch frame.Type {
+		case protocol.FrameDATAGRAM:
+			return frame.Payload, nil
+		case protocol.FrameFIN:
+			return nil, io.EOF
+		case protocol.FrameRST:
+			return nil, fmt.Errorf("udp stream reset")
+		case protocol.FramePADDING, protocol.FrameCOVER:
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected frame type: %d", frame.Type)
+		}
 	}
 }
 
@@ -486,9 +490,7 @@ func (ue *UDPExchange) Close() error {
 }
 
 func (ue *UDPExchange) LastSeen() time.Time {
-	ue.mu.Lock()
-	defer ue.mu.Unlock()
-	return ue.lastSeen
+	return time.Unix(0, ue.lastSeen.Load())
 }
 
 func isInteractivePort(target string) bool {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/time v0.15.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gvisor.dev/gvisor v0.0.0-20260701204157-69c2d17aea96
 )
@@ -247,7 +248,6 @@ require (
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446 // indirect

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/base64"
 	"fmt"
+	"net"
 	"net/http"
 	"runtime/debug"
 	"time"
@@ -28,6 +29,8 @@ type ProxyHandler struct {
 	tcpHandler       *TCPHandler
 	udpHandler       *UDPHandler
 	icmpHandler      *ICMPHandler
+	saltCache        *saltCache
+	ipLimiter        *ipRateLimiter
 }
 
 type ProxyHandlerConfig struct {
@@ -85,7 +88,17 @@ func NewProxyHandler(cfg ProxyHandlerConfig) *ProxyHandler {
 		tcpHandler:       NewTCPHandler(cfg.StreamIdleTimeout, cfg.Timeout, cfg.NextProxy),
 		udpHandler:       NewUDPHandler(cfg.UDPIdleTimeout, cfg.NextProxy),
 		icmpHandler:      NewICMPHandler(),
+		saltCache:        newSaltCache(),
+		ipLimiter:        newIPRateLimiter(),
 	}
+}
+
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }
 
 func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -109,6 +122,27 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	salt, err := base64.RawURLEncoding.DecodeString(saltB64)
 	if err != nil || len(salt) != 16 {
+		ServeFallback(w, r)
+		return
+	}
+
+	// Bound handshake attempts per source IP to mitigate replay storms and
+	// CPU abuse. Only counted for requests that look like a real handshake
+	// (valid x-es header), so plain fallback-page traffic is unaffected.
+	if !h.ipLimiter.Allow(clientIP(r)) {
+		log.Error("[SERVER] handshake rate limited", "remote", r.RemoteAddr)
+		stats.RecordServerHandshakeError()
+		ServeFallback(w, r)
+		return
+	}
+
+	// Reject replayed bootstrap records. Every stream uses a unique random
+	// salt; a salt already accepted by this server means the record is being
+	// re-delivered (replay), and accepting it would re-dial the target and
+	// re-deliver the first packet.
+	if h.saltCache.MarkSeen(saltB64) {
+		log.Error("[SERVER] replayed salt", "remote", r.RemoteAddr, "endpoint", r.URL.Path)
+		stats.RecordServerHandshakeError()
 		ServeFallback(w, r)
 		return
 	}
@@ -202,7 +236,10 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch endpoint {
 	case sharedconfig.EndpointTCP:
 		stats.RecordServerTCPStream()
-		handleErr = h.tcpHandler.Handle(r.Context(), c2sReader, s2cShaper, target)
+		// cancelRead unblocks the relay's client-read goroutine immediately
+		// when the relay terminates (idle timeout/error), instead of letting
+		// it linger on the request body until net/http closes it.
+		handleErr = h.tcpHandler.Handle(r.Context(), c2sReader, s2cShaper, target, func() { _ = r.Body.Close() })
 	case sharedconfig.EndpointUDP:
 		stats.RecordServerUDPStream()
 		handleErr = h.udpHandler.Handle(r.Context(), c2sReader, s2cShaper, target)

--- a/server/handler/ratelimit.go
+++ b/server/handler/ratelimit.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -16,30 +18,32 @@ const (
 	// handshakeBurst is the initial bucket capacity (allowed burst size).
 	handshakeBurst = 100
 
-	// ipCleanupThreshold triggers a sweep of idle buckets once the map grows
+	// ipCleanupThreshold triggers a sweep of idle entries once the map grows
 	// beyond this many distinct source IPs.
 	ipCleanupThreshold = 4096
 
-	// ipCleanupTTL is how long a fully-replenished bucket may stay idle
-	// before it is dropped.
+	// ipCleanupTTL is how long an idle limiter entry may stay before it is
+	// dropped. Idle for this long the bucket is necessarily full again, so
+	// dropping and recreating it loses no state.
 	ipCleanupTTL = 30 * time.Minute
 )
 
-// ipRateLimiter is a simple per-IP token bucket that bounds the rate of
-// handshake attempts, mitigating replay storms and resource abuse.
+// ipRateLimiter bounds handshake attempts per source IP using a token bucket
+// per IP (golang.org/x/time/rate), mitigating replay storms and resource
+// abuse.
 type ipRateLimiter struct {
 	mu      sync.Mutex
-	buckets map[string]*ipTokenBucket
+	entries map[string]*ipRateEntry
 	now     func() time.Time
 }
 
-type ipTokenBucket struct {
-	tokens float64
-	last   time.Time
+type ipRateEntry struct {
+	lim      *rate.Limiter
+	lastSeen time.Time
 }
 
 func newIPRateLimiter() *ipRateLimiter {
-	return &ipRateLimiter{buckets: make(map[string]*ipTokenBucket), now: time.Now}
+	return &ipRateLimiter{entries: make(map[string]*ipRateEntry), now: time.Now}
 }
 
 // Allow reports whether the given IP may perform a handshake right now.
@@ -47,35 +51,27 @@ func (l *ipRateLimiter) Allow(ip string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if len(l.buckets) >= ipCleanupThreshold {
+	if len(l.entries) >= ipCleanupThreshold {
 		l.cleanupLocked()
 	}
 
 	now := l.now()
-	b, ok := l.buckets[ip]
+	e, ok := l.entries[ip]
 	if !ok {
-		// Consume the first token on bucket creation so the total allowed
-		// burst equals handshakeBurst.
-		l.buckets[ip] = &ipTokenBucket{tokens: handshakeBurst - 1, last: now}
-		return true
+		e = &ipRateEntry{lim: rate.NewLimiter(rate.Limit(handshakeRate), handshakeBurst), lastSeen: now}
+		l.entries[ip] = e
 	}
-
-	b.tokens = min(float64(handshakeBurst), b.tokens+now.Sub(b.last).Seconds()*handshakeRate)
-	b.last = now
-	if b.tokens < 1 {
-		return false
-	}
-	b.tokens--
-	return true
+	e.lastSeen = now
+	return e.lim.AllowN(now, 1)
 }
 
-// cleanupLocked drops buckets that are fully replenished and have been idle
-// for ipCleanupTTL, preventing unbounded growth of the map.
+// cleanupLocked drops entries idle for ipCleanupTTL, preventing unbounded
+// growth of the map.
 func (l *ipRateLimiter) cleanupLocked() {
 	now := l.now()
-	for ip, b := range l.buckets {
-		if b.tokens >= float64(handshakeBurst) && now.Sub(b.last) > ipCleanupTTL {
-			delete(l.buckets, ip)
+	for ip, e := range l.entries {
+		if now.Sub(e.lastSeen) > ipCleanupTTL {
+			delete(l.entries, ip)
 		}
 	}
 }

--- a/server/handler/ratelimit.go
+++ b/server/handler/ratelimit.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// handshakeRate is the token refill rate (handshakes per second) allowed
+	// per source IP. The salt replay cache already rejects replayed records
+	// before any dial happens, so this limiter mainly bounds brute-force
+	// handshake attempts that waste decryption CPU. Tuned generously enough
+	// not to disturb legit clients behind a shared (NAT) IP.
+	handshakeRate = 50.0
+
+	// handshakeBurst is the initial bucket capacity (allowed burst size).
+	handshakeBurst = 100
+
+	// ipCleanupThreshold triggers a sweep of idle buckets once the map grows
+	// beyond this many distinct source IPs.
+	ipCleanupThreshold = 4096
+
+	// ipCleanupTTL is how long a fully-replenished bucket may stay idle
+	// before it is dropped.
+	ipCleanupTTL = 30 * time.Minute
+)
+
+// ipRateLimiter is a simple per-IP token bucket that bounds the rate of
+// handshake attempts, mitigating replay storms and resource abuse.
+type ipRateLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]*ipTokenBucket
+	now     func() time.Time
+}
+
+type ipTokenBucket struct {
+	tokens float64
+	last   time.Time
+}
+
+func newIPRateLimiter() *ipRateLimiter {
+	return &ipRateLimiter{buckets: make(map[string]*ipTokenBucket), now: time.Now}
+}
+
+// Allow reports whether the given IP may perform a handshake right now.
+func (l *ipRateLimiter) Allow(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if len(l.buckets) >= ipCleanupThreshold {
+		l.cleanupLocked()
+	}
+
+	now := l.now()
+	b, ok := l.buckets[ip]
+	if !ok {
+		// Consume the first token on bucket creation so the total allowed
+		// burst equals handshakeBurst.
+		l.buckets[ip] = &ipTokenBucket{tokens: handshakeBurst - 1, last: now}
+		return true
+	}
+
+	b.tokens = min(float64(handshakeBurst), b.tokens+now.Sub(b.last).Seconds()*handshakeRate)
+	b.last = now
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// cleanupLocked drops buckets that are fully replenished and have been idle
+// for ipCleanupTTL, preventing unbounded growth of the map.
+func (l *ipRateLimiter) cleanupLocked() {
+	now := l.now()
+	for ip, b := range l.buckets {
+		if b.tokens >= float64(handshakeBurst) && now.Sub(b.last) > ipCleanupTTL {
+			delete(l.buckets, ip)
+		}
+	}
+}

--- a/server/handler/replay_test.go
+++ b/server/handler/replay_test.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestSaltCache_MarkSeen(t *testing.T) {
+	c := newSaltCache()
+
+	salt := base64.RawURLEncoding.EncodeToString(make([]byte, 16))
+
+	if c.MarkSeen(salt) {
+		t.Fatal("first MarkSeen should report not-seen")
+	}
+	if !c.MarkSeen(salt) {
+		t.Fatal("second MarkSeen of the same salt should report seen (replay)")
+	}
+
+	other := base64.RawURLEncoding.EncodeToString(append([]byte(nil), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+	if c.MarkSeen(other) {
+		t.Fatal("a different salt should report not-seen")
+	}
+}
+
+func TestSaltCache_DistinctSalts(t *testing.T) {
+	c := newSaltCache()
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 1000; i++ {
+		buf := make([]byte, 16)
+		_, _ = rng.Read(buf)
+		salt := base64.RawURLEncoding.EncodeToString(buf)
+		if c.MarkSeen(salt) {
+			t.Fatalf("salt %q reported as seen on first use", salt)
+		}
+	}
+}
+
+func TestIPRateLimiter_BurstThenReject(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	l := newIPRateLimiter()
+	l.now = func() time.Time { return now }
+
+	for i := 0; i < handshakeBurst; i++ {
+		if !l.Allow("1.2.3.4") {
+			t.Fatalf("request %d within burst should be allowed", i)
+		}
+	}
+	if l.Allow("1.2.3.4") {
+		t.Fatal("request beyond burst should be rejected")
+	}
+}
+
+func TestIPRateLimiter_Refill(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	l := newIPRateLimiter()
+	l.now = func() time.Time { return now }
+
+	for i := 0; i < handshakeBurst; i++ {
+		l.Allow("1.2.3.4")
+	}
+
+	// Advance 1s: exactly handshakeRate tokens are replenished.
+	now = now.Add(time.Second)
+	allowed := 0
+	for i := 0; i < int(handshakeRate); i++ {
+		if l.Allow("1.2.3.4") {
+			allowed++
+		}
+	}
+	if allowed != int(handshakeRate) {
+		t.Fatalf("allowed = %d, want %d", allowed, int(handshakeRate))
+	}
+	if l.Allow("1.2.3.4") {
+		t.Fatal("request after consuming refilled tokens should be rejected")
+	}
+}
+
+func TestIPRateLimiter_PerIPIsolation(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	l := newIPRateLimiter()
+	l.now = func() time.Time { return now }
+
+	for i := 0; i < handshakeBurst; i++ {
+		l.Allow("1.2.3.4")
+	}
+	if l.Allow("1.2.3.4") {
+		t.Fatal("exhausted IP should be rejected")
+	}
+	if !l.Allow("5.6.7.8") {
+		t.Fatal("a fresh IP should be allowed independently")
+	}
+}

--- a/server/handler/saltcache.go
+++ b/server/handler/saltcache.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/coocood/freecache"
+)
+
+const (
+	// saltCacheSize is the freecache capacity in bytes (~8MB, tens of
+	// thousands of entries). Entries are 1-byte values keyed by the 22-char
+	// base64url salt.
+	saltCacheSize = 8 * 1024 * 1024
+
+	// saltCacheTTL bounds how long a salt stays in the cache. Streams live
+	// far shorter than this, so TTL expiry only bounds memory.
+	saltCacheTTL = time.Hour
+)
+
+// saltCache records bootstrap salts that have already been accepted by the
+// server. Every stream uses a fresh random salt (16 bytes, transmitted in
+// plaintext via the x-es header), so a replayed bootstrap record necessarily
+// carries a salt the server has already seen. Rejecting duplicate salts
+// therefore defeats replay attacks, which would otherwise make the server
+// re-dial the target and re-deliver the first packet on every replay.
+type saltCache struct {
+	cache *freecache.Cache
+}
+
+func newSaltCache() *saltCache {
+	return &saltCache{cache: freecache.NewCache(saltCacheSize)}
+}
+
+// MarkSeen records saltB64 and reports whether it was already present.
+// The returned bool is true when the salt has been seen before, i.e. the
+// request is a replay and must be rejected.
+func (c *saltCache) MarkSeen(saltB64 string) bool {
+	key := []byte(saltB64)
+	if _, err := c.cache.Get(key); err == nil {
+		return true
+	}
+	_ = c.cache.Set(key, []byte{1}, int(saltCacheTTL.Seconds()))
+	return false
+}

--- a/server/handler/tcp.go
+++ b/server/handler/tcp.go
@@ -22,6 +22,7 @@ import (
 
 type TCPHandler struct {
 	dialer      *net.Dialer
+	dialContext func(context.Context, string, string) (net.Conn, error)
 	nextProxy   *nextproxy.NextProxy
 	idleTimeout time.Duration
 	dialTimeout time.Duration
@@ -61,6 +62,10 @@ func (h *TCPHandler) dialTarget(ctx context.Context, network, addr string) (net.
 		log.Info("[TCP_HANDLE] dialing via next proxy", "target", addr, "proxy", h.nextProxy.URL().String())
 		return h.nextProxy.DialContext(ctx, network, addr)
 	}
+	// Test-only injection point; nil in production.
+	if h.dialContext != nil {
+		return h.dialContext(ctx, network, addr)
+	}
 	d := h.dialer
 	conn, err := d.DialContext(ctx, outboundTCPNetwork(addr), addr)
 	if err != nil {
@@ -93,7 +98,12 @@ func outboundTCPNetwork(addr string) string {
 	return "tcp4"
 }
 
-func (h *TCPHandler) Handle(ctx context.Context, dr *crypto.DecryptedReader, s2c shaper.Shaper, target string) error {
+// Handle relays a TCP stream between the client and the target.
+// cancelRead is invoked when the relay terminates (timeout/error/completion);
+// it unblocks a copy goroutine that may be stuck reading from the client
+// (e.g. the HTTP/2 request body), so no goroutine lingers after the handler
+// returns.
+func (h *TCPHandler) Handle(ctx context.Context, dr *crypto.DecryptedReader, s2c shaper.Shaper, target string, cancelRead func()) error {
 	log.Info("[TCP_HANDLE] dialing target", "target", target, "timeout", h.dialTimeout)
 	targetConn, err := h.dialTarget(ctx, "tcp", target)
 	if err != nil {
@@ -117,6 +127,9 @@ func (h *TCPHandler) Handle(ctx context.Context, dr *crypto.DecryptedReader, s2c
 	}
 
 	result := relay.Bidirectional(h.idleTimeout, func() {
+		if cancelRead != nil {
+			cancelRead()
+		}
 		_ = targetConn.Close()
 	},
 		func(signal func()) error { return h.copyFromClient(dr, targetConn, signal) },

--- a/server/handler/tcp_test.go
+++ b/server/handler/tcp_test.go
@@ -1,8 +1,18 @@
 package handler
 
 import (
+	"context"
+	"io"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	sharedconfig "github.com/nange/easyss/v3/config"
+	"github.com/nange/easyss/v3/crypto"
+	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/shaper"
 )
 
 func TestOutboundTCPNetwork(t *testing.T) {
@@ -40,4 +50,76 @@ func TestOutboundTCPNetwork(t *testing.T) {
 			}
 		})
 	}
+}
+
+type stubConn struct {
+	closed chan struct{}
+	once   sync.Once
+	remote net.Addr
+}
+
+func newStubConn(remote net.Addr) *stubConn {
+	return &stubConn{closed: make(chan struct{}), remote: remote}
+}
+
+func (c *stubConn) Read(p []byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *stubConn) Write(p []byte) (int, error) { return len(p), nil }
+
+func (c *stubConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (c *stubConn) LocalAddr() net.Addr { return &net.TCPAddr{} }
+
+func (c *stubConn) RemoteAddr() net.Addr { return c.remote }
+
+func (c *stubConn) SetDeadline(t time.Time) error { return nil }
+
+func (c *stubConn) SetReadDeadline(t time.Time) error { return nil }
+
+func (c *stubConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func TestTCPHandler_CancelReadOnIdleTimeout(t *testing.T) {
+	h := NewTCPHandler(150*time.Millisecond, 5*time.Second, nil)
+	// A silent peer: the stub accepts writes and never produces data, with a
+	// public remote address so the post-dial SSRF guard passes.
+	stub := newStubConn(&net.TCPAddr{IP: net.ParseIP("8.8.8.8"), Port: 53})
+	h.dialContext = func(context.Context, string, string) (net.Conn, error) { return stub, nil }
+
+	sk, err := crypto.NewStreamKeys(
+		[]byte("0123456789abcdef0123456789abcdef"),
+		make([]byte, 16),
+		sharedconfig.EndpointTCP,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aad := crypto.BuildAAD(sharedconfig.EndpointTCP, make([]byte, 16), "s2c", "session", protocol.MethodAES256GCM)
+	enc, counter, err := sk.Encryptor("s2c", "session", protocol.MethodAES256GCM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pr, pw := io.Pipe()
+	dr := crypto.NewDecryptedReader(pr, aad, enc, counter)
+	s2c := shaper.New(crypto.NewRecordWriter(io.Discard, enc, counter, aad), shaper.Config{})
+
+	var cancelled atomic.Bool
+	start := time.Now()
+	err = h.Handle(context.Background(), dr, s2c, "8.8.8.8:53", func() { cancelled.Store(true) })
+	if err == nil {
+		t.Fatal("Handle should return an error on idle timeout")
+	}
+	if !cancelled.Load() {
+		t.Fatal("cancelRead should be invoked when the relay terminates")
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Fatal("Handle took too long to return")
+	}
+	_ = pw.Close()
 }

--- a/shaper/batch.go
+++ b/shaper/batch.go
@@ -253,6 +253,11 @@ func (bs *batchShaper) injectCoverFrame(f protocol.Frame) error {
 	defer bs.mu.Unlock()
 
 	if bs.closing.Load() || bs.err != nil {
+		// Return the pooled payload so no buffer is leaked when the shaper
+		// is already closed or failed.
+		if f.Type == protocol.FrameCOVER && len(f.Payload) > 0 {
+			bytespool.MustPut(f.Payload)
+		}
 		return nil
 	}
 

--- a/shaper/covertraffic.go
+++ b/shaper/covertraffic.go
@@ -9,7 +9,10 @@ import (
 	"github.com/nange/easyss/v3/util/bytespool"
 )
 
-var coverRNG = newSeededChaCha8()
+var (
+	coverRNG   = newSeededChaCha8()
+	coverRNGMu sync.Mutex
+)
 
 type coverInjector struct {
 	cfg              CoverConfig
@@ -143,7 +146,11 @@ func (ci *coverInjector) onIdle() {
 	ci.mu.Unlock()
 
 	payload := bytespool.Get(frameSize)[:frameSize]
+	// The package-level RNG is shared across streams; math/rand/v2 sources
+	// are not safe for concurrent use, so guard the fill with a mutex.
+	coverRNGMu.Lock()
 	_, _ = coverRNG.Read(payload)
+	coverRNGMu.Unlock()
 	frame := protocol.Frame{
 		Type:    protocol.FrameCOVER,
 		Length:  uint16(frameSize),

--- a/shaper/shaper.go
+++ b/shaper/shaper.go
@@ -3,6 +3,7 @@ package shaper
 import (
 	cryptorand "crypto/rand"
 	"math/rand/v2"
+	"sync"
 
 	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/stats"
@@ -14,7 +15,10 @@ func newSeededChaCha8() *rand.ChaCha8 {
 	return rand.NewChaCha8(seed)
 }
 
-var paddingRNG = newSeededChaCha8()
+var (
+	paddingRNG   = newSeededChaCha8()
+	paddingRNGMu sync.Mutex
+)
 
 type Shaper interface {
 	PushFrame(f protocol.Frame) error
@@ -57,7 +61,11 @@ func BuildPaddingFrame(totalSize int) (protocol.Frame, bool) {
 
 	stats.RecordPaddingBytes(padSize)
 	frame := protocol.NewFramePADDING(uint16(padSize))
+	// The package-level RNG is shared across streams; math/rand/v2 sources
+	// are not safe for concurrent use, so guard the fill with a mutex.
+	paddingRNGMu.Lock()
 	_, _ = paddingRNG.Read(frame.Payload)
+	paddingRNGMu.Unlock()
 	return frame, true
 }
 


### PR DESCRIPTION
- reject replayed bootstrap records via one-time salt cache
- rate limit handshake attempts per source IP
- unblock relay client-read goroutine on teardown
- make UDPExchange.lastSeen atomic and drop recursion
- detect self-target requests to local interface IPs
- return pooled cover payload on early inject return
- guard shared padding/cover RNGs with mutex