### PR TITLE
feat: jitter dns cache ttl to avoid expiry bursts

### DIFF
--- a/client/dns/cache.go
+++ b/client/dns/cache.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 
 	"github.com/coocood/freecache"
@@ -59,6 +60,9 @@ func (c *Cache) Get(name, qtype string, isDirect bool) *dns.Msg {
 
 // Set stores a DNS message in the appropriate cache using DNS TTL.
 // Only A and AAAA records are cached. If isDirect is true, the direct cache is used.
+// The effective cache lifetime is the base TTL plus a random jitter in
+// [0, baseTTL) so that entries with the same base TTL do not expire at the
+// same moment, avoiding bursts of concurrent DNS queries.
 func (c *Cache) Set(msg *dns.Msg, isDirect bool) error {
 	if msg == nil || len(msg.Question) == 0 {
 		return nil
@@ -70,7 +74,7 @@ func (c *Cache) Set(msg *dns.Msg, isDirect bool) error {
 			return err
 		}
 		key := []byte(q.Name + dns.TypeToString[q.Qtype])
-		ttl := dnsCacheTTL(msg, c.serverDomain)
+		ttl := jitterTTL(dnsCacheTTL(msg, c.serverDomain))
 		if isDirect {
 			return c.direct.Set(key, v, ttl)
 		}
@@ -107,6 +111,18 @@ func dnsCacheTTL(msg *dns.Msg, serverDomain string) int {
 		ttl = minCacheTTL
 	}
 	return int(ttl)
+}
+
+// jitterTTL returns the effective cache lifetime in seconds for a base TTL:
+// the base TTL plus a random jitter in [0, ttl). Entries sharing the same
+// base TTL therefore expire at scattered moments instead of all at once,
+// avoiding a burst of concurrent DNS queries. A TTL of 0 (never expire,
+// e.g. the proxy server's own domain) is returned unchanged.
+func jitterTTL(ttl int) int {
+	if ttl <= 0 {
+		return ttl
+	}
+	return ttl + rand.IntN(ttl)
 }
 
 // PrePopulate resolves the domain via the given DNS server and stores the

--- a/client/dns/cache_test.go
+++ b/client/dns/cache_test.go
@@ -252,3 +252,31 @@ func TestCache_ServerDomain_NeverExpires(t *testing.T) {
 		t.Fatal("regular domain entry expired before minCacheTTL")
 	}
 }
+
+func TestJitterTTL_NeverExpire(t *testing.T) {
+	// TTL 0（服务器域名永不过期）必须原样返回，不受抖动影响
+	if ttl := jitterTTL(0); ttl != 0 {
+		t.Errorf("jitterTTL(0) expected 0, got %d", ttl)
+	}
+	// 负数属于防御性边界，不应 panic 也不应被改动
+	if ttl := jitterTTL(-1); ttl != -1 {
+		t.Errorf("jitterTTL(-1) expected -1, got %d", ttl)
+	}
+}
+
+func TestJitterTTL_Range(t *testing.T) {
+	const base = 1800
+	seen := make(map[int]bool)
+	for i := 0; i < 1000; i++ {
+		ttl := jitterTTL(base)
+		// 结果必须在 [base, 2*base) 区间内
+		if ttl < base || ttl >= 2*base {
+			t.Fatalf("jitterTTL(%d) = %d, want in [%d, %d)", base, ttl, base, 2*base)
+		}
+		seen[ttl] = true
+	}
+	// 1000 次采样下结果应分散，而非固定同一个值
+	if len(seen) < 2 {
+		t.Errorf("jitterTTL(%d) always returned %d, expected random jitter", base, base)
+	}
+}


### PR DESCRIPTION
## 背景

客户端 DNS 查询结果缓存后存在一个突出问题：大量域名（尤其是 TTL 被 clamp 到统一下限/上限的条目）的缓存几乎在同一时刻过期，导致短时间内爆发大量 DNS 查询请求。无论从性能（上游 DNS 服务器瞬时压力）还是流量特征（突发的查询模式容易被识别）角度都不友好。

## 改动

- `client/dns/cache.go`：新增 `jitterTTL()`，写入缓存时的实际存活时间 = 基础 TTL + 随机(0, 基础 TTL)，即最终 TTL 落在 `[基础TTL, 2×基础TTL)` 区间，让过期时刻均匀错开。
- `client/dns/cache_test.go`：新增 `TestJitterTTL_NeverExpire`（服务器域名永不过期语义不变）与 `TestJitterTTL_Range`（1000 次采样结果均落在 `[base, 2×base)` 且取值分散）。

## 设计要点

1. 抖动施加在 clamp **之后**：若先加随机再 clamp，低于 `minCacheTTL` 的条目会被重新统一 clamp 成同一个 30 分钟，抖动完全失效。
2. `dnsCacheTTL` 保持纯函数，clamp 逻辑与既有测试不变。
3. 服务器自身域名仍永不过期（TTL=0 原样返回），避免 TUN 启动期 DNS 死锁。
4. 使用 `math/rand/v2` 顶层 `rand.IntN`，并发安全，无需额外加锁。
5. direct / proxied 两个缓存各自独立取随机数，同域名两条目过期时刻也不同，分散效果更好。

## 验证

- `go test -v ./client/dns/...` 全部通过（14 个测试）
- `make lint` 0 issues