### PR TITLE
fix: improve h2 connection management for weak networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ Easyss v3 支持两种配置模式，自动识别：
   "transport": {
     "protocol": "h2",
     "conn_count_max": 12,
-    "stream_threshold": 8,
+    "stream_threshold": 4,
     "priority_slot_ratio": 0.5
   },
   "shaper": {
     "batch_window_ms": 3,
     "cover_budget_ratio": 0.03,
-    "cover_budget_cap": 131072
+    "cover_budget_cap": 16384
   },
   "log": {
     "level": "info",
@@ -293,7 +293,7 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
     "fallback_cdn_domains": [],
     "batch_window_ms": 3,
     "cover_budget_ratio": 0.03,
-    "cover_budget_cap": 131072
+    "cover_budget_cap": 16384
   },
   "log": {
       "level": "info",
@@ -319,7 +319,7 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
 | `server.fallback_cdn_domains` | 否 | [] | 仅对 `fallback_target` 为 URL 生效。<br>配置需要通过代理中转的 CDN 域名列表（如 `["github.githubassets.com"]`）。HTML 和 CSP 中引用这些域名的绝对 URL 会被重写为 `/__cdn__/<host>/...` 路径前缀形式，浏览器请求时走代理转发到对应 CDN，避免直连 CDN 暴露真实 IP 或被 CSP 拦截 |
 | `server.batch_window_ms` | 否 | 3 | 流量整形批处理窗口，单位毫秒，范围 1-10 |
 | `server.cover_budget_ratio` | 否 | 0.03 | cover traffic 占真实流量的预算比例，设为 0 或负数使用默认值，范围 (0, 1] |
-| `server.cover_budget_cap` | 否 | 131072 | cover traffic 最大累积预算，单位字节，默认 128KB |
+| `server.cover_budget_cap` | 否 | 16384 | cover traffic 最大累积预算，单位字节，默认 16KB |
 | `timeout` | 否 | 30 | 超时时间，单位秒 |
 
 > **fallback_target 使用示例**：

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ Easyss v3 支持两种配置模式，自动识别：
     "protocol": "h2",
     "conn_count_max": 12,
     "stream_threshold": 4,
-    "priority_slot_ratio": 0.5
+    "priority_slot_ratio": 0.5,
+    "conn_lifetime_sec": 900,
+    "conn_max_bytes": 157286400
   },
   "shaper": {
     "batch_window_ms": 3,

--- a/client/client.go
+++ b/client/client.go
@@ -87,6 +87,8 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 		MaxSlotCount:      cfg.Transport.ConnCountMax,
 		StreamThreshold:   cfg.Transport.StreamThreshold,
 		PrioritySlotRatio: cfg.Transport.PrioritySlotRatio,
+		ConnLifetime:      time.Duration(cfg.Transport.ConnLifetimeSec) * time.Second,
+		ConnMaxBytes:      cfg.Transport.ConnMaxBytes,
 		Timeout:           cfg.TimeoutDuration(),
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return dialWithConfig(ctx, cfg, client.dialer, rt, network, addr)

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -55,6 +55,8 @@ type TransportConfig struct {
 	ConnCountMax      int     `json:"conn_count_max"`
 	StreamThreshold   int     `json:"stream_threshold"`
 	PrioritySlotRatio float64 `json:"priority_slot_ratio"`
+	ConnLifetimeSec   int     `json:"conn_lifetime_sec"` // max connection lifetime in seconds, 0 uses default
+	ConnMaxBytes      int64   `json:"conn_max_bytes"`    // max bytes per connection, 0 uses default
 }
 
 type ShaperConfig struct {
@@ -182,6 +184,12 @@ func applyDefaults(c *ClientConfig) {
 	}
 	if c.Transport.StreamThreshold <= 0 {
 		c.Transport.StreamThreshold = config.DefaultStreamThreshold
+	}
+	if c.Transport.ConnLifetimeSec <= 0 {
+		c.Transport.ConnLifetimeSec = config.DefaultConnLifetimeSec
+	}
+	if c.Transport.ConnMaxBytes <= 0 {
+		c.Transport.ConnMaxBytes = config.DefaultConnMaxBytes
 	}
 	if c.Shaper.BatchWindowMS <= 0 {
 		c.Shaper.BatchWindowMS = config.DefaultBatchWindowMS

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -573,6 +573,12 @@ func TestApplyDefaults(t *testing.T) {
 		if cfg.Transport.StreamThreshold != config.DefaultStreamThreshold {
 			t.Errorf("StreamThreshold = %d", cfg.Transport.StreamThreshold)
 		}
+		if cfg.Transport.ConnLifetimeSec != config.DefaultConnLifetimeSec {
+			t.Errorf("ConnLifetimeSec = %d", cfg.Transport.ConnLifetimeSec)
+		}
+		if cfg.Transport.ConnMaxBytes != config.DefaultConnMaxBytes {
+			t.Errorf("ConnMaxBytes = %d", cfg.Transport.ConnMaxBytes)
+		}
 		if cfg.Shaper.BatchWindowMS != config.DefaultBatchWindowMS {
 			t.Errorf("BatchWindowMS = %d", cfg.Shaper.BatchWindowMS)
 		}

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -130,7 +130,7 @@ func exampleV3ServerConfig() string {
 			FallbackCDNDomains:   nil,
 			BatchWindowMS:        3,
 			CoverBudgetRatio:     0.03,
-			CoverBudgetCap:       128 * 1024,
+			CoverBudgetCap:       16 * 1024,
 			PprofEnabled:         false,
 		},
 		Transport: config.TransportConfig{

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -364,13 +364,13 @@ func exampleV3Config() string {
 		Transport: config.TransportConfig{
 			Protocol:          "h2",
 			ConnCountMax:      12,
-			StreamThreshold:   8,
+			StreamThreshold:   4,
 			PrioritySlotRatio: 0.5,
 		},
 		Shaper: config.ShaperConfig{
 			BatchWindowMS:    3,
 			CoverBudgetRatio: 0.03,
-			CoverBudgetCap:   128 * 1024,
+			CoverBudgetCap:   16 * 1024,
 		},
 		Log: config.LogConfig{
 			Level:    "info",

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -366,6 +366,8 @@ func exampleV3Config() string {
 			ConnCountMax:      12,
 			StreamThreshold:   4,
 			PrioritySlotRatio: 0.5,
+			ConnLifetimeSec:   900,
+			ConnMaxBytes:      150 * 1024 * 1024,
 		},
 		Shaper: config.ShaperConfig{
 			BatchWindowMS:    3,

--- a/config/types.go
+++ b/config/types.go
@@ -11,7 +11,7 @@ const (
 	DefaultConnCountMax    = 12
 	DefaultStreamThreshold = 4
 	DefaultBatchWindowMS   = 3
-	DefaultCoverBudgetCap  = 128 * 1024 // 128KB
+	DefaultCoverBudgetCap  = 16 * 1024 // 16KB
 
 	// Heavy-stream detection: a stream is considered "heavy" (monopolizing
 	// its shared TCP connection under packet loss) when either condition

--- a/config/types.go
+++ b/config/types.go
@@ -34,11 +34,23 @@ const (
 	// DegradedPersistCycles consecutive health-check intervals is marked
 	// degraded — new streams avoid it and its idle connection is retired
 	// early instead of lingering. The mark clears after
-	// DegradedRecoverCycles healthy intervals.
+	// DegradedRecoverCycles healthy intervals. Detection only runs while
+	// the link RTT is at most DegradedMaxRTT: a congested link makes every
+	// connection slow, so retiring connections then only adds handshake
+	// churn without recovering anything.
 	HealthCheckInterval         = 5 * time.Second
 	DegradedThroughputThreshold = 64 * 1024 // 64KB/s
 	DegradedPersistCycles       = 3
 	DegradedRecoverCycles       = 2
+	DegradedMaxRTT              = 500 * time.Millisecond
+
+	// Connection rotation: long-lived TCP+TLS connections are frequently
+	// throttled by middleboxes — especially during peak hours — which is
+	// why a reconnect feels fast again. A slot whose connection exceeded
+	// either limit stops accepting new streams and its idle connection is
+	// closed, so the next stream dials a fresh one (invisible to users).
+	DefaultConnLifetimeSec = 900               // 15min
+	DefaultConnMaxBytes    = 150 * 1024 * 1024 // 150MB
 
 	HTTP2ServerMaxReadFrameSize           = 1<<24 - 1  // 16MB-1，nginx/Cloudflare 主流值
 	HTTP2ServerReceiveBufferPerConnection = 1 << 20    // 1MB，避免 64KB 瓶颈导致长期运行吞吐量下降

--- a/config/types.go
+++ b/config/types.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // NextProtos is the ALPN protocol list advertised in TLS handshakes,
 // matching what a real Chrome browser offers (h2 preferred, http/1.1 fallback).
 var NextProtos = []string{"h2", "http/1.1"}
@@ -7,9 +9,25 @@ var NextProtos = []string{"h2", "http/1.1"}
 const (
 	DefaultTimeout         = 30
 	DefaultConnCountMax    = 12
-	DefaultStreamThreshold = 8
+	DefaultStreamThreshold = 4
 	DefaultBatchWindowMS   = 3
 	DefaultCoverBudgetCap  = 128 * 1024 // 128KB
+
+	// Heavy-stream detection: a stream is considered "heavy" (monopolizing
+	// its shared TCP connection under packet loss) when either condition
+	// below is met, after which the hosting slot stops accepting new
+	// streams so interactive traffic (e.g. page refreshes) is not dragged
+	// down together with the heavy transfer.
+	//
+	// 1. HeavyStreamThresholdBytes: fast, large transfers are marked as
+	//    soon as they cross this cumulative size (either direction).
+	// 2. HeavyStreamSlowThresholdBytes + HeavyStreamMinAge: slow transfers
+	//    on poor links — even a sub-MB resource takes seconds to load —
+	//    are marked once the stream has been alive long enough, so the
+	//    isolation kicks in promptly exactly when the link is congested.
+	HeavyStreamThresholdBytes     = 1 * 1024 * 1024 // 1MB
+	HeavyStreamSlowThresholdBytes = 256 * 1024      // 256KB
+	HeavyStreamMinAge             = 3 * time.Second
 
 	HTTP2ServerMaxReadFrameSize           = 1<<24 - 1  // 16MB-1，nginx/Cloudflare 主流值
 	HTTP2ServerReceiveBufferPerConnection = 1 << 20    // 1MB，避免 64KB 瓶颈导致长期运行吞吐量下降

--- a/config/types.go
+++ b/config/types.go
@@ -29,6 +29,17 @@ const (
 	HeavyStreamSlowThresholdBytes = 256 * 1024      // 256KB
 	HeavyStreamMinAge             = 3 * time.Second
 
+	// Degraded-slot detection: a slot hosting heavy streams whose download
+	// throughput stays below DegradedThroughputThreshold for
+	// DegradedPersistCycles consecutive health-check intervals is marked
+	// degraded — new streams avoid it and its idle connection is retired
+	// early instead of lingering. The mark clears after
+	// DegradedRecoverCycles healthy intervals.
+	HealthCheckInterval         = 5 * time.Second
+	DegradedThroughputThreshold = 64 * 1024 // 64KB/s
+	DegradedPersistCycles       = 3
+	DegradedRecoverCycles       = 2
+
 	HTTP2ServerMaxReadFrameSize           = 1<<24 - 1  // 16MB-1，nginx/Cloudflare 主流值
 	HTTP2ServerReceiveBufferPerConnection = 1 << 20    // 1MB，避免 64KB 瓶颈导致长期运行吞吐量下降
 	HTTP2ServerReceiveBufferPerStream     = 256 * 1024 // 256KB，流级别接收窗口

--- a/shaper/covertraffic.go
+++ b/shaper/covertraffic.go
@@ -48,7 +48,7 @@ func newCoverInjector(cfg CoverConfig, inject func(protocol.Frame) error, isClos
 		cfg.MaxSize = cfg.MinSize
 	}
 	if cfg.BudgetCap <= 0 {
-		cfg.BudgetCap = 128 * 1024
+		cfg.BudgetCap = 16 * 1024
 	}
 
 	ci := &coverInjector{

--- a/shaper/shaper.go
+++ b/shaper/shaper.go
@@ -32,7 +32,7 @@ type CoverConfig struct {
 	IdleTimeout int     // idle timeout in ms before sending cover frames (default 300)
 	MinSize     int     // min cover frame payload size in bytes (default 128)
 	MaxSize     int     // max cover frame payload size in bytes (default 1500)
-	BudgetCap   int     // max accumulated cover budget in bytes, 0 means unlimited (default 128KB)
+	BudgetCap   int     // max accumulated cover budget in bytes, 0 means unlimited (default 16KB)
 }
 
 type Config struct {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -43,6 +43,10 @@ type stats struct {
 	priorityFallback      atomic.Int64
 	bulkFallback          atomic.Int64
 
+	// Transport health (client-side)
+	slotDegraded        atomic.Int64
+	slotRetiredDegraded atomic.Int64
+
 	rttMu    sync.Mutex
 	rttEWMA  int64 // nanoseconds, EWMA-smoothed RTT
 	rttCount atomic.Int64
@@ -89,6 +93,9 @@ func RecordStreamOpenedPriority() { g.priorityStreamsOpened.Add(1) }
 func RecordStreamOpenedBulk()     { g.bulkStreamsOpened.Add(1) }
 func RecordPriorityFallback()     { g.priorityFallback.Add(1) }
 func RecordBulkFallback()         { g.bulkFallback.Add(1) }
+
+func RecordSlotDegraded()        { g.slotDegraded.Add(1) }
+func RecordSlotRetiredDegraded() { g.slotRetiredDegraded.Add(1) }
 
 const rttAlpha = 0.35
 
@@ -142,6 +149,8 @@ func ResetCounters() {
 	g.bulkStreamsOpened.Store(0)
 	g.priorityFallback.Store(0)
 	g.bulkFallback.Store(0)
+	g.slotDegraded.Store(0)
+	g.slotRetiredDegraded.Store(0)
 
 	g.rttMu.Lock()
 	g.rttEWMA = 0
@@ -190,6 +199,10 @@ type Snapshot struct {
 	BulkStreamsOpened     int64 `json:"bulk_streams_opened"`
 	PriorityFallback      int64 `json:"priority_fallback"`
 	BulkFallback          int64 `json:"bulk_fallback"`
+
+	// Transport health (client-side only; zero on server)
+	SlotDegraded        int64 `json:"slot_degraded,omitempty"`
+	SlotRetiredDegraded int64 `json:"slot_retired_degraded,omitempty"`
 
 	// Speed
 	UploadSpeed            int64  `json:"upload_speed"`
@@ -272,6 +285,8 @@ func Collect() Snapshot {
 		BulkStreamsOpened:      g.bulkStreamsOpened.Load(),
 		PriorityFallback:       g.priorityFallback.Load(),
 		BulkFallback:           g.bulkFallback.Load(),
+		SlotDegraded:           g.slotDegraded.Load(),
+		SlotRetiredDegraded:    g.slotRetiredDegraded.Load(),
 		UploadSpeed:            upSpeed,
 		DownloadSpeed:          downSpeed,
 		UploadSpeedHuman:       HumanBytes(upSpeed) + "/s",

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -46,6 +46,7 @@ type stats struct {
 	// Transport health (client-side)
 	slotDegraded        atomic.Int64
 	slotRetiredDegraded atomic.Int64
+	connRotated         atomic.Int64
 
 	rttMu    sync.Mutex
 	rttEWMA  int64 // nanoseconds, EWMA-smoothed RTT
@@ -96,6 +97,7 @@ func RecordBulkFallback()         { g.bulkFallback.Add(1) }
 
 func RecordSlotDegraded()        { g.slotDegraded.Add(1) }
 func RecordSlotRetiredDegraded() { g.slotRetiredDegraded.Add(1) }
+func RecordConnRotated()         { g.connRotated.Add(1) }
 
 const rttAlpha = 0.35
 
@@ -151,6 +153,7 @@ func ResetCounters() {
 	g.bulkFallback.Store(0)
 	g.slotDegraded.Store(0)
 	g.slotRetiredDegraded.Store(0)
+	g.connRotated.Store(0)
 
 	g.rttMu.Lock()
 	g.rttEWMA = 0
@@ -203,6 +206,7 @@ type Snapshot struct {
 	// Transport health (client-side only; zero on server)
 	SlotDegraded        int64 `json:"slot_degraded,omitempty"`
 	SlotRetiredDegraded int64 `json:"slot_retired_degraded,omitempty"`
+	ConnRotated         int64 `json:"conn_rotated,omitempty"`
 
 	// Speed
 	UploadSpeed            int64  `json:"upload_speed"`
@@ -287,6 +291,7 @@ func Collect() Snapshot {
 		BulkFallback:           g.bulkFallback.Load(),
 		SlotDegraded:           g.slotDegraded.Load(),
 		SlotRetiredDegraded:    g.slotRetiredDegraded.Load(),
+		ConnRotated:            g.connRotated.Load(),
 		UploadSpeed:            upSpeed,
 		DownloadSpeed:          downSpeed,
 		UploadSpeedHuman:       HumanBytes(upSpeed) + "/s",

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -204,9 +204,9 @@ type Snapshot struct {
 	BulkFallback          int64 `json:"bulk_fallback"`
 
 	// Transport health (client-side only; zero on server)
-	SlotDegraded        int64 `json:"slot_degraded,omitempty"`
-	SlotRetiredDegraded int64 `json:"slot_retired_degraded,omitempty"`
-	ConnRotated         int64 `json:"conn_rotated,omitempty"`
+	SlotDegraded        int64 `json:"slot_degraded"`
+	SlotRetiredDegraded int64 `json:"slot_retired_degraded"`
+	ConnRotated         int64 `json:"conn_rotated"`
 
 	// Speed
 	UploadSpeed            int64  `json:"upload_speed"`

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -16,6 +16,7 @@ import (
 	utls "github.com/refraction-networking/utls"
 
 	sharedconfig "github.com/nange/easyss/v3/config"
+	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/stats"
 	"github.com/nange/easyss/v3/transport"
 )
@@ -24,6 +25,18 @@ type transportSlot struct {
 	t      *http.Transport
 	active atomic.Int32
 	heavy  atomic.Int32 // number of active heavy streams (>= HeavyStreamThreshold bytes)
+	// bytesRecv is the cumulative downloaded bytes across streams on this
+	// slot; sampled by the health loop to estimate recent throughput.
+	bytesRecv atomic.Int64
+	// degraded marks a slot whose download throughput stays below the
+	// degraded threshold while hosting heavy streams; new streams avoid it
+	// and its idle connection is retired early.
+	degraded atomic.Bool
+
+	// Health-loop state, touched only from the health loop goroutine.
+	lastBytes     int64
+	lowCycles     int
+	recoverCycles int
 }
 
 type HTTP2Transport struct {
@@ -94,7 +107,7 @@ func New(cfg Config) (*HTTP2Transport, error) {
 		slots[i] = newSlot(cfg.TLSConfig, timeout, dialCtx)
 	}
 
-	return &HTTP2Transport{
+	tr := &HTTP2Transport{
 		slots:         slots,
 		maxSlots:      maxSlots,
 		threshold:     threshold,
@@ -103,7 +116,9 @@ func New(cfg Config) (*HTTP2Transport, error) {
 		serverURL:     cfg.ServerURL,
 		ctx:           ctx,
 		cancel:        cancel,
-	}, nil
+	}
+	go tr.healthLoop()
+	return tr, nil
 }
 
 func newSlot(utlsCfg *utls.Config, timeout time.Duration, dialContext func(context.Context, string, string) (net.Conn, error)) *transportSlot {
@@ -297,32 +312,41 @@ func (t *HTTP2Transport) leastActiveSlotRange(start, end int) *transportSlot {
 		start = 0
 		end = live
 	}
-	// Prefer slots without heavy streams: a heavy stream monopolizes the
-	// connection's TCP window, so a new stream sharing that slot would be
-	// dragged down together with it (TCP head-of-line blocking under packet
-	// loss). Only fall back to heavy slots when none are available.
+	// Prefer healthy slots, then slots without heavy streams, and only fall
+	// back to degraded ones when nothing else is available:
+	//   - a heavy stream monopolizes the connection's TCP window, so a new
+	//     stream sharing that slot is dragged down together with it (TCP
+	//     head-of-line blocking under packet loss);
+	//   - a degraded slot already proved persistently low throughput, so it
+	//     is avoided unless it is the only option left.
+	passes := []struct {
+		skipHeavy    bool
+		skipDegraded bool
+	}{
+		{true, true},  // healthy slots
+		{false, true}, // heavy but not degraded
+		{false, false},
+	}
 	var best *transportSlot
-	var min int32 = math.MaxInt32
-	for i := start; i < end; i++ {
-		if t.slots[i].heavy.Load() > 0 {
-			continue
+	for _, p := range passes {
+		var min int32 = math.MaxInt32
+		for i := start; i < end; i++ {
+			s := t.slots[i]
+			if p.skipHeavy && s.heavy.Load() > 0 {
+				continue
+			}
+			if p.skipDegraded && s.degraded.Load() {
+				continue
+			}
+			if a := s.active.Load(); a < min {
+				best, min = s, a
+			}
 		}
-		if a := t.slots[i].active.Load(); a < min {
-			best, min = t.slots[i], a
+		if best != nil {
+			return best
 		}
 	}
-	if best != nil {
-		return best
-	}
-	for i := start; i < end; i++ {
-		if a := t.slots[i].active.Load(); a < min {
-			best, min = t.slots[i], a
-		}
-	}
-	if best == nil {
-		return t.slots[0]
-	}
-	return best
+	return t.slots[0]
 }
 
 // maybeGrowSlots checks whether all live slots are at or above the threshold,
@@ -404,28 +428,121 @@ func (t *HTTP2Transport) CloseIdle() {
 	// Shrink liveCount by retiring idle slots (any position, swap-remove).
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for {
-		live := int(t.liveCount.Load())
-		if live == 0 {
-			break
+	for t.shrinkIdleLocked() {
+	}
+}
+
+// shrinkIdleLocked retires one idle slot (active==0) from liveCount,
+// swap-removing it to the end. Caller must hold t.mu. Returns false when
+// no idle slot remains.
+func (t *HTTP2Transport) shrinkIdleLocked() bool {
+	live := int(t.liveCount.Load())
+	for i := 0; i < live; i++ {
+		if t.slots[i].active.Load() != 0 {
+			continue
 		}
-		// Find first idle slot.
-		retired := -1
-		for i := 0; i < live; i++ {
-			if t.slots[i].active.Load() == 0 {
-				retired = i
-				break
-			}
-		}
-		if retired < 0 {
-			break // no idle slots left
-		}
-		// Swap-remove: move idle slot to the end, then shrink.
 		last := live - 1
-		if retired != last {
-			t.slots[retired], t.slots[last] = t.slots[last], t.slots[retired]
+		if i != last {
+			t.slots[i], t.slots[last] = t.slots[last], t.slots[i]
 		}
 		t.liveCount.Add(-1)
+		return true
+	}
+	return false
+}
+
+// healthLoop periodically samples slot download throughput and marks
+// persistently slow slots as degraded, retiring them once they go idle.
+// It runs until the transport is closed (t.ctx cancelled).
+func (t *HTTP2Transport) healthLoop() {
+	interval := sharedconfig.HealthCheckInterval
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			t.evaluateHealth(interval)
+		case <-t.ctx.Done():
+			return
+		}
+	}
+}
+
+func (t *HTTP2Transport) evaluateHealth(interval time.Duration) {
+	live := int(t.liveCount.Load())
+	for i := 0; i < live; i++ {
+		s := t.slots[i]
+		t.evaluateSlotHealth(i, s, interval)
+		if s.degraded.Load() && s.active.Load() == 0 {
+			t.retireSlot(s)
+			// retireSlot swap-removes the slot to the end and shrinks
+			// liveCount; re-evaluate the slot swapped into position i.
+			live--
+			i--
+		}
+	}
+}
+
+// evaluateSlotHealth updates one slot's degraded state from its recent
+// download throughput. Only slots hosting heavy streams are considered —
+// idle or short-lived slots naturally carry zero throughput. The mark is
+// set after DegradedPersistCycles consecutive slow intervals and cleared
+// after DegradedRecoverCycles healthy ones.
+func (t *HTTP2Transport) evaluateSlotHealth(idx int, s *transportSlot, interval time.Duration) {
+	if s.heavy.Load() == 0 {
+		return
+	}
+	now := s.bytesRecv.Load()
+	perSec := int64(interval / time.Second)
+	throughput := (now - s.lastBytes) / perSec
+	s.lastBytes = now
+
+	if throughput >= int64(sharedconfig.DegradedThroughputThreshold) {
+		s.lowCycles = 0
+		if s.degraded.Load() {
+			s.recoverCycles++
+			if s.recoverCycles >= sharedconfig.DegradedRecoverCycles {
+				s.degraded.Store(false)
+				s.recoverCycles = 0
+				log.Info("[TRANSPORT] slot recovered", "slot", idx, "throughput_kb_s", throughput/1024)
+			}
+		}
+		return
+	}
+
+	s.recoverCycles = 0
+	s.lowCycles++
+	if s.lowCycles >= sharedconfig.DegradedPersistCycles && !s.degraded.Load() {
+		s.degraded.Store(true)
+		s.lowCycles = 0
+		stats.RecordSlotDegraded()
+		log.Info("[TRANSPORT] slot degraded", "slot", idx, "throughput_kb_s", throughput/1024)
+	}
+}
+
+// retireSlot closes a degraded slot's idle connection and shrinks liveCount
+// once the slot no longer hosts any stream. Streams are re-checked under
+// the lock so a concurrent Open cannot be stranded.
+func (t *HTTP2Transport) retireSlot(s *transportSlot) {
+	s.t.CloseIdleConnections()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if s.active.Load() != 0 {
+		return
+	}
+	live := int(t.liveCount.Load())
+	for i := 0; i < live; i++ {
+		if t.slots[i] != s {
+			continue
+		}
+		last := live - 1
+		if i != last {
+			t.slots[i], t.slots[last] = t.slots[last], t.slots[i]
+		}
+		t.liveCount.Add(-1)
+		stats.RecordSlotRetiredDegraded()
+		log.Info("[TRANSPORT] slot retired (degraded)", "slot", i)
+		return
 	}
 }
 

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"runtime"
@@ -34,7 +35,7 @@ type transportSlot struct {
 	degraded atomic.Bool
 
 	// Connection rotation state.
-	connStart     atomic.Int64 // unix nano of the last successful dial on this slot
+	expireAt      atomic.Int64 // unix nano deadline of the current connection (dial time + lifetime + jitter)
 	connBytesRecv atomic.Int64 // bytes downloaded over the current connection
 	// expiring marks a slot whose connection exceeded the lifetime or bytes
 	// limit; new streams avoid it and its idle connection is closed so the
@@ -129,7 +130,7 @@ func New(cfg Config) (*HTTP2Transport, error) {
 	// actual TCP connections are established lazily by Go's http.Transport.
 	slots := make([]*transportSlot, maxSlots)
 	for i := range slots {
-		slots[i] = newSlot(cfg.TLSConfig, timeout, dialCtx)
+		slots[i] = newSlot(cfg.TLSConfig, timeout, dialCtx, connLifetime)
 	}
 
 	tr := &HTTP2Transport{
@@ -148,7 +149,7 @@ func New(cfg Config) (*HTTP2Transport, error) {
 	return tr, nil
 }
 
-func newSlot(utlsCfg *utls.Config, timeout time.Duration, dialContext func(context.Context, string, string) (net.Conn, error)) *transportSlot {
+func newSlot(utlsCfg *utls.Config, timeout time.Duration, dialContext func(context.Context, string, string) (net.Conn, error), connLifetime time.Duration) *transportSlot {
 	if dialContext == nil {
 		dialContext = defaultDialContext
 	}
@@ -202,9 +203,10 @@ func newSlot(utlsCfg *utls.Config, timeout time.Duration, dialContext func(conte
 				_ = uconn.Close()
 				return nil, fmt.Errorf("server negotiated %q, want h2", proto)
 			}
-			// A new connection resets the rotation state: lifetime, bytes
-			// carried and the expiring mark all start fresh.
-			slot.connStart.Store(time.Now().UnixNano())
+			// A new connection resets the rotation state: the lifetime
+			// deadline (with per-connection jitter), bytes carried and the
+			// expiring mark all start fresh.
+			slot.expireAt.Store(time.Now().Add(rotationLifetime(connLifetime)).UnixNano())
 			slot.connBytesRecv.Store(0)
 			slot.expiring.Store(false)
 			return uconn, nil
@@ -634,7 +636,7 @@ func (t *HTTP2Transport) evaluateRotation(idx int, s *transportSlot) {
 // or bytes limit and should stop accepting new streams.
 func (t *HTTP2Transport) rotationDue(s *transportSlot, now time.Time) bool {
 	if t.connLifetime > 0 {
-		if start := s.connStart.Load(); start > 0 && now.Sub(time.Unix(0, start)) >= t.connLifetime {
+		if expireAt := s.expireAt.Load(); expireAt > 0 && now.UnixNano() >= expireAt {
 			return true
 		}
 	}
@@ -642,6 +644,19 @@ func (t *HTTP2Transport) rotationDue(s *transportSlot, now time.Time) bool {
 		return true
 	}
 	return false
+}
+
+// rotationLifetime returns the connection lifetime with a per-connection
+// random jitter of up to 20%. Connections created in the same burst (e.g.
+// several slots dialing together) then expire in different health ticks,
+// so rotations and the subsequent TLS handshakes do not cluster into a
+// single fingerprintable burst.
+func rotationLifetime(base time.Duration) time.Duration {
+	span := int64(base) / 5
+	if span <= 0 {
+		return base
+	}
+	return base + time.Duration(rand.Int64N(span+1))
 }
 
 // retireSlot closes a degraded slot's idle connection and shrinks liveCount

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -23,6 +23,7 @@ import (
 type transportSlot struct {
 	t      *http.Transport
 	active atomic.Int32
+	heavy  atomic.Int32 // number of active heavy streams (>= HeavyStreamThreshold bytes)
 }
 
 type HTTP2Transport struct {
@@ -220,17 +221,25 @@ func (t *HTTP2Transport) Open(ctx context.Context, req transport.OpenRequest) (t
 
 	respCh := make(chan roundTripResult, 1)
 
+	var stream *HTTP2Stream
 	doneOnce := sync.OnceFunc(func() {
+		// Release the slot's heavy mark exactly once (doneOnce runs at most
+		// a single time), so the slot becomes eligible for new streams again.
+		if stream.heavyFlag.Swap(false) {
+			slot.heavy.Add(-1)
+		}
 		slot.active.Add(-1)
 		stats.RecordStreamClosed()
 		cancel()
 	})
 
-	stream := &HTTP2Stream{
-		w:      pw,
-		respCh: respCh,
-		cancel: cancel,
-		done:   doneOnce,
+	stream = &HTTP2Stream{
+		w:         pw,
+		respCh:    respCh,
+		cancel:    cancel,
+		done:      doneOnce,
+		slot:      slot,
+		startTime: time.Now(),
 	}
 
 	go func() {
@@ -288,8 +297,23 @@ func (t *HTTP2Transport) leastActiveSlotRange(start, end int) *transportSlot {
 		start = 0
 		end = live
 	}
+	// Prefer slots without heavy streams: a heavy stream monopolizes the
+	// connection's TCP window, so a new stream sharing that slot would be
+	// dragged down together with it (TCP head-of-line blocking under packet
+	// loss). Only fall back to heavy slots when none are available.
 	var best *transportSlot
 	var min int32 = math.MaxInt32
+	for i := start; i < end; i++ {
+		if t.slots[i].heavy.Load() > 0 {
+			continue
+		}
+		if a := t.slots[i].active.Load(); a < min {
+			best, min = t.slots[i], a
+		}
+	}
+	if best != nil {
+		return best
+	}
 	for i := start; i < end; i++ {
 		if a := t.slots[i].active.Load(); a < min {
 			best, min = t.slots[i], a

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -33,8 +33,18 @@ type transportSlot struct {
 	// and its idle connection is retired early.
 	degraded atomic.Bool
 
+	// Connection rotation state.
+	connStart     atomic.Int64 // unix nano of the last successful dial on this slot
+	connBytesRecv atomic.Int64 // bytes downloaded over the current connection
+	// expiring marks a slot whose connection exceeded the lifetime or bytes
+	// limit; new streams avoid it and its idle connection is closed so the
+	// next stream dials a fresh one. Cleared when a new connection is
+	// established or the rotation completes.
+	expiring atomic.Bool
+
 	// Health-loop state, touched only from the health loop goroutine.
 	lastBytes     int64
+	lastHeavy     int // last observed heavy count, tracks heavy 0->1 transitions
 	lowCycles     int
 	recoverCycles int
 }
@@ -48,6 +58,10 @@ type HTTP2Transport struct {
 	bulkThreshold int32
 	mu            sync.RWMutex // protects slot retire (shrink) and grow; RLock protects stream assignment
 
+	// Connection rotation limits.
+	connLifetime time.Duration // max age of a connection before rotation
+	connMaxBytes int64         // max bytes per connection before rotation
+
 	serverURL string
 
 	ctx    context.Context
@@ -60,6 +74,8 @@ type Config struct {
 	MaxSlotCount      int
 	StreamThreshold   int
 	PrioritySlotRatio float64
+	ConnLifetime      time.Duration // max age of a connection before rotation (0: default)
+	ConnMaxBytes      int64         // max bytes per connection before rotation (0: default)
 	Timeout           time.Duration
 	DialContext       func(ctx context.Context, network, addr string) (net.Conn, error)
 }
@@ -98,6 +114,15 @@ func New(cfg Config) (*HTTP2Transport, error) {
 		dialCtx = defaultDialContext
 	}
 
+	connLifetime := cfg.ConnLifetime
+	if connLifetime <= 0 {
+		connLifetime = time.Duration(sharedconfig.DefaultConnLifetimeSec) * time.Second
+	}
+	connMaxBytes := cfg.ConnMaxBytes
+	if connMaxBytes <= 0 {
+		connMaxBytes = sharedconfig.DefaultConnMaxBytes
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Pre-allocate and initialize all slots. Transports are cheap structs;
@@ -113,6 +138,8 @@ func New(cfg Config) (*HTTP2Transport, error) {
 		threshold:     threshold,
 		prioritySlots: prioritySlots,
 		bulkThreshold: bulkThreshold,
+		connLifetime:  connLifetime,
+		connMaxBytes:  connMaxBytes,
 		serverURL:     cfg.ServerURL,
 		ctx:           ctx,
 		cancel:        cancel,
@@ -125,6 +152,8 @@ func newSlot(utlsCfg *utls.Config, timeout time.Duration, dialContext func(conte
 	if dialContext == nil {
 		dialContext = defaultDialContext
 	}
+
+	slot := &transportSlot{}
 
 	protos := &http.Protocols{}
 	protos.SetHTTP2(true)
@@ -173,10 +202,16 @@ func newSlot(utlsCfg *utls.Config, timeout time.Duration, dialContext func(conte
 				_ = uconn.Close()
 				return nil, fmt.Errorf("server negotiated %q, want h2", proto)
 			}
+			// A new connection resets the rotation state: lifetime, bytes
+			// carried and the expiring mark all start fresh.
+			slot.connStart.Store(time.Now().UnixNano())
+			slot.connBytesRecv.Store(0)
+			slot.expiring.Store(false)
 			return uconn, nil
 		},
 	}
-	return &transportSlot{t: tr}
+	slot.t = tr
+	return slot
 }
 
 func defaultDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -240,9 +275,7 @@ func (t *HTTP2Transport) Open(ctx context.Context, req transport.OpenRequest) (t
 	doneOnce := sync.OnceFunc(func() {
 		// Release the slot's heavy mark exactly once (doneOnce runs at most
 		// a single time), so the slot becomes eligible for new streams again.
-		if stream.heavyFlag.Swap(false) {
-			slot.heavy.Add(-1)
-		}
+		stream.releaseHeavy()
 		slot.active.Add(-1)
 		stats.RecordStreamClosed()
 		cancel()
@@ -313,19 +346,23 @@ func (t *HTTP2Transport) leastActiveSlotRange(start, end int) *transportSlot {
 		end = live
 	}
 	// Prefer healthy slots, then slots without heavy streams, and only fall
-	// back to degraded ones when nothing else is available:
+	// back to degraded or expiring ones when nothing else is available:
 	//   - a heavy stream monopolizes the connection's TCP window, so a new
 	//     stream sharing that slot is dragged down together with it (TCP
 	//     head-of-line blocking under packet loss);
 	//   - a degraded slot already proved persistently low throughput, so it
-	//     is avoided unless it is the only option left.
+	//     is avoided unless it is the only option left;
+	//   - an expiring slot is due for connection rotation, so new streams
+	//     avoid it unless nothing else is available.
 	passes := []struct {
 		skipHeavy    bool
 		skipDegraded bool
+		skipExpiring bool
 	}{
-		{true, true},  // healthy slots
-		{false, true}, // heavy but not degraded
-		{false, false},
+		{true, true, true},   // healthy slots
+		{false, true, true},  // heavy but not degraded/expiring
+		{false, false, true}, // degraded but not expiring
+		{false, false, false},
 	}
 	var best *transportSlot
 	for _, p := range passes {
@@ -336,6 +373,9 @@ func (t *HTTP2Transport) leastActiveSlotRange(start, end int) *transportSlot {
 				continue
 			}
 			if p.skipDegraded && s.degraded.Load() {
+				continue
+			}
+			if p.skipExpiring && s.expiring.Load() {
 				continue
 			}
 			if a := s.active.Load(); a < min {
@@ -349,8 +389,9 @@ func (t *HTTP2Transport) leastActiveSlotRange(start, end int) *transportSlot {
 	return t.slots[0]
 }
 
-// maybeGrowSlots checks whether all live slots are at or above the threshold,
-// and if so, activates one more slot (up to maxSlots). Uses double-checked locking.
+// maybeGrowSlots checks whether the live slots that a new stream would
+// actually use are all at or above the threshold, and if so, activates one
+// more slot (up to maxSlots). Uses double-checked locking.
 func (t *HTTP2Transport) maybeGrowSlots(highPriority bool) {
 	live := t.liveCount.Load()
 	if int(live) >= t.maxSlots {
@@ -373,14 +414,13 @@ func (t *HTTP2Transport) maybeGrowSlots(highPriority bool) {
 		if start >= end {
 			return
 		}
-		for i := start; i < end; i++ {
-			if t.slots[i].active.Load() < thresh {
-				return
-			}
+		if !t.shouldGrow(start, end, thresh) {
+			return
 		}
 	}
 
-	// All slots in range are at or above threshold — try to grow under lock.
+	// All eligible slots in range are at or above threshold — try to grow
+	// under lock.
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -402,10 +442,8 @@ func (t *HTTP2Transport) maybeGrowSlots(highPriority bool) {
 		if start2 >= end2 {
 			return
 		}
-		for i := start2; i < end2; i++ {
-			if t.slots[i].active.Load() < thresh {
-				return
-			}
+		if !t.shouldGrow(start2, end2, thresh) {
+			return
 		}
 	}
 
@@ -417,6 +455,26 @@ func (t *HTTP2Transport) maybeGrowSlots(highPriority bool) {
 	} else {
 		t.liveCount.Add(1)
 	}
+}
+
+// shouldGrow reports whether the range [start,end) needs one more live
+// slot: every slot a new stream would actually use is at or above the
+// threshold. Heavy, degraded and expiring slots are skipped — a new stream
+// avoids them, so a heavy slot hosting a single download must not block
+// growing more connections. A range with no eligible slot at all also
+// grows, since new streams then fall back onto heavy/degraded slots and
+// deserve a fresh connection.
+func (t *HTTP2Transport) shouldGrow(start, end, thresh int32) bool {
+	for i := start; i < end; i++ {
+		s := t.slots[i]
+		if s.heavy.Load() > 0 || s.degraded.Load() || s.expiring.Load() {
+			continue
+		}
+		if s.active.Load() < thresh {
+			return false
+		}
+	}
+	return true
 }
 
 func (t *HTTP2Transport) CloseIdle() {
@@ -451,9 +509,10 @@ func (t *HTTP2Transport) shrinkIdleLocked() bool {
 	return false
 }
 
-// healthLoop periodically samples slot download throughput and marks
-// persistently slow slots as degraded, retiring them once they go idle.
-// It runs until the transport is closed (t.ctx cancelled).
+// healthLoop periodically samples slot health: download throughput feeds
+// the degraded detector, connection age/bytes feed rotation, and idle
+// degraded slots are retired. It runs until the transport is closed
+// (t.ctx cancelled).
 func (t *HTTP2Transport) healthLoop() {
 	interval := sharedconfig.HealthCheckInterval
 	ticker := time.NewTicker(interval)
@@ -469,11 +528,19 @@ func (t *HTTP2Transport) healthLoop() {
 }
 
 func (t *HTTP2Transport) evaluateHealth(interval time.Duration) {
+	// A congested link (high RTT) makes every connection slow: marking or
+	// retiring slots then only adds handshake churn without recovering
+	// anything, so degraded detection is gated on a healthy RTT. Rotation,
+	// on the other hand, is exactly what a throttled connection needs and
+	// runs regardless of RTT.
+	linkOK := stats.Collect().AvgRTT() <= sharedconfig.DegradedMaxRTT
+
 	live := int(t.liveCount.Load())
 	for i := 0; i < live; i++ {
 		s := t.slots[i]
-		t.evaluateSlotHealth(i, s, interval)
-		if s.degraded.Load() && s.active.Load() == 0 {
+		t.evaluateSlotHealth(i, s, interval, linkOK)
+		t.evaluateRotation(i, s)
+		if linkOK && s.degraded.Load() && s.active.Load() == 0 {
 			t.retireSlot(s)
 			// retireSlot swap-removes the slot to the end and shrinks
 			// liveCount; re-evaluate the slot swapped into position i.
@@ -488,12 +555,35 @@ func (t *HTTP2Transport) evaluateHealth(interval time.Duration) {
 // idle or short-lived slots naturally carry zero throughput. The mark is
 // set after DegradedPersistCycles consecutive slow intervals and cleared
 // after DegradedRecoverCycles healthy ones.
-func (t *HTTP2Transport) evaluateSlotHealth(idx int, s *transportSlot, interval time.Duration) {
+func (t *HTTP2Transport) evaluateSlotHealth(idx int, s *transportSlot, interval time.Duration, linkOK bool) {
 	if s.heavy.Load() == 0 {
+		s.lastHeavy = 0
 		return
 	}
+	if s.lastHeavy == 0 {
+		// First heavy stream on this slot since it went idle: bytes
+		// transferred by earlier small streams must not skew the first
+		// sample, so reset the baseline and skip this interval.
+		s.lastHeavy = 1
+		s.lastBytes = s.bytesRecv.Load()
+		s.lowCycles = 0
+		s.recoverCycles = 0
+		return
+	}
+	if !linkOK {
+		// Congested link: low throughput is a link property, not evidence
+		// that this particular connection is broken. Advance the baseline
+		// so the first healthy interval starts from a clean sample, and
+		// freeze the counters.
+		s.lastBytes = s.bytesRecv.Load()
+		return
+	}
+
 	now := s.bytesRecv.Load()
 	perSec := int64(interval / time.Second)
+	if perSec <= 0 {
+		perSec = 1
+	}
 	throughput := (now - s.lastBytes) / perSec
 	s.lastBytes = now
 
@@ -518,6 +608,40 @@ func (t *HTTP2Transport) evaluateSlotHealth(idx int, s *transportSlot, interval 
 		stats.RecordSlotDegraded()
 		log.Info("[TRANSPORT] slot degraded", "slot", idx, "throughput_kb_s", throughput/1024)
 	}
+}
+
+// evaluateRotation marks a slot expiring once its connection exceeded the
+// lifetime or bytes limit, and completes the rotation once the slot goes
+// idle: the tired connection is closed so the next stream dials a fresh
+// one. In-flight streams are never interrupted.
+func (t *HTTP2Transport) evaluateRotation(idx int, s *transportSlot) {
+	if s.expiring.Load() {
+		if s.active.Load() == 0 {
+			s.t.CloseIdleConnections()
+			s.expiring.Store(false)
+			stats.RecordConnRotated()
+			log.Info("[TRANSPORT] connection rotated", "slot", idx)
+		}
+		return
+	}
+	if t.rotationDue(s, time.Now()) {
+		s.expiring.Store(true)
+		log.Info("[TRANSPORT] slot connection expiring", "slot", idx)
+	}
+}
+
+// rotationDue reports whether the slot's connection exceeded the lifetime
+// or bytes limit and should stop accepting new streams.
+func (t *HTTP2Transport) rotationDue(s *transportSlot, now time.Time) bool {
+	if t.connLifetime > 0 {
+		if start := s.connStart.Load(); start > 0 && now.Sub(time.Unix(0, start)) >= t.connLifetime {
+			return true
+		}
+	}
+	if t.connMaxBytes > 0 && s.connBytesRecv.Load() >= t.connMaxBytes {
+		return true
+	}
+	return false
 }
 
 // retireSlot closes a degraded slot's idle connection and shrinks liveCount

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -29,7 +29,7 @@ func TestUTLSDialUsesHTTP2(t *testing.T) {
 	slot := newSlot(&utls.Config{
 		InsecureSkipVerify: true,
 		NextProtos:         sharedconfig.NextProtos,
-	}, time.Second, nil)
+	}, time.Second, nil, time.Minute)
 	t.Cleanup(slot.t.CloseIdleConnections)
 
 	req, err := http.NewRequest(http.MethodPost, srv.URL, nil)
@@ -528,7 +528,7 @@ func TestRotationDue(t *testing.T) {
 	t.Run("lifetime exceeded", func(t *testing.T) {
 		tr := &HTTP2Transport{connLifetime: time.Minute}
 		s := &transportSlot{}
-		s.connStart.Store(now.Add(-2 * time.Minute).UnixNano())
+		s.expireAt.Store(now.Add(-2 * time.Minute).UnixNano())
 		if !tr.rotationDue(s, now) {
 			t.Fatal("expected rotation due by age")
 		}
@@ -537,7 +537,7 @@ func TestRotationDue(t *testing.T) {
 	t.Run("bytes exceeded", func(t *testing.T) {
 		tr := &HTTP2Transport{connLifetime: time.Hour, connMaxBytes: 1024}
 		s := &transportSlot{}
-		s.connStart.Store(now.Add(-time.Second).UnixNano())
+		s.expireAt.Store(now.Add(time.Hour).UnixNano())
 		s.connBytesRecv.Store(2048)
 		if !tr.rotationDue(s, now) {
 			t.Fatal("expected rotation due by bytes")
@@ -547,7 +547,7 @@ func TestRotationDue(t *testing.T) {
 	t.Run("fresh connection not due", func(t *testing.T) {
 		tr := &HTTP2Transport{connLifetime: time.Minute, connMaxBytes: 1024}
 		s := &transportSlot{}
-		s.connStart.Store(now.Add(-time.Second).UnixNano())
+		s.expireAt.Store(now.Add(time.Minute).UnixNano())
 		s.connBytesRecv.Store(512)
 		if tr.rotationDue(s, now) {
 			t.Fatal("fresh connection must not rotate")
@@ -563,11 +563,22 @@ func TestRotationDue(t *testing.T) {
 	})
 }
 
+func TestRotationLifetimeJitter(t *testing.T) {
+	const base = 15 * time.Minute
+	max := base + base/5
+	for i := 0; i < 1000; i++ {
+		got := rotationLifetime(base)
+		if got < base || got > max {
+			t.Fatalf("rotationLifetime(%v) = %v, want within [%v, %v]", base, got, base, max)
+		}
+	}
+}
+
 func TestEvaluateRotation(t *testing.T) {
 	t.Run("marks expiring and completes rotation when idle", func(t *testing.T) {
 		tr := &HTTP2Transport{connLifetime: time.Minute}
 		s := &transportSlot{t: &http.Transport{}}
-		s.connStart.Store(time.Now().Add(-2 * time.Minute).UnixNano())
+		s.expireAt.Store(time.Now().Add(-2 * time.Minute).UnixNano())
 		s.active.Store(1)
 		// First pass: still busy, only mark expiring.
 		tr.evaluateRotation(0, s)
@@ -585,7 +596,7 @@ func TestEvaluateRotation(t *testing.T) {
 	t.Run("fresh connection not expiring", func(t *testing.T) {
 		tr := &HTTP2Transport{connLifetime: time.Hour}
 		s := &transportSlot{t: &http.Transport{}}
-		s.connStart.Store(time.Now().UnixNano())
+		s.expireAt.Store(time.Now().Add(time.Hour).UnixNano())
 		tr.evaluateRotation(0, s)
 		if s.expiring.Load() {
 			t.Fatal("fresh connection must not expire")

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -198,17 +198,20 @@ func TestTrackReadMarksSlotHeavy(t *testing.T) {
 
 		// Below the fast threshold and too young for the slow path: no mark.
 		stream.trackRead(sharedconfig.HeavyStreamThresholdBytes - 1)
-		if slot.heavy.Load() != 0 || stream.heavyFlag.Load() {
-			t.Fatalf("marked heavy before threshold: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
+		if slot.heavy.Load() != 0 || stream.heavyState.Load() != heavyIdle {
+			t.Fatalf("marked heavy before threshold: slot.heavy=%d state=%d", slot.heavy.Load(), stream.heavyState.Load())
 		}
 
 		// Crossing the fast threshold: mark exactly once.
 		stream.trackRead(2)
-		if slot.heavy.Load() != 1 || !stream.heavyFlag.Load() {
-			t.Fatalf("expected heavy mark after threshold: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
+		if slot.heavy.Load() != 1 || stream.heavyState.Load() != heavyMarked {
+			t.Fatalf("expected heavy mark after threshold: slot.heavy=%d state=%d", slot.heavy.Load(), stream.heavyState.Load())
 		}
 		if slot.bytesRecv.Load() != int64(sharedconfig.HeavyStreamThresholdBytes+1) {
 			t.Fatalf("bytesRecv not accumulated: %d", slot.bytesRecv.Load())
+		}
+		if slot.connBytesRecv.Load() != slot.bytesRecv.Load() {
+			t.Fatalf("connBytesRecv = %d, want %d", slot.connBytesRecv.Load(), slot.bytesRecv.Load())
 		}
 
 		// Further transfers must not double-mark.
@@ -218,11 +221,12 @@ func TestTrackReadMarksSlotHeavy(t *testing.T) {
 		}
 
 		// Release on stream end: mirrors the doneOnce logic in Open.
-		if stream.heavyFlag.Swap(false) {
-			slot.heavy.Add(-1)
-		}
+		stream.releaseHeavy()
 		if slot.heavy.Load() != 0 {
 			t.Fatalf("heavy mark not released: %d", slot.heavy.Load())
+		}
+		if stream.heavyState.Load() != heavyReleased {
+			t.Fatalf("state = %d, want released", stream.heavyState.Load())
 		}
 	})
 
@@ -243,8 +247,8 @@ func TestTrackReadMarksSlotHeavy(t *testing.T) {
 
 		// At or above the slow threshold with sufficient age: mark once.
 		stream.trackRead(1024)
-		if slot.heavy.Load() != 1 || !stream.heavyFlag.Load() {
-			t.Fatalf("expected heavy mark on slow path: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
+		if slot.heavy.Load() != 1 || stream.heavyState.Load() != heavyMarked {
+			t.Fatalf("expected heavy mark on slow path: slot.heavy=%d state=%d", slot.heavy.Load(), stream.heavyState.Load())
 		}
 	})
 
@@ -263,8 +267,28 @@ func TestTrackReadMarksSlotHeavy(t *testing.T) {
 	t.Run("nil slot no-op", func(t *testing.T) {
 		noSlot := &HTTP2Stream{}
 		noSlot.trackRead(sharedconfig.HeavyStreamThresholdBytes)
-		if noSlot.heavyFlag.Load() {
+		if noSlot.heavyState.Load() != heavyIdle {
 			t.Fatal("nil slot must not be marked heavy")
+		}
+	})
+
+	// Releasing before the stream ever qualified as heavy must never
+	// increment the slot counter, and a later transfer must not leak it.
+	t.Run("release before marking never increments", func(t *testing.T) {
+		slot := &transportSlot{}
+		stream := &HTTP2Stream{slot: slot, startTime: time.Now()}
+		stream.releaseHeavy()
+		stream.trackRead(sharedconfig.HeavyStreamThresholdBytes)
+		if slot.heavy.Load() != 0 {
+			t.Fatalf("heavy marked after release: %d", slot.heavy.Load())
+		}
+		if stream.heavyState.Load() != heavyReleased {
+			t.Fatalf("state = %d, want released", stream.heavyState.Load())
+		}
+		// A double release must not decrement below zero.
+		stream.releaseHeavy()
+		if slot.heavy.Load() != 0 {
+			t.Fatalf("double release changed counter: %d", slot.heavy.Load())
 		}
 	})
 }
@@ -282,15 +306,18 @@ func TestEvaluateSlotHealth(t *testing.T) {
 	// (2KB/s, well below the 64KB/s degraded threshold).
 	lowThroughput := func(s *transportSlot) {
 		s.bytesRecv.Add(10 * 1024)
-		tr.evaluateSlotHealth(0, s, interval)
+		tr.evaluateSlotHealth(0, s, interval, true)
 	}
 	highThroughput := func(s *transportSlot) {
 		s.bytesRecv.Add(2 * 1024 * 1024) // 2MB over 5s = 400KB/s
-		tr.evaluateSlotHealth(0, s, interval)
+		tr.evaluateSlotHealth(0, s, interval, true)
 	}
 
 	t.Run("marks degraded after consecutive slow intervals", func(t *testing.T) {
 		s := newHeavySlot()
+		// The first interval after heavy 0->1 only resets the throughput
+		// baseline and is skipped.
+		lowThroughput(s)
 		for i := 0; i < sharedconfig.DegradedPersistCycles-1; i++ {
 			lowThroughput(s)
 			if s.degraded.Load() {
@@ -305,6 +332,7 @@ func TestEvaluateSlotHealth(t *testing.T) {
 
 	t.Run("healthy interval resets the slow counter", func(t *testing.T) {
 		s := newHeavySlot()
+		lowThroughput(s) // baseline reset
 		lowThroughput(s)
 		lowThroughput(s)
 		highThroughput(s)
@@ -317,6 +345,7 @@ func TestEvaluateSlotHealth(t *testing.T) {
 
 	t.Run("clears degraded after consecutive healthy intervals", func(t *testing.T) {
 		s := newHeavySlot()
+		lowThroughput(s) // baseline reset
 		for i := 0; i < sharedconfig.DegradedPersistCycles; i++ {
 			lowThroughput(s)
 		}
@@ -340,6 +369,35 @@ func TestEvaluateSlotHealth(t *testing.T) {
 		}
 		if s.degraded.Load() {
 			t.Fatal("non-heavy slot must not degrade")
+		}
+	})
+
+	t.Run("congested link never degrades", func(t *testing.T) {
+		s := newHeavySlot()
+		// Baseline reset happens before the congestion gate.
+		tr.evaluateSlotHealth(0, s, interval, false)
+		for i := 0; i < sharedconfig.DegradedPersistCycles+2; i++ {
+			s.bytesRecv.Add(10 * 1024)
+			tr.evaluateSlotHealth(0, s, interval, false)
+		}
+		if s.degraded.Load() {
+			t.Fatal("degraded while link congested")
+		}
+	})
+
+	t.Run("heavy 0->1 transition resets throughput baseline", func(t *testing.T) {
+		s := newHeavySlot()
+		s.bytesRecv.Add(50 * 1024) // stale bytes from earlier small streams
+		// First sample only resets the baseline.
+		tr.evaluateSlotHealth(0, s, interval, true)
+		if s.lowCycles != 0 {
+			t.Fatalf("lowCycles = %d after baseline reset, want 0", s.lowCycles)
+		}
+		// A slow interval afterwards counts from the reset point.
+		s.bytesRecv.Add(10 * 1024)
+		tr.evaluateSlotHealth(0, s, interval, true)
+		if s.lowCycles != 1 {
+			t.Fatalf("lowCycles = %d, want 1", s.lowCycles)
 		}
 	})
 }
@@ -395,6 +453,142 @@ func TestLeastActiveSlotRangePrefersHealthyOverDegraded(t *testing.T) {
 		tr.slots[1].degraded.Store(true)
 		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[1] {
 			t.Fatalf("expected least-active degraded slot 1, got active=%d", got.active.Load())
+		}
+	})
+}
+
+func TestLeastActiveSlotRangePrefersNonExpiring(t *testing.T) {
+	t.Run("skips expiring slot when fresh exists", func(t *testing.T) {
+		tr := newTestSlots([2]int32{2, 0}, [2]int32{1, 0})
+		tr.slots[1].expiring.Store(true)
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[0] {
+			t.Fatalf("expected non-expiring slot 0, got active=%d expiring=%v", got.active.Load(), got.expiring.Load())
+		}
+	})
+
+	t.Run("prefers degraded-but-fresh over expiring", func(t *testing.T) {
+		tr := newTestSlots([2]int32{3, 1}, [2]int32{1, 1})
+		tr.slots[0].degraded.Store(true)
+		tr.slots[1].expiring.Store(true)
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[0] {
+			t.Fatalf("expected degraded slot 0 over expiring, got active=%d", got.active.Load())
+		}
+	})
+
+	t.Run("falls back to expiring when nothing else", func(t *testing.T) {
+		tr := newTestSlots([2]int32{5, 1}, [2]int32{3, 1})
+		tr.slots[0].expiring.Store(true)
+		tr.slots[1].expiring.Store(true)
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[1] {
+			t.Fatalf("expected least-active expiring slot 1, got active=%d", got.active.Load())
+		}
+	})
+}
+
+func TestShouldGrow(t *testing.T) {
+	t.Run("heavy slot with single stream does not block growth", func(t *testing.T) {
+		tr := newTestSlots([2]int32{1, 1}, [2]int32{8, 0})
+		// slot0 is heavy with 1 stream (below threshold), slot1 eligible at
+		// threshold: growth must be allowed since new streams avoid slot0.
+		if !tr.shouldGrow(0, 2, 4) {
+			t.Fatal("expected growth with heavy slot below threshold")
+		}
+	})
+
+	t.Run("eligible slot below threshold blocks growth", func(t *testing.T) {
+		tr := newTestSlots([2]int32{3, 0}, [2]int32{8, 0})
+		if tr.shouldGrow(0, 2, 4) {
+			t.Fatal("expected no growth while an eligible slot has capacity")
+		}
+	})
+
+	t.Run("all slots heavy still grows", func(t *testing.T) {
+		tr := newTestSlots([2]int32{1, 1}, [2]int32{1, 1})
+		if !tr.shouldGrow(0, 2, 4) {
+			t.Fatal("expected growth when no eligible slot exists")
+		}
+	})
+
+	t.Run("degraded and expiring slots do not block growth", func(t *testing.T) {
+		tr := newTestSlots([2]int32{1, 0}, [2]int32{8, 0})
+		tr.slots[0].degraded.Store(true)
+		if !tr.shouldGrow(0, 2, 4) {
+			t.Fatal("expected growth with degraded slot below threshold")
+		}
+		tr2 := newTestSlots([2]int32{1, 0}, [2]int32{8, 0})
+		tr2.slots[0].expiring.Store(true)
+		if !tr2.shouldGrow(0, 2, 4) {
+			t.Fatal("expected growth with expiring slot below threshold")
+		}
+	})
+}
+
+func TestRotationDue(t *testing.T) {
+	now := time.Now()
+	t.Run("lifetime exceeded", func(t *testing.T) {
+		tr := &HTTP2Transport{connLifetime: time.Minute}
+		s := &transportSlot{}
+		s.connStart.Store(now.Add(-2 * time.Minute).UnixNano())
+		if !tr.rotationDue(s, now) {
+			t.Fatal("expected rotation due by age")
+		}
+	})
+
+	t.Run("bytes exceeded", func(t *testing.T) {
+		tr := &HTTP2Transport{connLifetime: time.Hour, connMaxBytes: 1024}
+		s := &transportSlot{}
+		s.connStart.Store(now.Add(-time.Second).UnixNano())
+		s.connBytesRecv.Store(2048)
+		if !tr.rotationDue(s, now) {
+			t.Fatal("expected rotation due by bytes")
+		}
+	})
+
+	t.Run("fresh connection not due", func(t *testing.T) {
+		tr := &HTTP2Transport{connLifetime: time.Minute, connMaxBytes: 1024}
+		s := &transportSlot{}
+		s.connStart.Store(now.Add(-time.Second).UnixNano())
+		s.connBytesRecv.Store(512)
+		if tr.rotationDue(s, now) {
+			t.Fatal("fresh connection must not rotate")
+		}
+	})
+
+	t.Run("never dialed slot not due by age", func(t *testing.T) {
+		tr := &HTTP2Transport{connLifetime: time.Minute}
+		s := &transportSlot{}
+		if tr.rotationDue(s, now) {
+			t.Fatal("undialed slot must not rotate")
+		}
+	})
+}
+
+func TestEvaluateRotation(t *testing.T) {
+	t.Run("marks expiring and completes rotation when idle", func(t *testing.T) {
+		tr := &HTTP2Transport{connLifetime: time.Minute}
+		s := &transportSlot{t: &http.Transport{}}
+		s.connStart.Store(time.Now().Add(-2 * time.Minute).UnixNano())
+		s.active.Store(1)
+		// First pass: still busy, only mark expiring.
+		tr.evaluateRotation(0, s)
+		if !s.expiring.Load() {
+			t.Fatal("expected expiring mark")
+		}
+		// Second pass: idle now, rotation completes and clears the mark.
+		s.active.Store(0)
+		tr.evaluateRotation(0, s)
+		if s.expiring.Load() {
+			t.Fatal("expected expiring cleared after rotation")
+		}
+	})
+
+	t.Run("fresh connection not expiring", func(t *testing.T) {
+		tr := &HTTP2Transport{connLifetime: time.Hour}
+		s := &transportSlot{t: &http.Transport{}}
+		s.connStart.Store(time.Now().UnixNano())
+		tr.evaluateRotation(0, s)
+		if s.expiring.Load() {
+			t.Fatal("fresh connection must not expire")
 		}
 	})
 }

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -189,7 +189,7 @@ func TestLeastActiveSlotRangeSkipsHeavy(t *testing.T) {
 	})
 }
 
-func TestTrackBytesMarksSlotHeavy(t *testing.T) {
+func TestTrackReadMarksSlotHeavy(t *testing.T) {
 	// Fast path: a large transfer is marked as soon as it crosses the
 	// cumulative size threshold.
 	t.Run("fast large transfer marks at size threshold", func(t *testing.T) {
@@ -197,19 +197,22 @@ func TestTrackBytesMarksSlotHeavy(t *testing.T) {
 		stream := &HTTP2Stream{slot: slot, startTime: time.Now()}
 
 		// Below the fast threshold and too young for the slow path: no mark.
-		stream.trackBytes(sharedconfig.HeavyStreamThresholdBytes - 1)
+		stream.trackRead(sharedconfig.HeavyStreamThresholdBytes - 1)
 		if slot.heavy.Load() != 0 || stream.heavyFlag.Load() {
 			t.Fatalf("marked heavy before threshold: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
 		}
 
 		// Crossing the fast threshold: mark exactly once.
-		stream.trackBytes(2)
+		stream.trackRead(2)
 		if slot.heavy.Load() != 1 || !stream.heavyFlag.Load() {
 			t.Fatalf("expected heavy mark after threshold: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
 		}
+		if slot.bytesRecv.Load() != int64(sharedconfig.HeavyStreamThresholdBytes+1) {
+			t.Fatalf("bytesRecv not accumulated: %d", slot.bytesRecv.Load())
+		}
 
 		// Further transfers must not double-mark.
-		stream.trackBytes(64 * 1024)
+		stream.trackRead(64 * 1024)
 		if slot.heavy.Load() != 1 {
 			t.Fatalf("heavy marked more than once: %d", slot.heavy.Load())
 		}
@@ -233,13 +236,13 @@ func TestTrackBytesMarksSlotHeavy(t *testing.T) {
 		}
 
 		// Below the slow threshold: no mark regardless of age.
-		stream.trackBytes(sharedconfig.HeavyStreamSlowThresholdBytes - 1)
+		stream.trackRead(sharedconfig.HeavyStreamSlowThresholdBytes - 1)
 		if slot.heavy.Load() != 0 {
 			t.Fatalf("marked heavy below slow threshold: %d", slot.heavy.Load())
 		}
 
 		// At or above the slow threshold with sufficient age: mark once.
-		stream.trackBytes(1024)
+		stream.trackRead(1024)
 		if slot.heavy.Load() != 1 || !stream.heavyFlag.Load() {
 			t.Fatalf("expected heavy mark on slow path: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
 		}
@@ -250,7 +253,7 @@ func TestTrackBytesMarksSlotHeavy(t *testing.T) {
 		slot := &transportSlot{}
 		stream := &HTTP2Stream{slot: slot, startTime: time.Now()}
 
-		stream.trackBytes(sharedconfig.HeavyStreamSlowThresholdBytes)
+		stream.trackRead(sharedconfig.HeavyStreamSlowThresholdBytes)
 		if slot.heavy.Load() != 0 {
 			t.Fatalf("young stream marked heavy: %d", slot.heavy.Load())
 		}
@@ -259,9 +262,139 @@ func TestTrackBytesMarksSlotHeavy(t *testing.T) {
 	// Nil slot is a no-op (e.g. test-constructed streams).
 	t.Run("nil slot no-op", func(t *testing.T) {
 		noSlot := &HTTP2Stream{}
-		noSlot.trackBytes(sharedconfig.HeavyStreamThresholdBytes)
+		noSlot.trackRead(sharedconfig.HeavyStreamThresholdBytes)
 		if noSlot.heavyFlag.Load() {
 			t.Fatal("nil slot must not be marked heavy")
+		}
+	})
+}
+
+func TestEvaluateSlotHealth(t *testing.T) {
+	interval := sharedconfig.HealthCheckInterval
+	tr := &HTTP2Transport{}
+
+	newHeavySlot := func() *transportSlot {
+		s := &transportSlot{t: &http.Transport{}}
+		s.heavy.Store(1)
+		return s
+	}
+	// lowThroughput simulates one health interval carrying 10KB
+	// (2KB/s, well below the 64KB/s degraded threshold).
+	lowThroughput := func(s *transportSlot) {
+		s.bytesRecv.Add(10 * 1024)
+		tr.evaluateSlotHealth(0, s, interval)
+	}
+	highThroughput := func(s *transportSlot) {
+		s.bytesRecv.Add(2 * 1024 * 1024) // 2MB over 5s = 400KB/s
+		tr.evaluateSlotHealth(0, s, interval)
+	}
+
+	t.Run("marks degraded after consecutive slow intervals", func(t *testing.T) {
+		s := newHeavySlot()
+		for i := 0; i < sharedconfig.DegradedPersistCycles-1; i++ {
+			lowThroughput(s)
+			if s.degraded.Load() {
+				t.Fatalf("degraded too early at cycle %d", i+1)
+			}
+		}
+		lowThroughput(s)
+		if !s.degraded.Load() {
+			t.Fatal("expected degraded after persist cycles")
+		}
+	})
+
+	t.Run("healthy interval resets the slow counter", func(t *testing.T) {
+		s := newHeavySlot()
+		lowThroughput(s)
+		lowThroughput(s)
+		highThroughput(s)
+		lowThroughput(s)
+		lowThroughput(s)
+		if s.degraded.Load() {
+			t.Fatal("expected not degraded after a healthy interval")
+		}
+	})
+
+	t.Run("clears degraded after consecutive healthy intervals", func(t *testing.T) {
+		s := newHeavySlot()
+		for i := 0; i < sharedconfig.DegradedPersistCycles; i++ {
+			lowThroughput(s)
+		}
+		if !s.degraded.Load() {
+			t.Fatal("expected degraded")
+		}
+		highThroughput(s)
+		if !s.degraded.Load() {
+			t.Fatal("cleared too early after a single healthy interval")
+		}
+		highThroughput(s)
+		if s.degraded.Load() {
+			t.Fatal("expected cleared after recover cycles")
+		}
+	})
+
+	t.Run("slots without heavy streams never degrade", func(t *testing.T) {
+		s := &transportSlot{t: &http.Transport{}}
+		for i := 0; i < sharedconfig.DegradedPersistCycles+2; i++ {
+			lowThroughput(s)
+		}
+		if s.degraded.Load() {
+			t.Fatal("non-heavy slot must not degrade")
+		}
+	})
+}
+
+func TestRetireSlotShrinksLiveCount(t *testing.T) {
+	s0 := &transportSlot{t: &http.Transport{}}
+	s0.active.Store(1)
+	s1 := &transportSlot{t: &http.Transport{}}
+	s1.degraded.Store(true)
+	tr := &HTTP2Transport{slots: []*transportSlot{s0, s1}}
+	tr.liveCount.Store(2)
+
+	tr.retireSlot(s1)
+	if got := tr.liveCount.Load(); got != 1 {
+		t.Fatalf("liveCount = %d, want 1", got)
+	}
+	if tr.slots[0] != s0 {
+		t.Fatal("live slot must stay at the front")
+	}
+
+	// Busy slots are never retired.
+	s2 := &transportSlot{t: &http.Transport{}}
+	s2.active.Store(1)
+	s2.degraded.Store(true)
+	tr2 := &HTTP2Transport{slots: []*transportSlot{s2}}
+	tr2.liveCount.Store(1)
+	tr2.retireSlot(s2)
+	if got := tr2.liveCount.Load(); got != 1 {
+		t.Fatalf("busy slot retired: liveCount = %d", got)
+	}
+}
+
+func TestLeastActiveSlotRangePrefersHealthyOverDegraded(t *testing.T) {
+	t.Run("skips degraded slot when healthy exists", func(t *testing.T) {
+		tr := newTestSlots([2]int32{2, 0}, [2]int32{1, 0})
+		tr.slots[1].degraded.Store(true)
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[0] {
+			t.Fatalf("expected healthy slot 0, got active=%d heavy=%d degraded=%v", got.active.Load(), got.heavy.Load(), got.degraded.Load())
+		}
+	})
+
+	t.Run("prefers heavy-but-not-degraded over degraded", func(t *testing.T) {
+		tr := newTestSlots([2]int32{1, 1}, [2]int32{3, 1})
+		tr.slots[1].degraded.Store(true)
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[0] {
+			t.Fatalf("expected non-degraded slot 0, got active=%d degraded=%v", got.active.Load(), got.degraded.Load())
+		}
+	})
+
+	t.Run("falls back to degraded when nothing else", func(t *testing.T) {
+		tr := newTestSlots([2]int32{5, 1}, [2]int32{3, 1})
+		tr.slots[0].degraded.Store(true)
+		tr.slots[1].degraded.Store(true)
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[1] {
+			t.Fatalf("expected least-active degraded slot 1, got active=%d", got.active.Load())
 		}
 	})
 }

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -140,3 +140,128 @@ func TestHTTP2Transport_200StatusReadsBody(t *testing.T) {
 		t.Fatalf("got %q, want %q", body, "hello")
 	}
 }
+
+// newTestSlots builds live slots with explicit active/heavy counters.
+// Transport structs inside slots are left nil — scheduling tests never dial.
+func newTestSlots(specs ...[2]int32) *HTTP2Transport {
+	slots := make([]*transportSlot, len(specs))
+	for i, s := range specs {
+		slots[i] = &transportSlot{}
+		slots[i].active.Store(s[0])
+		slots[i].heavy.Store(s[1])
+	}
+	tr := &HTTP2Transport{
+		slots:    slots,
+		maxSlots: len(slots),
+	}
+	tr.liveCount.Store(int32(len(slots)))
+	return tr
+}
+
+func TestLeastActiveSlotRangeSkipsHeavy(t *testing.T) {
+	t.Run("prefers non-heavy slot", func(t *testing.T) {
+		tr := newTestSlots([2]int32{5, 1}, [2]int32{2, 0})
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[1] {
+			t.Fatalf("expected non-heavy slot 1, got active=%d heavy=%d", got.active.Load(), got.heavy.Load())
+		}
+	})
+
+	t.Run("picks least active among non-heavy", func(t *testing.T) {
+		tr := newTestSlots([2]int32{5, 0}, [2]int32{2, 1}, [2]int32{3, 0})
+		if got := tr.leastActiveSlotRange(0, 3); got != tr.slots[2] {
+			t.Fatalf("expected least-active non-heavy slot 2, got active=%d heavy=%d", got.active.Load(), got.heavy.Load())
+		}
+	})
+
+	t.Run("falls back to least active when all heavy", func(t *testing.T) {
+		tr := newTestSlots([2]int32{5, 1}, [2]int32{2, 1})
+		if got := tr.leastActiveSlotRange(0, 2); got != tr.slots[1] {
+			t.Fatalf("expected least-active slot 1, got active=%d heavy=%d", got.active.Load(), got.heavy.Load())
+		}
+	})
+
+	t.Run("respects liveCount bound", func(t *testing.T) {
+		tr := newTestSlots([2]int32{5, 0}, [2]int32{2, 0}, [2]int32{3, 0})
+		tr.liveCount.Store(2)
+		if got := tr.leastActiveSlotRange(0, 3); got != tr.slots[1] {
+			t.Fatalf("expected slot 1 within live range, got active=%d", got.active.Load())
+		}
+	})
+}
+
+func TestTrackBytesMarksSlotHeavy(t *testing.T) {
+	// Fast path: a large transfer is marked as soon as it crosses the
+	// cumulative size threshold.
+	t.Run("fast large transfer marks at size threshold", func(t *testing.T) {
+		slot := &transportSlot{}
+		stream := &HTTP2Stream{slot: slot, startTime: time.Now()}
+
+		// Below the fast threshold and too young for the slow path: no mark.
+		stream.trackBytes(sharedconfig.HeavyStreamThresholdBytes - 1)
+		if slot.heavy.Load() != 0 || stream.heavyFlag.Load() {
+			t.Fatalf("marked heavy before threshold: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
+		}
+
+		// Crossing the fast threshold: mark exactly once.
+		stream.trackBytes(2)
+		if slot.heavy.Load() != 1 || !stream.heavyFlag.Load() {
+			t.Fatalf("expected heavy mark after threshold: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
+		}
+
+		// Further transfers must not double-mark.
+		stream.trackBytes(64 * 1024)
+		if slot.heavy.Load() != 1 {
+			t.Fatalf("heavy marked more than once: %d", slot.heavy.Load())
+		}
+
+		// Release on stream end: mirrors the doneOnce logic in Open.
+		if stream.heavyFlag.Swap(false) {
+			slot.heavy.Add(-1)
+		}
+		if slot.heavy.Load() != 0 {
+			t.Fatalf("heavy mark not released: %d", slot.heavy.Load())
+		}
+	})
+
+	// Slow path: on a poor link even a sub-MB transfer becomes long-lived,
+	// so it must be marked once the stream has been alive long enough.
+	t.Run("slow transfer marks after min age", func(t *testing.T) {
+		slot := &transportSlot{}
+		stream := &HTTP2Stream{
+			slot:      slot,
+			startTime: time.Now().Add(-sharedconfig.HeavyStreamMinAge - time.Second),
+		}
+
+		// Below the slow threshold: no mark regardless of age.
+		stream.trackBytes(sharedconfig.HeavyStreamSlowThresholdBytes - 1)
+		if slot.heavy.Load() != 0 {
+			t.Fatalf("marked heavy below slow threshold: %d", slot.heavy.Load())
+		}
+
+		// At or above the slow threshold with sufficient age: mark once.
+		stream.trackBytes(1024)
+		if slot.heavy.Load() != 1 || !stream.heavyFlag.Load() {
+			t.Fatalf("expected heavy mark on slow path: slot.heavy=%d flag=%v", slot.heavy.Load(), stream.heavyFlag.Load())
+		}
+	})
+
+	// A young stream below the fast threshold must not be marked.
+	t.Run("young stream below fast threshold not marked", func(t *testing.T) {
+		slot := &transportSlot{}
+		stream := &HTTP2Stream{slot: slot, startTime: time.Now()}
+
+		stream.trackBytes(sharedconfig.HeavyStreamSlowThresholdBytes)
+		if slot.heavy.Load() != 0 {
+			t.Fatalf("young stream marked heavy: %d", slot.heavy.Load())
+		}
+	})
+
+	// Nil slot is a no-op (e.g. test-constructed streams).
+	t.Run("nil slot no-op", func(t *testing.T) {
+		noSlot := &HTTP2Stream{}
+		noSlot.trackBytes(sharedconfig.HeavyStreamThresholdBytes)
+		if noSlot.heavyFlag.Load() {
+			t.Fatal("nil slot must not be marked heavy")
+		}
+	})
+}

--- a/transport/http2/stream.go
+++ b/transport/http2/stream.go
@@ -37,20 +37,33 @@ type HTTP2Stream struct {
 
 	// Heavy-stream tracking: once the stream qualifies as heavy (fast large
 	// transfer, or slow transfer on a poor link), it marks its slot so that
-	// new streams avoid sharing that connection.
+	// new streams avoid sharing that connection. See heavyIdle/heavyMarked/
+	// heavyReleased below.
 	startTime   time.Time
 	transferred atomic.Int64
-	heavyOnce   sync.Once
-	heavyFlag   atomic.Bool
+	heavyMu     sync.Mutex
+	heavyState  atomic.Int32
 }
 
-// trackRead accumulates downloaded bytes: on the slot (transport health
-// signal) and in the heavy-stream detector.
+// Heavy-stream state machine: a stream transitions heavyIdle -> heavyMarked
+// the first time it qualifies as heavy, and heavyMarked -> heavyReleased
+// when it closes. The mutex pairs each transition with its slot counter
+// update, so slot.heavy can never leak regardless of how Read/Write/Close
+// interleave.
+const (
+	heavyIdle     int32 = iota // stream never qualified as heavy
+	heavyMarked                // qualified: slot.heavy incremented
+	heavyReleased              // closed: slot.heavy decremented if marked
+)
+
+// trackRead accumulates downloaded bytes: on the slot (transport health and
+// connection rotation signals) and in the heavy-stream detector.
 func (s *HTTP2Stream) trackRead(n int) {
 	if s.slot == nil || n <= 0 {
 		return
 	}
 	s.slot.bytesRecv.Add(int64(n))
+	s.slot.connBytesRecv.Add(int64(n))
 	s.accumulate(n)
 }
 
@@ -68,16 +81,41 @@ func (s *HTTP2Stream) accumulate(n int) {
 		return
 	}
 	total := s.transferred.Add(int64(n))
+	// Fast path: marking happens at most once per stream; once the state
+	// left heavyIdle (marked or released) there is nothing left to do.
+	if s.heavyState.Load() != heavyIdle {
+		return
+	}
 	fast := total >= sharedconfig.HeavyStreamThresholdBytes
 	slow := total >= sharedconfig.HeavyStreamSlowThresholdBytes &&
 		time.Since(s.startTime) >= sharedconfig.HeavyStreamMinAge
 	if !fast && !slow {
 		return
 	}
-	s.heavyOnce.Do(func() {
-		s.heavyFlag.Store(true)
+	s.heavyMu.Lock()
+	defer s.heavyMu.Unlock()
+	if s.heavyState.CompareAndSwap(heavyIdle, heavyMarked) {
 		s.slot.heavy.Add(1)
-	})
+	}
+}
+
+// releaseHeavy releases the slot's heavy mark exactly once per stream. It
+// is called from the stream's done callback (guarded by sync.OnceFunc),
+// while accumulate may run concurrently from Read/Write. The mutex pairs
+// each state transition with its counter update so slot.heavy cannot leak.
+func (s *HTTP2Stream) releaseHeavy() {
+	if s.slot == nil {
+		return
+	}
+	s.heavyMu.Lock()
+	defer s.heavyMu.Unlock()
+	switch s.heavyState.Load() {
+	case heavyMarked:
+		s.heavyState.Store(heavyReleased)
+		s.slot.heavy.Add(-1)
+	case heavyIdle:
+		s.heavyState.Store(heavyReleased)
+	}
 }
 
 // setRoundTripErr stores the RoundTrip error for use by Write() when the pipe

--- a/transport/http2/stream.go
+++ b/transport/http2/stream.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
+	"time"
 
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/transport"
 )
 
@@ -21,6 +24,7 @@ type HTTP2Stream struct {
 	respCh <-chan roundTripResult
 	cancel context.CancelFunc
 	done   func()
+	slot   *transportSlot
 
 	mu       sync.Mutex
 	r        io.ReadCloser
@@ -30,6 +34,35 @@ type HTTP2Stream struct {
 
 	rtErrMu sync.Mutex
 	rtErr   error // RoundTrip error, captured for better diagnostics in Write()
+
+	// Heavy-stream tracking: once the stream qualifies as heavy (fast large
+	// transfer, or slow transfer on a poor link), it marks its slot so that
+	// new streams avoid sharing that connection.
+	startTime   time.Time
+	transferred atomic.Int64
+	heavyOnce   sync.Once
+	heavyFlag   atomic.Bool
+}
+
+// trackBytes accumulates transferred bytes and marks the owning slot as
+// heavy the first time the stream qualifies: either it crossed the fast
+// size threshold, or it has been alive long enough carrying at least the
+// slow threshold (slow links make even small transfers long-lived).
+func (s *HTTP2Stream) trackBytes(n int) {
+	if s.slot == nil || n <= 0 {
+		return
+	}
+	total := s.transferred.Add(int64(n))
+	fast := total >= sharedconfig.HeavyStreamThresholdBytes
+	slow := total >= sharedconfig.HeavyStreamSlowThresholdBytes &&
+		time.Since(s.startTime) >= sharedconfig.HeavyStreamMinAge
+	if !fast && !slow {
+		return
+	}
+	s.heavyOnce.Do(func() {
+		s.heavyFlag.Store(true)
+		s.slot.heavy.Add(1)
+	})
 }
 
 // setRoundTripErr stores the RoundTrip error for use by Write() when the pipe
@@ -91,6 +124,9 @@ func (s *HTTP2Stream) Read(p []byte) (int, error) {
 	}
 
 	n, err := r.Read(p)
+	if n > 0 {
+		s.trackBytes(n)
+	}
 	if err != nil {
 		s.done()
 	}
@@ -99,6 +135,9 @@ func (s *HTTP2Stream) Read(p []byte) (int, error) {
 
 func (s *HTTP2Stream) Write(p []byte) (int, error) {
 	n, err := s.w.Write(p)
+	if n > 0 {
+		s.trackBytes(n)
+	}
 	if err != nil {
 		s.done()
 		if errors.Is(err, io.ErrClosedPipe) {

--- a/transport/http2/stream.go
+++ b/transport/http2/stream.go
@@ -44,11 +44,26 @@ type HTTP2Stream struct {
 	heavyFlag   atomic.Bool
 }
 
-// trackBytes accumulates transferred bytes and marks the owning slot as
+// trackRead accumulates downloaded bytes: on the slot (transport health
+// signal) and in the heavy-stream detector.
+func (s *HTTP2Stream) trackRead(n int) {
+	if s.slot == nil || n <= 0 {
+		return
+	}
+	s.slot.bytesRecv.Add(int64(n))
+	s.accumulate(n)
+}
+
+// trackWrite accumulates uploaded bytes into the heavy-stream detector.
+func (s *HTTP2Stream) trackWrite(n int) {
+	s.accumulate(n)
+}
+
+// accumulate feeds the heavy-stream detector and marks the owning slot as
 // heavy the first time the stream qualifies: either it crossed the fast
 // size threshold, or it has been alive long enough carrying at least the
 // slow threshold (slow links make even small transfers long-lived).
-func (s *HTTP2Stream) trackBytes(n int) {
+func (s *HTTP2Stream) accumulate(n int) {
 	if s.slot == nil || n <= 0 {
 		return
 	}
@@ -125,7 +140,7 @@ func (s *HTTP2Stream) Read(p []byte) (int, error) {
 
 	n, err := r.Read(p)
 	if n > 0 {
-		s.trackBytes(n)
+		s.trackRead(n)
 	}
 	if err != nil {
 		s.done()
@@ -136,7 +151,7 @@ func (s *HTTP2Stream) Read(p []byte) (int, error) {
 func (s *HTTP2Stream) Write(p []byte) (int, error) {
 	n, err := s.w.Write(p)
 	if n > 0 {
-		s.trackBytes(n)
+		s.trackWrite(n)
 	}
 	if err != nil {
 		s.done()


### PR DESCRIPTION
## 背景

弱网场景下长生命周期 HTTP/2 连接会逐渐劣化（吞吐下降、拥塞窗口失效），
单个大流量 stream 也会拖慢同连接上的其他 stream。

## 改动

- **隔离重流**：超过阈值的 heavy stream 分配到独立 h2 连接，避免大流量拖累其他流
- **自动退役劣化连接**：健康检测循环监控各连接吞吐，长期低于阈值且承载 heavy stream 的连接被标记 degraded，新流不再分配、空闲连接提前回收
- **长连接轮换**：连接超过生命周期或累计字节上限后轮换新连接，并加入随机 jitter 避免多个连接同时续期造成流量尖峰
- **cover budget 上限调低**：默认 16KB，配合连接轮换控制单连接累积流量
- **健康统计补齐 omitempty**：`transport/health` 字段输出更规范

## 测试

- `go test -v ./transport/http2/...` 新增/更新约 465 行测试
- `make lint` 通过

## 配置影响

新增配置项：`conn_lifetime`、`conn_max_bytes`、`heavy_stream_threshold`（默认值见 `config/types.go`），均向后兼容。