### PR TITLE
feat: migrate tray to gogpu/systray(zero CGO)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Easyss 是一款兼容 SOCKS5/HTTP 代理的安全上网工具，客户端+服�
 ## 核心目录结构
 
 ```
-cmd/easyss/         客户端入口，含系统托盘(systray) UI，Windows/Mac 需要 CGO
+cmd/easyss/         客户端入口，含系统托盘(systray) UI（gogpu/systray，纯 Go 零 CGO）
 cmd/easyss-server/  服务端入口，单文件 main.go
 client/             客户端核心：Client 结构体
 client/config/      客户端配置（JSON 解析、v2→v3 迁移）
@@ -48,7 +48,7 @@ version/            构建版本信息（GitTag、BuildDate 等）
 # 客户端 (Linux/Mac)
 make easyss
 
-# 客户端 (Windows) — 需要 CGO_ENABLED=1，systray 依赖 CGO
+# 客户端 (Windows)
 make easyss-windows
 
 # 服务端
@@ -144,7 +144,7 @@ Makefile 通过 `-ldflags` 向 `version/` 包注入以下变量，其余变量�
 
 ## Windows 构建注意事项
 
-- 客户端需要 CGO（`CGO_ENABLED=1`），依赖系统托盘库 `getlantern/systray`；服务端禁用 CGO
+- 客户端使用纯 Go 系统托盘库 `github.com/gogpu/systray`（零 CGO，Windows 走 Win32、Linux 走 D-Bus SNI、macOS 走 goffi FFI）；服务端禁用 CGO
 - 客户端产物连 `-H windowsgui` 标志以隐藏控制台窗口
 - `.gitignore` 规则 `cmd/easyss/easyss*` 排除二进制但保留 `easyss_windows.syso`
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ LDFLAGS += -X "github.com/nange/easyss/v3/version.BuildDate=$(shell date '+%Y-%m
 LDFLAGS += -X "github.com/nange/easyss/v3/version.GitTag=$(shell git describe --tags)"
 
 GO := go
-GO_BUILD := go build -ldflags '$(LDFLAGS)'
+GO_BUILD := CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)'
 WIN_ARCH ?= amd64
-GO_BUILD_WIN := GOOS=windows GOARCH=$(WIN_ARCH) CGO_ENABLED=0 go build -ldflags '-H windowsgui $(LDFLAGS)'
+GO_BUILD_WIN := GOOS=windows GOARCH=$(WIN_ARCH) go build -ldflags '-H windowsgui $(LDFLAGS)'
 GOMOBILE := $(shell go env GOPATH)/bin/gomobile
 GOMOBILE_BIND := $(GOMOBILE) bind -target=android/arm64,android/amd64 -androidapi 29 -ldflags '$(LDFLAGS)'
 
@@ -26,7 +26,7 @@ easyss-windows:
 
 easyss-mac-app:
 	cd cmd/easyss; \
-	CGO_ENABLED=0 GOOS=darwin $(GO_BUILD) -o ../../bin/easyss
+	GOOS=darwin $(GO_BUILD) -o ../../bin/easyss
 	bash scripts/app-bundle.sh bin/easyss icon/icon_1024_1024.png cmd/easyss/Info.plist
 
 easyss-without-tray:
@@ -35,11 +35,11 @@ easyss-without-tray:
 
 easyss-server:
 	cd cmd/easyss-server; \
-	CGO_ENABLED=0 $(GO_BUILD) -o ../../bin/easyss-server
+	$(GO_BUILD) -o ../../bin/easyss-server
 
 easyss-server-windows:
 	cd cmd/easyss-server; \
-	CGO_ENABLED=0 GOOS=windows GOARCH=$(WIN_ARCH) go build -ldflags '$(LDFLAGS)' -o ../../bin/easyss-server.exe
+	GOOS=windows GOARCH=$(WIN_ARCH) $(GO_BUILD) -o ../../bin/easyss-server.exe
 
 easyss-android-aar:
 	@if ! command -v javac >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS += -X "github.com/nange/easyss/v3/version.GitTag=$(shell git describe --
 GO := go
 GO_BUILD := go build -ldflags '$(LDFLAGS)'
 WIN_ARCH ?= amd64
-GO_BUILD_WIN := GOOS=windows GOARCH=$(WIN_ARCH) CGO_ENABLED=1 go build -ldflags '-H windowsgui $(LDFLAGS)'
+GO_BUILD_WIN := GOOS=windows GOARCH=$(WIN_ARCH) CGO_ENABLED=0 go build -ldflags '-H windowsgui $(LDFLAGS)'
 GOMOBILE := $(shell go env GOPATH)/bin/gomobile
 GOMOBILE_BIND := $(GOMOBILE) bind -target=android/arm64,android/amd64 -androidapi 29 -ldflags '$(LDFLAGS)'
 
@@ -26,7 +26,7 @@ easyss-windows:
 
 easyss-mac-app:
 	cd cmd/easyss; \
-	MACOSX_DEPLOYMENT_TARGET=14.0 CGO_LDFLAGS="-mmacosx-version-min=14.0" $(GO_BUILD) -o ../../bin/easyss
+	CGO_ENABLED=0 GOOS=darwin $(GO_BUILD) -o ../../bin/easyss
 	bash scripts/app-bundle.sh bin/easyss icon/icon_1024_1024.png cmd/easyss/Info.plist
 
 easyss-without-tray:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS += -X "github.com/nange/easyss/v3/version.GitTag=$(shell git describe --
 GO := go
 GO_BUILD := CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)'
 WIN_ARCH ?= amd64
-GO_BUILD_WIN := GOOS=windows GOARCH=$(WIN_ARCH) go build -ldflags '-H windowsgui $(LDFLAGS)'
+GO_BUILD_WIN := GOOS=windows GOARCH=$(WIN_ARCH) CGO_ENABLED=0 go build -ldflags '-H windowsgui $(LDFLAGS)'
 GOMOBILE := $(shell go env GOPATH)/bin/gomobile
 GOMOBILE_BIND := $(GOMOBILE) bind -target=android/arm64,android/amd64 -androidapi 29 -ldflags '$(LDFLAGS)'
 

--- a/cmd/easyss/lock_windows.go
+++ b/cmd/easyss/lock_windows.go
@@ -16,12 +16,14 @@ var winLockHandle windows.Handle
 func acquireSingletonLock() {
 	name, _ := windows.UTF16PtrFromString("Global\\Easyss_Singleton")
 	handle, err := windows.CreateMutex(nil, false, name)
-	if err != nil {
+	if err != nil && err != windows.ERROR_ALREADY_EXISTS {
 		log.Error("[EASYSS-V3] failed to create mutex", "err", err)
 		os.Exit(1)
 	}
-	if windows.GetLastError() == windows.ERROR_ALREADY_EXISTS {
-		_ = windows.CloseHandle(handle)
+	if err == windows.ERROR_ALREADY_EXISTS {
+		if handle != 0 {
+			_ = windows.CloseHandle(handle)
+		}
 		log.Warn("[EASYSS-V3] another instance is already running, exiting")
 		os.Exit(0)
 	}

--- a/cmd/easyss/start.go
+++ b/cmd/easyss/start.go
@@ -23,12 +23,6 @@ func runApp(disableTray, daemon bool, app *App) {
 	defer releaseSingletonLock()
 
 	if !disableTray && (runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
-		// Pin this goroutine to its OS thread: the tray window is created on
-		// the current thread and the message loop must run on the same thread
-		// (Win32 message queues are per-thread). Without this, the Go runtime
-		// may migrate the goroutine after blocking syscalls in Start().
-		runtime.LockOSThread()
-
 		ta := &TrayApp{
 			App:       app,
 			closing:   make(chan struct{}),

--- a/cmd/easyss/start.go
+++ b/cmd/easyss/start.go
@@ -30,8 +30,9 @@ func runApp(disableTray, daemon bool, app *App) {
 		runtime.LockOSThread()
 
 		ta := &TrayApp{
-			App:     app,
-			closing: make(chan struct{}),
+			App:       app,
+			closing:   make(chan struct{}),
+			trayBuilt: make(chan struct{}),
 		}
 
 		go func() {
@@ -41,15 +42,17 @@ func runApp(disableTray, daemon bool, app *App) {
 			select {
 			case sig := <-c:
 				log.Info("[EASYSS-V3] got signal to exit", "signal", sig)
-				if ta.tray != nil {
-					ta.tray.Remove()
-				}
+				// Wait for buildTray() to finish so the tray is non-nil and
+				// Remove() can terminate the message loop.
+				<-ta.trayBuilt
+				ta.tray.Remove()
 			case <-ta.closing:
 				log.Info("[EASYSS-V3] easyss exiting...")
 			}
 		}()
 
 		ta.buildTray()
+		close(ta.trayBuilt)
 		_ = ta.tray.Run()
 		ta.trayExit()
 	} else {

--- a/cmd/easyss/start.go
+++ b/cmd/easyss/start.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"syscall"
 
-	"fyne.io/systray"
 	"github.com/nange/easyss/v3/log"
 )
 
@@ -24,6 +23,12 @@ func runApp(disableTray, daemon bool, app *App) {
 	defer releaseSingletonLock()
 
 	if !disableTray && (runtime.GOOS == "windows" || runtime.GOOS == "darwin" || runtime.GOOS == "linux") {
+		// Pin this goroutine to its OS thread: the tray window is created on
+		// the current thread and the message loop must run on the same thread
+		// (Win32 message queues are per-thread). Without this, the Go runtime
+		// may migrate the goroutine after blocking syscalls in Start().
+		runtime.LockOSThread()
+
 		ta := &TrayApp{
 			App:     app,
 			closing: make(chan struct{}),
@@ -36,13 +41,17 @@ func runApp(disableTray, daemon bool, app *App) {
 			select {
 			case sig := <-c:
 				log.Info("[EASYSS-V3] got signal to exit", "signal", sig)
-				systray.Quit()
+				if ta.tray != nil {
+					ta.tray.Remove()
+				}
 			case <-ta.closing:
 				log.Info("[EASYSS-V3] easyss exiting...")
 			}
 		}()
 
-		systray.Run(ta.trayReady, ta.trayExit)
+		ta.buildTray()
+		_ = ta.tray.Run()
+		ta.trayExit()
 	} else {
 		proxyWasSet := false
 		if !app.cfg.Local.DisableSysProxy && app.cfg.Local.HTTPPort > 0 {

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -14,13 +14,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gogpu/systray"
 	"github.com/nange/easyss/v3/client/config"
 	"github.com/nange/easyss/v3/client/tun"
 	"github.com/nange/easyss/v3/icon"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/util"
-	"github.com/nange/systray"
 )
 
 type TrayApp struct {
@@ -32,7 +32,6 @@ type TrayApp struct {
 
 	tray     *systray.SystemTray
 	rootMenu *systray.Menu
-	checked  map[*systray.MenuItem]bool
 
 	serverMenuItems []*systray.MenuItem
 	serverAddrs     []string
@@ -41,9 +40,9 @@ type TrayApp struct {
 	autoStartItem   *systray.MenuItem
 
 	// UWP loopback exemption menu (Windows only).
-	uwpMu    sync.Mutex
-	uwpMenu  *systray.Menu
-	uwpItems []*UWPMenuItem
+	uwpMu    sync.Mutex     //nolint:unused // used in uwp_windows.go
+	uwpMenu  *systray.Menu  //nolint:unused // used in uwp_windows.go
+	uwpItems []*UWPMenuItem //nolint:unused // used in uwp_windows.go
 
 	// TUN helper management (darwin non-root).
 	tunHelperStdin io.WriteCloser // FIFO writer; close to signal helper shutdown
@@ -62,30 +61,6 @@ type UWPMenuItem struct {
 	MenuItem *systray.MenuItem
 	App      *UWPApp
 	Mu       sync.RWMutex
-}
-
-// setChecked updates both the native checkbox state and the local state map.
-// gogpu/systray has no Checked() query, so the map is the source of truth.
-func (a *TrayApp) setChecked(mi *systray.MenuItem, v bool) {
-	if mi == nil {
-		return
-	}
-	a.mu.Lock()
-	if a.checked == nil {
-		a.checked = make(map[*systray.MenuItem]bool)
-	}
-	a.checked[mi] = v
-	a.mu.Unlock()
-	mi.SetChecked(v)
-}
-
-func (a *TrayApp) isChecked(mi *systray.MenuItem) bool {
-	if mi == nil {
-		return false
-	}
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return a.checked[mi]
 }
 
 func (a *TrayApp) buildTray() {
@@ -166,7 +141,6 @@ func (a *TrayApp) buildSelectServerMenu() *systray.Menu {
 		item := m.AddCheckbox(addr, checked, func(idx int) func() {
 			return func() { a.selectServer(idx) }
 		}(idx))
-		a.setChecked(item, checked)
 		a.serverMenuItems = append(a.serverMenuItems, item)
 	}
 
@@ -175,13 +149,13 @@ func (a *TrayApp) buildSelectServerMenu() *systray.Menu {
 
 func (a *TrayApp) selectServer(idx int) {
 	go func() {
-		if a.isChecked(a.serverMenuItems[idx]) {
+		if a.serverMenuItems[idx].IsChecked() {
 			return
 		}
 		addr := a.serverAddrs[idx]
 		log.Info("[SYSTRAY] changing server to", "addr", addr)
 		for _, v := range a.serverMenuItems {
-			a.setChecked(v, false)
+			v.SetChecked(false)
 		}
 		clone := a.cfg.Clone()
 		clone.SetDefaultServerIndex(idx)
@@ -189,7 +163,7 @@ func (a *TrayApp) selectServer(idx int) {
 			log.Error("[SYSTRAY] changing server to", "addr", addr, "err", err)
 			return
 		}
-		a.setChecked(a.serverMenuItems[idx], true)
+		a.serverMenuItems[idx].SetChecked(true)
 		log.Info("[SYSTRAY] changes server success to", "addr", addr)
 	}()
 }
@@ -206,7 +180,7 @@ func (a *TrayApp) statsRefresher() {
 		case <-ticker.C:
 			rttMs, downSpeed := fetchStats(httpClient, url)
 			for i, mi := range a.serverMenuItems {
-				if a.isChecked(mi) {
+				if mi.IsChecked() {
 					mi.SetLabel(formatTitle(a.serverAddrs[i], rttMs, downSpeed))
 					break
 				}
@@ -271,7 +245,6 @@ func (a *TrayApp) buildProxyRuleMenu() *systray.Menu {
 		item := m.AddCheckbox(r.label, r.checked, func(rule string) func() {
 			return func() { go a.changeProxyRule(rule) }
 		}(r.rule))
-		a.setChecked(item, r.checked)
 		a.proxyRuleItems[r.rule] = item
 	}
 
@@ -279,12 +252,12 @@ func (a *TrayApp) buildProxyRuleMenu() *systray.Menu {
 }
 
 func (a *TrayApp) changeProxyRule(rule string) {
-	if a.isChecked(a.proxyRuleItems[rule]) {
+	if a.proxyRuleItems[rule].IsChecked() {
 		return
 	}
 	a.setProxyRule(rule)
 	for r, item := range a.proxyRuleItems {
-		a.setChecked(item, r == rule)
+		item.SetChecked(r == rule)
 	}
 }
 
@@ -301,11 +274,9 @@ func (a *TrayApp) buildProxyObjectMenu() *systray.Menu {
 
 	browserChecked := !a.cfg.Local.DisableSysProxy
 	browser := m.AddCheckbox("浏览器(设置系统代理)", browserChecked, a.toggleSysProxy)
-	a.setChecked(browser, browserChecked)
 	a.SetBrowserMenu(browser)
 
 	global := m.AddCheckbox("系统全局流量(Tun2socks)", a.cfg.Local.EnableTun2socks, a.toggleTun2socks)
-	a.setChecked(global, a.cfg.Local.EnableTun2socks)
 	a.SetTunMenu(global)
 
 	return m
@@ -314,17 +285,17 @@ func (a *TrayApp) buildProxyObjectMenu() *systray.Menu {
 func (a *TrayApp) toggleSysProxy() {
 	go func() {
 		mi := a.BrowserMenu()
-		if a.isChecked(mi) {
-			a.setChecked(mi, false)
+		if mi.IsChecked() {
+			mi.SetChecked(false)
 			if err := a.setSysProxyOff(); err != nil {
 				log.Error("[SYSTRAY] set sys-proxy off", "err", err)
-				a.setChecked(mi, true) // revert on failure
+				mi.SetChecked(true) // revert on failure
 			}
 		} else {
-			a.setChecked(mi, true)
+			mi.SetChecked(true)
 			if err := a.setSysProxyOn(); err != nil {
 				log.Error("[SYSTRAY] set sys-proxy on", "err", err)
-				a.setChecked(mi, false) // revert on failure
+				mi.SetChecked(false) // revert on failure
 			}
 		}
 	}()
@@ -333,12 +304,12 @@ func (a *TrayApp) toggleSysProxy() {
 func (a *TrayApp) toggleTun2socks() {
 	go func() {
 		mi := a.TunMenu()
-		log.Info("[SYSTRAY] tun menu clicked", "checked", a.isChecked(mi))
-		if a.isChecked(mi) {
-			a.setChecked(mi, false)
+		log.Info("[SYSTRAY] tun menu clicked", "checked", mi.IsChecked())
+		if mi.IsChecked() {
+			mi.SetChecked(false)
 			a.disableTun2socks()
 		} else {
-			a.setChecked(mi, true)
+			mi.SetChecked(true)
 			a.enableTun2socks(mi)
 		}
 	}()
@@ -362,7 +333,6 @@ func (a *TrayApp) buildLogLevelMenu() *systray.Menu {
 		item := m.AddCheckbox(l.level, l.checked, func(level string) func() {
 			return func() { go a.changeLogLevel(level) }
 		}(l.level))
-		a.setChecked(item, l.checked)
 		a.logLevelItems[l.level] = item
 	}
 
@@ -370,7 +340,7 @@ func (a *TrayApp) buildLogLevelMenu() *systray.Menu {
 }
 
 func (a *TrayApp) changeLogLevel(level string) {
-	if a.isChecked(a.logLevelItems[level]) {
+	if a.logLevelItems[level].IsChecked() {
 		return
 	}
 	a.cfg.Log.Level = level
@@ -390,7 +360,7 @@ func (a *TrayApp) changeLogLevel(level string) {
 	log.SetLevel(slogLevel)
 
 	for l, item := range a.logLevelItems {
-		a.setChecked(item, l == level)
+		item.SetChecked(l == level)
 	}
 }
 
@@ -410,19 +380,19 @@ func (a *TrayApp) catLog() error {
 
 func (a *TrayApp) toggleAutoStart() {
 	go func() {
-		if a.isChecked(a.autoStartItem) {
+		if a.autoStartItem.IsChecked() {
 			if err := DisableAutoStart(); err != nil {
 				log.Error("[SYSTRAY] disable auto-start", "err", err)
 				return
 			}
-			a.setChecked(a.autoStartItem, false)
+			a.autoStartItem.SetChecked(false)
 			log.Info("[SYSTRAY] auto-start disabled")
 		} else {
 			if err := EnableAutoStart(); err != nil {
 				log.Error("[SYSTRAY] enable auto-start", "err", err)
 				return
 			}
-			a.setChecked(a.autoStartItem, true)
+			a.autoStartItem.SetChecked(true)
 			log.Info("[SYSTRAY] auto-start enabled")
 		}
 	}()
@@ -522,13 +492,13 @@ func (a *TrayApp) enableTun2socks(menu *systray.MenuItem) {
 		// open the TUN device, set up routes, and pass the fd back.
 		if err := a.createTun2socksViaHelper(); err != nil {
 			log.Error("[SYSTRAY] create tun2socks via helper", "err", err)
-			a.setChecked(menu, false)
+			menu.SetChecked(false)
 			return
 		}
 	} else {
 		if err := a.createTun2socks(); err != nil {
 			log.Error("[SYSTRAY] create tun2socks", "err", err)
-			a.setChecked(menu, false)
+			menu.SetChecked(false)
 			return
 		}
 	}
@@ -544,7 +514,7 @@ func (a *TrayApp) disableTun2socks() {
 }
 
 func (a *TrayApp) restartService(newCfg *config.ClientConfig) error {
-	sysProxyEnabled := a.BrowserMenu() != nil && a.isChecked(a.BrowserMenu())
+	sysProxyEnabled := a.BrowserMenu() != nil && a.BrowserMenu().IsChecked()
 
 	// Stop everything including TUN. On macOS this prompts for admin
 	// credentials to clean up routes and DNS — acceptable during a
@@ -556,7 +526,7 @@ func (a *TrayApp) restartService(newCfg *config.ClientConfig) error {
 	// actual (off) state so the user can re-enable it with one click.
 	newCfg.Local.EnableTun2socks = false
 	if tunMenu := a.TunMenu(); tunMenu != nil {
-		a.setChecked(tunMenu, false)
+		tunMenu.SetChecked(false)
 	}
 
 	*a.App = App{
@@ -601,7 +571,7 @@ func (a *TrayApp) startLocalService() {
 		_ = pacPort
 	}
 
-	if a.BrowserMenu() != nil && a.isChecked(a.BrowserMenu()) {
+	if a.BrowserMenu() != nil && a.BrowserMenu().IsChecked() {
 		if err := a.setSysProxyOn(); err != nil {
 			log.Error("[SYSTRAY] start local: set sysproxy on", "err", err)
 		}
@@ -613,7 +583,7 @@ func (a *TrayApp) startLocalService() {
 
 	if a.cfg.Local.EnableTun2socks {
 		if a.TunMenu() != nil {
-			a.setChecked(a.TunMenu(), true)
+			a.TunMenu().SetChecked(true)
 		}
 	}
 }

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -30,8 +30,9 @@ type TrayApp struct {
 	browserMenu *systray.MenuItem
 	tunMenu     *systray.MenuItem
 
-	tray     *systray.SystemTray
-	rootMenu *systray.Menu
+	tray      *systray.SystemTray
+	rootMenu  *systray.Menu
+	trayBuilt chan struct{} // closed after buildTray() completes
 
 	serverMenuItems []*systray.MenuItem
 	serverAddrs     []string

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -14,13 +14,13 @@ import (
 	"sync"
 	"time"
 
-	"fyne.io/systray"
 	"github.com/nange/easyss/v3/client/config"
 	"github.com/nange/easyss/v3/client/tun"
 	"github.com/nange/easyss/v3/icon"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/util"
+	"github.com/nange/systray"
 )
 
 type TrayApp struct {
@@ -30,37 +30,101 @@ type TrayApp struct {
 	browserMenu *systray.MenuItem
 	tunMenu     *systray.MenuItem
 
+	tray     *systray.SystemTray
+	rootMenu *systray.Menu
+	checked  map[*systray.MenuItem]bool
+
+	serverMenuItems []*systray.MenuItem
+	serverAddrs     []string
+	proxyRuleItems  map[string]*systray.MenuItem
+	logLevelItems   map[string]*systray.MenuItem
+	autoStartItem   *systray.MenuItem
+
+	// UWP loopback exemption menu (Windows only).
+	uwpMu    sync.Mutex
+	uwpMenu  *systray.Menu
+	uwpItems []*UWPMenuItem
+
 	// TUN helper management (darwin non-root).
 	tunHelperStdin io.WriteCloser // FIFO writer; close to signal helper shutdown
 	tunHelperMu    sync.Mutex
 }
 
-func (a *TrayApp) trayReady() {
-	systray.SetTemplateIcon(icon.Data, icon.Data)
+// UWPApp represents an installed Windows UWP application.
+type UWPApp struct {
+	Name              string `json:"Name"`
+	PackageFamilyName string `json:"PackageFamilyName"`
+	Exempt            bool
+}
 
-	a.addSelectServerMenu()
-	systray.AddSeparator()
+// UWPMenuItem pairs a UWP app with its tray menu item.
+type UWPMenuItem struct {
+	MenuItem *systray.MenuItem
+	App      *UWPApp
+	Mu       sync.RWMutex
+}
 
-	a.addProxyRuleMenu()
-	systray.AddSeparator()
+// setChecked updates both the native checkbox state and the local state map.
+// gogpu/systray has no Checked() query, so the map is the source of truth.
+func (a *TrayApp) setChecked(mi *systray.MenuItem, v bool) {
+	if mi == nil {
+		return
+	}
+	a.mu.Lock()
+	if a.checked == nil {
+		a.checked = make(map[*systray.MenuItem]bool)
+	}
+	a.checked[mi] = v
+	a.mu.Unlock()
+	mi.SetChecked(v)
+}
 
-	browserMenu, tunMenu := a.addProxyObjectMenu()
-	systray.AddSeparator()
-	a.SetBrowserMenu(browserMenu)
-	a.SetTunMenu(tunMenu)
+func (a *TrayApp) isChecked(mi *systray.MenuItem) bool {
+	if mi == nil {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.checked[mi]
+}
 
-	a.addUWPLoopbackMenu()
+func (a *TrayApp) buildTray() {
+	root := systray.NewMenu()
+	a.rootMenu = root
 
-	a.addLogLevelMenu()
-	systray.AddSeparator()
+	root.AddSubmenu("选择服务器", a.buildSelectServerMenu())
+	root.AddSeparator()
 
-	a.addCatLogsMenu()
-	systray.AddSeparator()
+	root.AddSubmenu("代理规则", a.buildProxyRuleMenu())
+	root.AddSeparator()
 
-	a.addAutoStartMenu()
-	systray.AddSeparator()
+	root.AddSubmenu("代理对象", a.buildProxyObjectMenu())
+	root.AddSeparator()
 
-	a.addExitMenu()
+	a.addUWPLoopbackMenu(root)
+
+	root.AddSubmenu("日志级别", a.buildLogLevelMenu())
+	root.AddSeparator()
+
+	root.Add("查看日志", func() { go a.catLogs() })
+	root.AddSeparator()
+
+	a.autoStartItem = root.AddCheckbox("开机启动", IsAutoStartEnabled(), a.toggleAutoStart)
+	root.AddSeparator()
+
+	root.Add("退出", a.exitApp)
+
+	a.tray = systray.New()
+	if runtime.GOOS == "darwin" {
+		// macOS template image (monochrome, adapts to menu bar theme).
+		a.tray.SetTemplateIcon(icon.TrayData)
+	} else {
+		// Windows/Linux: SetTemplateIcon is a no-op, use SetIcon.
+		a.tray.SetIcon(icon.TrayData)
+	}
+	a.tray.SetTooltip("Easyss")
+	a.tray.SetMenu(root)
+	a.tray.Show()
 
 	// Start service after menu is populated so that desktop environments
 	// (especially GNOME with AppIndicator) see a non-empty menu on first query.
@@ -70,6 +134,7 @@ func (a *TrayApp) trayReady() {
 	}
 
 	a.startLocalService()
+	go a.statsRefresher()
 }
 
 func (a *TrayApp) trayExit() {
@@ -86,61 +151,50 @@ func (a *TrayApp) trayExit() {
 	os.Exit(0)
 }
 
-func (a *TrayApp) addSelectServerMenu() {
-	selectServer := systray.AddMenuItem("选择服务器", "")
+func (a *TrayApp) buildSelectServerMenu() *systray.Menu {
+	m := systray.NewMenu()
 
 	addrs := a.cfg.ServerListAddrs()
-	var subMenuItems []*systray.MenuItem
+	if len(addrs) == 0 {
+		addrs = []string{a.cfg.DefaultServerAddr()}
+	}
+	a.serverAddrs = addrs
+	a.serverMenuItems = make([]*systray.MenuItem, 0, len(addrs))
 
-	if len(addrs) > 0 {
-		for _, addr := range addrs {
-			item := selectServer.AddSubMenuItemCheckbox(addr, "", false)
-			subMenuItems = append(subMenuItems, item)
-			if addr == a.cfg.DefaultServerAddr() {
-				item.Check()
-			}
-		}
-	} else {
-		item := selectServer.AddSubMenuItemCheckbox(a.cfg.DefaultServerAddr(), "", false)
-		subMenuItems = append(subMenuItems, item)
-		item.Check()
+	for idx, addr := range addrs {
+		checked := addr == a.cfg.DefaultServerAddr()
+		item := m.AddCheckbox(addr, checked, func(idx int) func() {
+			return func() { a.selectServer(idx) }
+		}(idx))
+		a.setChecked(item, checked)
+		a.serverMenuItems = append(a.serverMenuItems, item)
 	}
 
-	for i, item := range subMenuItems {
-		go func(idx int, mi *systray.MenuItem) {
-			for {
-				select {
-				case <-mi.ClickedCh:
-					func() {
-						if mi.Checked() {
-							mi.Check()
-							return
-						}
-						addr := addrs[idx]
-						log.Info("[SYSTRAY] changing server to", "addr", addr)
-						for _, v := range subMenuItems {
-							v.Uncheck()
-						}
-						clone := a.cfg.Clone()
-						clone.SetDefaultServerIndex(idx)
-						if err := a.restartService(clone); err != nil {
-							log.Error("[SYSTRAY] changing server to", "addr", addr, "err", err)
-						} else {
-							mi.Check()
-							log.Info("[SYSTRAY] changes server success to", "addr", addr)
-						}
-					}()
-				case <-a.closing:
-					return
-				}
-			}
-		}(i, item)
-	}
-
-	go a.statsRefresher(subMenuItems, addrs)
+	return m
 }
 
-func (a *TrayApp) statsRefresher(subMenuItems []*systray.MenuItem, addrs []string) {
+func (a *TrayApp) selectServer(idx int) {
+	go func() {
+		if a.isChecked(a.serverMenuItems[idx]) {
+			return
+		}
+		addr := a.serverAddrs[idx]
+		log.Info("[SYSTRAY] changing server to", "addr", addr)
+		for _, v := range a.serverMenuItems {
+			a.setChecked(v, false)
+		}
+		clone := a.cfg.Clone()
+		clone.SetDefaultServerIndex(idx)
+		if err := a.restartService(clone); err != nil {
+			log.Error("[SYSTRAY] changing server to", "addr", addr, "err", err)
+			return
+		}
+		a.setChecked(a.serverMenuItems[idx], true)
+		log.Info("[SYSTRAY] changes server success to", "addr", addr)
+	}()
+}
+
+func (a *TrayApp) statsRefresher() {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
@@ -151,9 +205,9 @@ func (a *TrayApp) statsRefresher(subMenuItems []*systray.MenuItem, addrs []strin
 		select {
 		case <-ticker.C:
 			rttMs, downSpeed := fetchStats(httpClient, url)
-			for i, mi := range subMenuItems {
-				if mi.Checked() {
-					mi.SetTitle(formatTitle(addrs[i], rttMs, downSpeed))
+			for i, mi := range a.serverMenuItems {
+				if a.isChecked(mi) {
+					mi.SetLabel(formatTitle(a.serverAddrs[i], rttMs, downSpeed))
 					break
 				}
 			}
@@ -197,97 +251,41 @@ func formatTitle(addr string, rttMs float64, downSpeed string) string {
 	return addr
 }
 
-func (a *TrayApp) addProxyRuleMenu() {
-	proxyMenu := systray.AddMenuItem("代理规则", "")
+func (a *TrayApp) buildProxyRuleMenu() *systray.Menu {
+	m := systray.NewMenu()
+	a.proxyRuleItems = make(map[string]*systray.MenuItem)
 
-	auto := proxyMenu.AddSubMenuItemCheckbox("自动(自定义规则+绕过大陆IP域名)", "", false)
-	if a.cfg.Routing.ProxyRule == "auto" {
-		auto.Check()
+	rules := []struct {
+		rule    string
+		label   string
+		checked bool
+	}{
+		{"auto", "自动(自定义规则+绕过大陆IP域名)", a.cfg.Routing.ProxyRule == "auto"},
+		{"auto_block", "自动+屏蔽广告跟踪", a.cfg.Routing.ProxyRule == "auto_block"},
+		{"reverse_auto", "反向自动(国外访问国内)", a.cfg.Routing.ProxyRule == "reverse_auto"},
+		{"proxy", "代理全部(绕过局域网地址)", a.cfg.Routing.ProxyRule == "proxy"},
+		{"direct", "直接连接", a.cfg.Routing.ProxyRule == "direct"},
 	}
 
-	autoBlock := proxyMenu.AddSubMenuItemCheckbox("自动+屏蔽广告跟踪", "", false)
-	if a.cfg.Routing.ProxyRule == "auto_block" {
-		autoBlock.Check()
+	for _, r := range rules {
+		item := m.AddCheckbox(r.label, r.checked, func(rule string) func() {
+			return func() { go a.changeProxyRule(rule) }
+		}(r.rule))
+		a.setChecked(item, r.checked)
+		a.proxyRuleItems[r.rule] = item
 	}
 
-	reverseAuto := proxyMenu.AddSubMenuItemCheckbox("反向自动(国外访问国内)", "", false)
-	if a.cfg.Routing.ProxyRule == "reverse_auto" {
-		reverseAuto.Check()
-	}
+	return m
+}
 
-	proxy := proxyMenu.AddSubMenuItemCheckbox("代理全部(绕过局域网地址)", "", false)
-	if a.cfg.Routing.ProxyRule == "proxy" {
-		proxy.Check()
+func (a *TrayApp) changeProxyRule(rule string) {
+	if a.isChecked(a.proxyRuleItems[rule]) {
+		return
 	}
-
-	direct := proxyMenu.AddSubMenuItemCheckbox("直接连接", "", false)
-	if a.cfg.Routing.ProxyRule == "direct" {
-		direct.Check()
+	a.setProxyRule(rule)
+	for r, item := range a.proxyRuleItems {
+		a.setChecked(item, r == rule)
 	}
-
-	go func() {
-		for {
-			select {
-			case <-auto.ClickedCh:
-				if auto.Checked() {
-					auto.Check()
-					continue
-				}
-				a.setProxyRule("auto")
-				auto.Check()
-				autoBlock.Uncheck()
-				reverseAuto.Uncheck()
-				proxy.Uncheck()
-				direct.Uncheck()
-			case <-autoBlock.ClickedCh:
-				if autoBlock.Checked() {
-					autoBlock.Check()
-					continue
-				}
-				a.setProxyRule("auto_block")
-				autoBlock.Check()
-				auto.Uncheck()
-				reverseAuto.Uncheck()
-				proxy.Uncheck()
-				direct.Uncheck()
-			case <-reverseAuto.ClickedCh:
-				if reverseAuto.Checked() {
-					reverseAuto.Check()
-					continue
-				}
-				a.setProxyRule("reverse_auto")
-				reverseAuto.Check()
-				auto.Uncheck()
-				autoBlock.Uncheck()
-				proxy.Uncheck()
-				direct.Uncheck()
-			case <-proxy.ClickedCh:
-				if proxy.Checked() {
-					proxy.Check()
-					continue
-				}
-				a.setProxyRule("proxy")
-				proxy.Check()
-				auto.Uncheck()
-				autoBlock.Uncheck()
-				reverseAuto.Uncheck()
-				direct.Uncheck()
-			case <-direct.ClickedCh:
-				if direct.Checked() {
-					direct.Check()
-					continue
-				}
-				a.setProxyRule("direct")
-				direct.Check()
-				auto.Uncheck()
-				autoBlock.Uncheck()
-				reverseAuto.Uncheck()
-				proxy.Uncheck()
-			case <-a.closing:
-				return
-			}
-		}
-	}()
 }
 
 func (a *TrayApp) setProxyRule(rule string) {
@@ -298,67 +296,108 @@ func (a *TrayApp) setProxyRule(rule string) {
 	log.Info("[SYSTRAY] proxy rule changed", "rule", rule)
 }
 
-func (a *TrayApp) addProxyObjectMenu() (*systray.MenuItem, *systray.MenuItem) {
-	proxyMenu := systray.AddMenuItem("代理对象", "")
+func (a *TrayApp) buildProxyObjectMenu() *systray.Menu {
+	m := systray.NewMenu()
 
 	browserChecked := !a.cfg.Local.DisableSysProxy
-	browser := proxyMenu.AddSubMenuItemCheckbox("浏览器(设置系统代理)", "", browserChecked)
-	global := proxyMenu.AddSubMenuItemCheckbox("系统全局流量(Tun2socks)", "", a.cfg.Local.EnableTun2socks)
+	browser := m.AddCheckbox("浏览器(设置系统代理)", browserChecked, a.toggleSysProxy)
+	a.setChecked(browser, browserChecked)
+	a.SetBrowserMenu(browser)
 
-	go func() {
-		for {
-			select {
-			case <-browser.ClickedCh:
-				if browser.Checked() {
-					browser.Uncheck()
-					go func() {
-						if err := a.setSysProxyOff(); err != nil {
-							log.Error("[SYSTRAY] set sys-proxy off", "err", err)
-							browser.Check() // revert on failure
-						}
-					}()
-				} else {
-					browser.Check()
-					go func() {
-						if err := a.setSysProxyOn(); err != nil {
-							log.Error("[SYSTRAY] set sys-proxy on", "err", err)
-							browser.Uncheck() // revert on failure
-						}
-					}()
-				}
-			case <-global.ClickedCh:
-				log.Info("[SYSTRAY] tun menu clicked", "checked", global.Checked())
-				if global.Checked() {
-					global.Uncheck()
-					go a.disableTun2socks()
-				} else {
-					global.Check()
-					go a.enableTun2socks(global)
-				}
-			case <-a.closing:
-				return
-			}
-		}
-	}()
+	global := m.AddCheckbox("系统全局流量(Tun2socks)", a.cfg.Local.EnableTun2socks, a.toggleTun2socks)
+	a.setChecked(global, a.cfg.Local.EnableTun2socks)
+	a.SetTunMenu(global)
 
-	return browser, global
+	return m
 }
 
-func (a *TrayApp) addCatLogsMenu() {
-	catLog := systray.AddMenuItem("查看日志", "")
-
+func (a *TrayApp) toggleSysProxy() {
 	go func() {
-		for {
-			select {
-			case <-catLog.ClickedCh:
-				if err := a.catLog(); err != nil {
-					log.Error("[SYSTRAY] cat log", "err", err)
-				}
-			case <-a.closing:
-				return
+		mi := a.BrowserMenu()
+		if a.isChecked(mi) {
+			a.setChecked(mi, false)
+			if err := a.setSysProxyOff(); err != nil {
+				log.Error("[SYSTRAY] set sys-proxy off", "err", err)
+				a.setChecked(mi, true) // revert on failure
+			}
+		} else {
+			a.setChecked(mi, true)
+			if err := a.setSysProxyOn(); err != nil {
+				log.Error("[SYSTRAY] set sys-proxy on", "err", err)
+				a.setChecked(mi, false) // revert on failure
 			}
 		}
 	}()
+}
+
+func (a *TrayApp) toggleTun2socks() {
+	go func() {
+		mi := a.TunMenu()
+		log.Info("[SYSTRAY] tun menu clicked", "checked", a.isChecked(mi))
+		if a.isChecked(mi) {
+			a.setChecked(mi, false)
+			a.disableTun2socks()
+		} else {
+			a.setChecked(mi, true)
+			a.enableTun2socks(mi)
+		}
+	}()
+}
+
+func (a *TrayApp) buildLogLevelMenu() *systray.Menu {
+	m := systray.NewMenu()
+	a.logLevelItems = make(map[string]*systray.MenuItem)
+
+	levels := []struct {
+		level   string
+		checked bool
+	}{
+		{"debug", a.cfg.Log.Level == "debug"},
+		{"info", a.cfg.Log.Level == "info" || a.cfg.Log.Level == ""},
+		{"warn", a.cfg.Log.Level == "warn"},
+		{"error", a.cfg.Log.Level == "error"},
+	}
+
+	for _, l := range levels {
+		item := m.AddCheckbox(l.level, l.checked, func(level string) func() {
+			return func() { go a.changeLogLevel(level) }
+		}(l.level))
+		a.setChecked(item, l.checked)
+		a.logLevelItems[l.level] = item
+	}
+
+	return m
+}
+
+func (a *TrayApp) changeLogLevel(level string) {
+	if a.isChecked(a.logLevelItems[level]) {
+		return
+	}
+	a.cfg.Log.Level = level
+	log.Info("[SYSTRAY] log level changed", "level", level)
+
+	var slogLevel slog.Level
+	switch level {
+	case "debug":
+		slogLevel = slog.LevelDebug
+	case "warn":
+		slogLevel = slog.LevelWarn
+	case "error":
+		slogLevel = slog.LevelError
+	default:
+		slogLevel = slog.LevelInfo
+	}
+	log.SetLevel(slogLevel)
+
+	for l, item := range a.logLevelItems {
+		a.setChecked(item, l == level)
+	}
+}
+
+func (a *TrayApp) catLogs() {
+	if err := a.catLog(); err != nil {
+		log.Error("[SYSTRAY] cat log", "err", err)
+	}
 }
 
 func (a *TrayApp) catLog() error {
@@ -369,128 +408,33 @@ func (a *TrayApp) catLog() error {
 	return catLogFile(filePath)
 }
 
-func (a *TrayApp) addLogLevelMenu() {
-	logLevelMenu := systray.AddMenuItem("日志级别", "")
-
-	debug := logLevelMenu.AddSubMenuItemCheckbox("Debug", "", false)
-	info := logLevelMenu.AddSubMenuItemCheckbox("Info", "", false)
-	warn := logLevelMenu.AddSubMenuItemCheckbox("Warn", "", false)
-	errLevel := logLevelMenu.AddSubMenuItemCheckbox("Error", "", false)
-
-	switch a.cfg.Log.Level {
-	case "debug":
-		debug.Check()
-	case "warn":
-		warn.Check()
-	case "error":
-		errLevel.Check()
-	default:
-		info.Check()
-	}
-
+func (a *TrayApp) toggleAutoStart() {
 	go func() {
-		for {
-			select {
-			case <-debug.ClickedCh:
-				if debug.Checked() {
-					debug.Check()
-					continue
-				}
-				debug.Check()
-				info.Uncheck()
-				warn.Uncheck()
-				errLevel.Uncheck()
-				a.cfg.Log.Level = "debug"
-				log.Info("[SYSTRAY] log level changed", "level", "debug")
-				log.SetLevel(slog.LevelDebug)
-			case <-info.ClickedCh:
-				if info.Checked() {
-					info.Check()
-					continue
-				}
-				info.Check()
-				debug.Uncheck()
-				warn.Uncheck()
-				errLevel.Uncheck()
-				a.cfg.Log.Level = "info"
-				log.Info("[SYSTRAY] log level changed", "level", "info")
-				log.SetLevel(slog.LevelInfo)
-			case <-warn.ClickedCh:
-				if warn.Checked() {
-					warn.Check()
-					continue
-				}
-				warn.Check()
-				debug.Uncheck()
-				info.Uncheck()
-				errLevel.Uncheck()
-				a.cfg.Log.Level = "warn"
-				log.Info("[SYSTRAY] log level changed", "level", "warn")
-				log.SetLevel(slog.LevelWarn)
-			case <-errLevel.ClickedCh:
-				if errLevel.Checked() {
-					errLevel.Check()
-					continue
-				}
-				errLevel.Check()
-				debug.Uncheck()
-				info.Uncheck()
-				warn.Uncheck()
-				a.cfg.Log.Level = "error"
-				log.Warn("[SYSTRAY] log level changed", "level", "error")
-				log.SetLevel(slog.LevelError)
-			case <-a.closing:
+		if a.isChecked(a.autoStartItem) {
+			if err := DisableAutoStart(); err != nil {
+				log.Error("[SYSTRAY] disable auto-start", "err", err)
 				return
 			}
+			a.setChecked(a.autoStartItem, false)
+			log.Info("[SYSTRAY] auto-start disabled")
+		} else {
+			if err := EnableAutoStart(); err != nil {
+				log.Error("[SYSTRAY] enable auto-start", "err", err)
+				return
+			}
+			a.setChecked(a.autoStartItem, true)
+			log.Info("[SYSTRAY] auto-start enabled")
 		}
 	}()
 }
 
-func (a *TrayApp) addAutoStartMenu() {
-	autoStart := systray.AddMenuItemCheckbox("开机启动", "", IsAutoStartEnabled())
-
+func (a *TrayApp) exitApp() {
 	go func() {
-		for {
-			select {
-			case <-autoStart.ClickedCh:
-				if autoStart.Checked() {
-					if err := DisableAutoStart(); err != nil {
-						log.Error("[SYSTRAY] disable auto-start", "err", err)
-						continue
-					}
-					autoStart.Uncheck()
-					log.Info("[SYSTRAY] auto-start disabled")
-				} else {
-					if err := EnableAutoStart(); err != nil {
-						log.Error("[SYSTRAY] enable auto-start", "err", err)
-						continue
-					}
-					autoStart.Check()
-					log.Info("[SYSTRAY] auto-start enabled")
-				}
-			case <-a.closing:
-				return
-			}
-		}
-	}()
-}
-
-func (a *TrayApp) addExitMenu() {
-	quit := systray.AddMenuItem("退出", "")
-
-	go func() {
-		for {
-			select {
-			case <-quit.ClickedCh:
-				// Clear the system proxy synchronously — this is fast
-				// and does not require admin. Leave TUN cleanup for
-				// trayExit() to avoid blocking the menu on osascript.
-				_ = a.setSysProxyOff()
-				systray.Quit()
-			case <-a.closing:
-				return
-			}
-		}
+		// Clear the system proxy synchronously — this is fast
+		// and does not require admin. Leave TUN cleanup for
+		// trayExit() to avoid blocking the menu on osascript.
+		_ = a.setSysProxyOff()
+		a.tray.Remove()
 	}()
 }
 
@@ -578,13 +522,13 @@ func (a *TrayApp) enableTun2socks(menu *systray.MenuItem) {
 		// open the TUN device, set up routes, and pass the fd back.
 		if err := a.createTun2socksViaHelper(); err != nil {
 			log.Error("[SYSTRAY] create tun2socks via helper", "err", err)
-			menu.Uncheck()
+			a.setChecked(menu, false)
 			return
 		}
 	} else {
 		if err := a.createTun2socks(); err != nil {
 			log.Error("[SYSTRAY] create tun2socks", "err", err)
-			menu.Uncheck()
+			a.setChecked(menu, false)
 			return
 		}
 	}
@@ -600,7 +544,7 @@ func (a *TrayApp) disableTun2socks() {
 }
 
 func (a *TrayApp) restartService(newCfg *config.ClientConfig) error {
-	sysProxyEnabled := a.browserMenu != nil && a.browserMenu.Checked()
+	sysProxyEnabled := a.BrowserMenu() != nil && a.isChecked(a.BrowserMenu())
 
 	// Stop everything including TUN. On macOS this prompts for admin
 	// credentials to clean up routes and DNS — acceptable during a
@@ -612,7 +556,7 @@ func (a *TrayApp) restartService(newCfg *config.ClientConfig) error {
 	// actual (off) state so the user can re-enable it with one click.
 	newCfg.Local.EnableTun2socks = false
 	if tunMenu := a.TunMenu(); tunMenu != nil {
-		tunMenu.Uncheck()
+		a.setChecked(tunMenu, false)
 	}
 
 	*a.App = App{
@@ -657,7 +601,7 @@ func (a *TrayApp) startLocalService() {
 		_ = pacPort
 	}
 
-	if a.browserMenu != nil && a.browserMenu.Checked() {
+	if a.BrowserMenu() != nil && a.isChecked(a.BrowserMenu()) {
 		if err := a.setSysProxyOn(); err != nil {
 			log.Error("[SYSTRAY] start local: set sysproxy on", "err", err)
 		}
@@ -668,8 +612,8 @@ func (a *TrayApp) startLocalService() {
 	}
 
 	if a.cfg.Local.EnableTun2socks {
-		if a.tunMenu != nil {
-			a.tunMenu.Check()
+		if a.TunMenu() != nil {
+			a.setChecked(a.TunMenu(), true)
 		}
 	}
 }

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -447,23 +447,18 @@ func (a *TrayApp) closeTun2socks() error {
 	a.tunHelperMu.Lock()
 	defer a.tunHelperMu.Unlock()
 
-	log.Info("[SYSTRAY] closeTun2socks called",
-		"stdinNil", a.tunHelperStdin == nil,
-		"tunMgrNil", a.tunMgr == nil)
-
 	// 1. Signal the helper to shut down by closing the FIFO.
 	//    The helper detects EOF on stdin, cleans up routes/DNS, and exits.
 	if a.tunHelperStdin != nil {
+		log.Info("[SYSTRAY] closeTun2socks: closing helper FIFO")
 		a.tunHelperStdin.Close() //nolint:errcheck
 		a.tunHelperStdin = nil
 	}
-	log.Info("[SYSTRAY] closeTun2socks: fifo closed, stopping engine")
 
 	// 2. Stop the tun2socks engine (no route/DNS cleanup — helper handles it).
 	if a.tunMgr != nil {
-		log.Info("[SYSTRAY] closeTun2socks: calling tunMgr.Stop")
+		log.Info("[SYSTRAY] closeTun2socks: stopping tun2socks engine")
 		a.tunMgr.Stop()
-		log.Info("[SYSTRAY] closeTun2socks: tunMgr.Stop done")
 		a.tunMgr = nil
 	}
 

--- a/cmd/easyss/uwp_other.go
+++ b/cmd/easyss/uwp_other.go
@@ -2,7 +2,7 @@
 
 package main
 
-import "github.com/nange/systray"
+import "github.com/gogpu/systray"
 
 func (a *TrayApp) addUWPLoopbackMenu(root *systray.Menu) {
 	// No-op on non-Windows

--- a/cmd/easyss/uwp_other.go
+++ b/cmd/easyss/uwp_other.go
@@ -2,6 +2,8 @@
 
 package main
 
-func (a *TrayApp) addUWPLoopbackMenu() {
+import "github.com/nange/systray"
+
+func (a *TrayApp) addUWPLoopbackMenu(root *systray.Menu) {
 	// No-op on non-Windows
 }

--- a/cmd/easyss/uwp_windows.go
+++ b/cmd/easyss/uwp_windows.go
@@ -6,156 +6,131 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
-	"sync"
 
-	"fyne.io/systray"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/util"
+	"github.com/nange/systray"
 )
 
-type UWPApp struct {
-	Name              string `json:"Name"`
-	PackageFamilyName string `json:"PackageFamilyName"`
-	Exempt            bool
+func (a *TrayApp) addUWPLoopbackMenu(root *systray.Menu) {
+	a.uwpMenu = systray.NewMenu()
+	root.AddSubmenu("Windows UWP应用豁免", a.uwpMenu)
+	root.AddSeparator()
+
+	a.uwpMenu.Add("刷新列表", func() { go a.uwpRefresh() })
+
+	// Populate the list asynchronously; the menu already shows "刷新列表".
+	go a.uwpRefresh()
 }
 
-type UWPMenuItem struct {
-	MenuItem *systray.MenuItem
-	App      *UWPApp
-	Mu       sync.RWMutex
-}
+func (a *TrayApp) uwpRefresh() {
+	a.uwpMu.Lock()
+	defer a.uwpMu.Unlock()
 
-func (a *TrayApp) addUWPLoopbackMenu() {
-	uwpMenu := systray.AddMenuItem("Windows UWP应用豁免", "")
+	apps, err := getInstalledUWPApps()
+	if err != nil {
+		log.Error("[UWP] Failed to get installed UWP apps", "err", err)
+		return
+	}
 
-	refreshItem := uwpMenu.AddSubMenuItem("刷新列表", "")
-	systray.AddSeparator()
+	exemptsStr, err := getExemptUWPAppsOutput()
+	if err != nil {
+		log.Error("[UWP] Failed to get exempt UWP apps", "err", err)
+	}
+	exemptsStr = strings.ToLower(exemptsStr)
 
-	var menuItems []*UWPMenuItem
-	var mu sync.Mutex
-
-	refreshFunc := func() {
-		mu.Lock()
-		defer mu.Unlock()
-
-		apps, err := getInstalledUWPApps()
-		if err != nil {
-			log.Error("[UWP] Failed to get installed UWP apps", "err", err)
-			return
-		}
-
-		exemptsStr, err := getExemptUWPAppsOutput()
-		if err != nil {
-			log.Error("[UWP] Failed to get exempt UWP apps", "err", err)
-		}
-		exemptsStr = strings.ToLower(exemptsStr)
-
-		for i := range apps {
-			if strings.Contains(exemptsStr, strings.ToLower(apps[i].PackageFamilyName)) {
-				apps[i].Exempt = true
-			}
-		}
-
-		sort.Slice(apps, func(i, j int) bool {
-			return strings.ToLower(apps[i].Name) < strings.ToLower(apps[j].Name)
-		})
-
-		appIndex := 0
-		for _, app := range apps {
-			if app.Name == "" || app.PackageFamilyName == "" {
-				continue
-			}
-
-			if appIndex >= len(menuItems) {
-				item := uwpMenu.AddSubMenuItemCheckbox(app.Name, "", app.Exempt)
-				uwpItem := &UWPMenuItem{
-					MenuItem: item,
-					App:      &app,
-				}
-				menuItems = append(menuItems, uwpItem)
-
-				go func(u *UWPMenuItem) {
-					for {
-						select {
-						case <-u.MenuItem.ClickedCh:
-							u.Mu.RLock()
-							targetApp := u.App
-							u.Mu.RUnlock()
-
-							if targetApp == nil {
-								continue
-							}
-
-							if u.MenuItem.Checked() {
-								if err := removeLoopbackExempt(targetApp.PackageFamilyName); err != nil {
-									log.Error("[UWP] Failed to remove exemption", "app", targetApp.Name, "err", err)
-								} else {
-									u.MenuItem.Uncheck()
-									log.Info("[UWP] Removed exemption", "app", targetApp.Name)
-									u.Mu.Lock()
-									if u.App != nil {
-										u.App.Exempt = false
-									}
-									u.Mu.Unlock()
-								}
-							} else {
-								if err := addLoopbackExempt(targetApp.PackageFamilyName); err != nil {
-									log.Error("[UWP] Failed to add exemption", "app", targetApp.Name, "err", err)
-								} else {
-									u.MenuItem.Check()
-									log.Info("[UWP] Added exemption", "app", targetApp.Name)
-									u.Mu.Lock()
-									if u.App != nil {
-										u.App.Exempt = true
-									}
-									u.Mu.Unlock()
-								}
-							}
-						case <-a.closing:
-							return
-						}
-					}
-				}(uwpItem)
-
-			} else {
-				uwpItem := menuItems[appIndex]
-				uwpItem.Mu.Lock()
-				uwpItem.App = &app
-				uwpItem.Mu.Unlock()
-
-				uwpItem.MenuItem.SetTitle(app.Name)
-				if app.Exempt {
-					uwpItem.MenuItem.Check()
-				} else {
-					uwpItem.MenuItem.Uncheck()
-				}
-				uwpItem.MenuItem.Show()
-			}
-			appIndex++
-		}
-
-		for i := appIndex; i < len(menuItems); i++ {
-			menuItems[i].MenuItem.Hide()
-			menuItems[i].Mu.Lock()
-			menuItems[i].App = nil
-			menuItems[i].Mu.Unlock()
+	for i := range apps {
+		if strings.Contains(exemptsStr, strings.ToLower(apps[i].PackageFamilyName)) {
+			apps[i].Exempt = true
 		}
 	}
 
+	sort.Slice(apps, func(i, j int) bool {
+		return strings.ToLower(apps[i].Name) < strings.ToLower(apps[j].Name)
+	})
+
+	// gogpu/systray builds the native menu (HMENU) on SetMenu; there is no
+	// Show/Hide for menu items. Reuse existing items and append new ones,
+	// then re-SetMenu only when the menu tree shape changed. Items that no
+	// longer correspond to an installed app are disabled instead of hidden.
+	needsRebuild := false
+	appIndex := 0
+	for _, app := range apps {
+		if app.Name == "" || app.PackageFamilyName == "" {
+			continue
+		}
+
+		if appIndex >= len(a.uwpItems) {
+			uwpItem := &UWPMenuItem{App: &app}
+			item := a.uwpMenu.AddCheckbox(app.Name, app.Exempt, func(u *UWPMenuItem) func() {
+				return func() { a.onUWPItemClicked(u) }
+			}(uwpItem))
+			uwpItem.MenuItem = item
+			a.setChecked(item, app.Exempt)
+			a.uwpItems = append(a.uwpItems, uwpItem)
+			needsRebuild = true
+		} else {
+			uwpItem := a.uwpItems[appIndex]
+			uwpItem.Mu.Lock()
+			uwpItem.App = &app
+			uwpItem.Mu.Unlock()
+
+			uwpItem.MenuItem.SetLabel(app.Name)
+			uwpItem.MenuItem.SetDisabled(false)
+			a.setChecked(uwpItem.MenuItem, app.Exempt)
+		}
+		appIndex++
+	}
+
+	for i := appIndex; i < len(a.uwpItems); i++ {
+		uwpItem := a.uwpItems[i]
+		uwpItem.MenuItem.SetDisabled(true)
+		uwpItem.Mu.Lock()
+		uwpItem.App = nil
+		uwpItem.Mu.Unlock()
+	}
+
+	if needsRebuild && a.tray != nil {
+		a.tray.SetMenu(a.rootMenu)
+	}
+}
+
+func (a *TrayApp) onUWPItemClicked(u *UWPMenuItem) {
 	go func() {
-		for {
-			select {
-			case <-refreshItem.ClickedCh:
-				log.Info("[UWP] Refreshing app list...")
-				refreshFunc()
-				log.Info("[UWP] Refresh complete")
-			case <-a.closing:
-				return
+		u.Mu.RLock()
+		targetApp := u.App
+		u.Mu.RUnlock()
+
+		if targetApp == nil {
+			return
+		}
+
+		if a.isChecked(u.MenuItem) {
+			if err := removeLoopbackExempt(targetApp.PackageFamilyName); err != nil {
+				log.Error("[UWP] Failed to remove exemption", "app", targetApp.Name, "err", err)
+			} else {
+				a.setChecked(u.MenuItem, false)
+				log.Info("[UWP] Removed exemption", "app", targetApp.Name)
+				u.Mu.Lock()
+				if u.App != nil {
+					u.App.Exempt = false
+				}
+				u.Mu.Unlock()
+			}
+		} else {
+			if err := addLoopbackExempt(targetApp.PackageFamilyName); err != nil {
+				log.Error("[UWP] Failed to add exemption", "app", targetApp.Name, "err", err)
+			} else {
+				a.setChecked(u.MenuItem, true)
+				log.Info("[UWP] Added exemption", "app", targetApp.Name)
+				u.Mu.Lock()
+				if u.App != nil {
+					u.App.Exempt = true
+				}
+				u.Mu.Unlock()
 			}
 		}
 	}()
-
-	go refreshFunc()
 }
 
 func getInstalledUWPApps() ([]UWPApp, error) {

--- a/cmd/easyss/uwp_windows.go
+++ b/cmd/easyss/uwp_windows.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/gogpu/systray"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/util"
-	"github.com/nange/systray"
 )
 
 func (a *TrayApp) addUWPLoopbackMenu(root *systray.Menu) {
@@ -66,7 +66,7 @@ func (a *TrayApp) uwpRefresh() {
 				return func() { a.onUWPItemClicked(u) }
 			}(uwpItem))
 			uwpItem.MenuItem = item
-			a.setChecked(item, app.Exempt)
+			item.SetChecked(app.Exempt)
 			a.uwpItems = append(a.uwpItems, uwpItem)
 			needsRebuild = true
 		} else {
@@ -77,7 +77,7 @@ func (a *TrayApp) uwpRefresh() {
 
 			uwpItem.MenuItem.SetLabel(app.Name)
 			uwpItem.MenuItem.SetDisabled(false)
-			a.setChecked(uwpItem.MenuItem, app.Exempt)
+			uwpItem.MenuItem.SetChecked(app.Exempt)
 		}
 		appIndex++
 	}
@@ -105,11 +105,11 @@ func (a *TrayApp) onUWPItemClicked(u *UWPMenuItem) {
 			return
 		}
 
-		if a.isChecked(u.MenuItem) {
+		if u.MenuItem.IsChecked() {
 			if err := removeLoopbackExempt(targetApp.PackageFamilyName); err != nil {
 				log.Error("[UWP] Failed to remove exemption", "app", targetApp.Name, "err", err)
 			} else {
-				a.setChecked(u.MenuItem, false)
+				u.MenuItem.SetChecked(false)
 				log.Info("[UWP] Removed exemption", "app", targetApp.Name)
 				u.Mu.Lock()
 				if u.App != nil {
@@ -121,7 +121,7 @@ func (a *TrayApp) onUWPItemClicked(u *UWPMenuItem) {
 			if err := addLoopbackExempt(targetApp.PackageFamilyName); err != nil {
 				log.Error("[UWP] Failed to add exemption", "app", targetApp.Name, "err", err)
 			} else {
-				a.setChecked(u.MenuItem, true)
+				u.MenuItem.SetChecked(true)
 				log.Info("[UWP] Added exemption", "app", targetApp.Name)
 				u.Mu.Lock()
 				if u.App != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.3
 require (
 	github.com/caddyserver/certmagic v0.25.2
 	github.com/coocood/freecache v1.2.7
+	github.com/gogpu/systray v0.2.6
 	github.com/libp2p/go-netroute v0.4.0
 	github.com/miekg/dns v1.1.72
 	github.com/oschwald/geoip2-golang v1.13.0
@@ -21,7 +22,7 @@ require (
 	gvisor.dev/gvisor v0.0.0-20260701204157-69c2d17aea96
 )
 
-require github.com/go-webgpu/goffi v0.6.2 // indirect
+require github.com/go-webgpu/goffi v0.6.3 // indirect
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
@@ -171,7 +172,6 @@ require (
 	github.com/moricho/tparallel v0.3.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
-	github.com/nange/systray v0.2.1-easyss.1
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.21.0 // indirect
@@ -268,3 +268,8 @@ tool (
 )
 
 replace github.com/xjasonlyu/tun2socks/v2 => github.com/nange/tun2socks/v2 v2.0.0-20260729130352-d1698910c4f0
+
+// Temporary local patch: upstream gogpu/systray v0.2.6 cannot update menu items
+// inside submenus on macOS (itemWithTag: doesn't search submenus). Fix is on
+// branch fix/darwin-submenu-update of the local fork; remove once released.
+replace github.com/gogpu/systray => /Users/nange/go/src/github.com/nange/systray

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/caddyserver/certmagic v0.25.2
 	github.com/coocood/freecache v1.2.7
-	github.com/gogpu/systray v0.2.6
+	github.com/gogpu/systray v0.2.8
 	github.com/libp2p/go-netroute v0.4.0
 	github.com/miekg/dns v1.1.72
 	github.com/oschwald/geoip2-golang v1.13.0
@@ -268,8 +268,3 @@ tool (
 )
 
 replace github.com/xjasonlyu/tun2socks/v2 => github.com/nange/tun2socks/v2 v2.0.0-20260729130352-d1698910c4f0
-
-// Temporary local patch: upstream gogpu/systray v0.2.6 cannot update menu items
-// inside submenus on macOS (itemWithTag: doesn't search submenus). Fix is on
-// branch fix/darwin-submenu-update of the local fork; remove once released.
-replace github.com/gogpu/systray => /Users/nange/go/src/github.com/nange/systray

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,6 @@ require (
 	gvisor.dev/gvisor v0.0.0-20260701204157-69c2d17aea96
 )
 
-require github.com/go-webgpu/goffi v0.6.3 // indirect
-
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
@@ -102,6 +100,7 @@ require (
 	github.com/go-toolsmith/strparse v1.1.0 // indirect
 	github.com/go-toolsmith/typep v1.1.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/go-webgpu/goffi v0.6.3 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/nange/easyss/v3
 go 1.26.3
 
 require (
-	fyne.io/systray v1.12.2
 	github.com/caddyserver/certmagic v0.25.2
 	github.com/coocood/freecache v1.2.7
 	github.com/libp2p/go-netroute v0.4.0
@@ -21,6 +20,8 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gvisor.dev/gvisor v0.0.0-20260701204157-69c2d17aea96
 )
+
+require github.com/go-webgpu/goffi v0.6.2 // indirect
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
@@ -102,7 +103,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/godoc-lint/godoc-lint v0.10.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
@@ -170,6 +171,7 @@ require (
 	github.com/moricho/tparallel v0.3.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
+	github.com/nange/systray v0.2.1-easyss.1
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ dev.gaijin.team/go/exhaustruct/v4 v4.0.0 h1:873r7aNneqoBB3IaFIzhvt2RFYTuHgmMjoKf
 dev.gaijin.team/go/exhaustruct/v4 v4.0.0/go.mod h1:aZ/k2o4Y05aMJtiux15x8iXaumE88YdiB0Ai4fXOzPI=
 dev.gaijin.team/go/golib v0.6.0 h1:v6nnznFTs4bppib/NyU1PQxobwDHwCXXl15P7DV5Zgo=
 dev.gaijin.team/go/golib v0.6.0/go.mod h1:uY1mShx8Z/aNHWDyAkZTkX+uCi5PdX7KsG1eDQa2AVE=
-fyne.io/systray v1.12.2 h1:Y8DZxgLHsVQt6rY9Zrkkg+j67S7vv/1F2viOWKPpVeA=
-fyne.io/systray v1.12.2/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/4meepo/tagalign v1.4.3 h1:Bnu7jGWwbfpAie2vyl63Zup5KuRv21olsPIha53BJr8=
 github.com/4meepo/tagalign v1.4.3/go.mod h1:00WwRjiuSbrRJnSVeGWPLp2epS5Q/l4UEy0apLLS37c=
 github.com/Abirdcfly/dupword v0.1.6 h1:qeL6u0442RPRe3mcaLcbaCi2/Y/hOcdtw6DE9odjz9c=
@@ -184,12 +182,14 @@ github.com/go-toolsmith/typep v1.1.0 h1:fIRYDyF+JywLfqzyhdiHzRop/GQDxxNhLGQ6gFUN
 github.com/go-toolsmith/typep v1.1.0/go.mod h1:fVIw+7zjdsMxDA3ITWnH1yOiw1rnTQKCsF/sk2H/qig=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE=
+github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUWY=
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/godoc-lint/godoc-lint v0.10.0 h1:OcyrziBi18sQSEpib6NesVHEJ/Xcng97NunePBA48g4=
 github.com/godoc-lint/godoc-lint v0.10.0/go.mod h1:KleLcHu/CGSvkjUH2RvZyoK1MBC7pDQg4NxMYLcBBsw=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
@@ -352,6 +352,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81U=
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
+github.com/nange/systray v0.2.1-easyss.1 h1:Cmvz0GxbAQY3tkHTXs/xkEv9Q2u48XWVzYabvg45XKI=
+github.com/nange/systray v0.2.1-easyss.1/go.mod h1:Zd+YQx0dstJS0trfVGVx+D+oAoCcvUzlL+DgI/zI+Oc=
 github.com/nange/tun2socks/v2 v2.0.0-20260729130352-d1698910c4f0 h1:aw2JV6rr4pU88A8CnPPjmJGwI+Q2nqaxOdaBlUfCnPI=
 github.com/nange/tun2socks/v2 v2.0.0-20260729130352-d1698910c4f0/go.mod h1:XHgJ3wbs63mZxGbJawt6jjNX65aPDl+Qhn2ePPEE4KI=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/godoc-lint/godoc-lint v0.10.0 h1:OcyrziBi18sQSEpib6NesVHEJ/Xcng97Nune
 github.com/godoc-lint/godoc-lint v0.10.0/go.mod h1:KleLcHu/CGSvkjUH2RvZyoK1MBC7pDQg4NxMYLcBBsw=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
+github.com/gogpu/systray v0.2.8 h1:3C/jUnHGO/e/kCbrRWw9n3psuuP7pfvSer68sqjzA4U=
+github.com/gogpu/systray v0.2.8/go.mod h1:aoA1tAjYSKH/iVc761t7IVDOaTRYmOwglbcbpcLF1v0=
 github.com/golangci/asciicheck v0.5.0 h1:jczN/BorERZwK8oiFBOGvlGPknhvq0bjnysTj4nUfo0=
 github.com/golangci/asciicheck v0.5.0/go.mod h1:5RMNAInbNFw2krqN6ibBxN/zfRFa9S6tA1nPdM0l8qQ=
 github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 h1:WUvBfQL6EW/40l6OmeSBYQJNSif4O11+bmWEz+C7FYw=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/go-toolsmith/typep v1.1.0 h1:fIRYDyF+JywLfqzyhdiHzRop/GQDxxNhLGQ6gFUN
 github.com/go-toolsmith/typep v1.1.0/go.mod h1:fVIw+7zjdsMxDA3ITWnH1yOiw1rnTQKCsF/sk2H/qig=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
-github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE=
-github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A=
+github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUWY=
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
@@ -352,8 +352,6 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81U=
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
-github.com/nange/systray v0.2.1-easyss.1 h1:Cmvz0GxbAQY3tkHTXs/xkEv9Q2u48XWVzYabvg45XKI=
-github.com/nange/systray v0.2.1-easyss.1/go.mod h1:Zd+YQx0dstJS0trfVGVx+D+oAoCcvUzlL+DgI/zI+Oc=
 github.com/nange/tun2socks/v2 v2.0.0-20260729130352-d1698910c4f0 h1:aw2JV6rr4pU88A8CnPPjmJGwI+Q2nqaxOdaBlUfCnPI=
 github.com/nange/tun2socks/v2 v2.0.0-20260729130352-d1698910c4f0/go.mod h1:XHgJ3wbs63mZxGbJawt6jjNX65aPDl+Qhn2ePPEE4KI=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=

--- a/icon/icon_darwin.go
+++ b/icon/icon_darwin.go
@@ -6,3 +6,8 @@ import (
 
 //go:embed icon_256_256.png
 var Data []byte
+
+// TrayData is the PNG data used for the tray icon.
+//
+//go:embed icon_256_256.png
+var TrayData []byte

--- a/icon/icon_darwin.go
+++ b/icon/icon_darwin.go
@@ -4,9 +4,6 @@ import (
 	_ "embed"
 )
 
-//go:embed icon_256_256.png
-var Data []byte
-
 // TrayData is the PNG data used for the tray icon.
 //
 //go:embed icon_256_256.png

--- a/icon/icon_linux.go
+++ b/icon/icon_linux.go
@@ -4,9 +4,6 @@ import (
 	_ "embed"
 )
 
-//go:embed icon_32_32.png
-var Data []byte
-
 // TrayData is the PNG data used for the tray icon.
 //
 //go:embed icon_32_32.png

--- a/icon/icon_linux.go
+++ b/icon/icon_linux.go
@@ -6,3 +6,8 @@ import (
 
 //go:embed icon_32_32.png
 var Data []byte
+
+// TrayData is the PNG data used for the tray icon.
+//
+//go:embed icon_32_32.png
+var TrayData []byte

--- a/icon/icon_windows.go
+++ b/icon/icon_windows.go
@@ -4,9 +4,6 @@ import (
 	_ "embed"
 )
 
-//go:embed icon_256_256.ico
-var Data []byte
-
 // TrayData is the PNG data used for the tray icon (gogpu/systray requires PNG).
 //
 //go:embed icon_32_32.png

--- a/icon/icon_windows.go
+++ b/icon/icon_windows.go
@@ -6,3 +6,8 @@ import (
 
 //go:embed icon_256_256.ico
 var Data []byte
+
+// TrayData is the PNG data used for the tray icon (gogpu/systray requires PNG).
+//
+//go:embed icon_32_32.png
+var TrayData []byte


### PR DESCRIPTION
Replace fyne.io/systray with github.com/nange/systray (gogpu/systray fork, pure Go FFI, no CGO). The fork fixes three Windows bugs:

- submenu clicks dispatched to the wrong callback (globally unique command IDs + cmdID->item map)
- SetLabel/SetChecked/SetDisabled no-ops on submenu items (owning HMENU)
- tray.Remove() left the process running (WM_CLOSE teardown + PostQuitMessage to end the message loop)

Also:
- rewrite tray menu to the builder/callback API, track checked state locally (no Checked() query in the new API)
- pin the main goroutine to its OS thread for the Win32 message loop
- fix Windows singleton lock: CreateMutex returns ERROR_ALREADY_EXISTS as err in newer Go, exit gracefully instead of "failed to create mutex"
- drop CGO for Windows client builds (CGO_ENABLED=0), simplify mac-app
- tray icon now uses PNG (gogpu requires PNG; SetTemplateIcon is macOS-only)