### PR TITLE
feat: never schedule streams onto degraded+expiring slots

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -48,6 +48,9 @@ type stats struct {
 	tierExpiringScheduled atomic.Int64
 	tierHeavyScheduled    atomic.Int64
 	tierDegradedScheduled atomic.Int64
+	// tierRetiringSkipped counts the times the scheduler passed over a
+	// retiring slot (degraded+expiring) when picking a slot for a stream.
+	tierRetiringSkipped atomic.Int64
 
 	// Transport health (client-side)
 	slotDegraded         atomic.Int64
@@ -107,6 +110,7 @@ func RecordBulkFallback()         { g.bulkFallback.Add(1) }
 func RecordTierExpiring()         { g.tierExpiringScheduled.Add(1) }
 func RecordTierHeavy()            { g.tierHeavyScheduled.Add(1) }
 func RecordTierDegraded()         { g.tierDegradedScheduled.Add(1) }
+func RecordTierRetiringSkipped()  { g.tierRetiringSkipped.Add(1) }
 
 func RecordSlotDegraded()        { g.slotDegraded.Add(1) }
 func RecordSlotRetiredDegraded() { g.slotRetiredDegraded.Add(1) }
@@ -177,6 +181,7 @@ func ResetCounters() {
 	g.tierExpiringScheduled.Store(0)
 	g.tierHeavyScheduled.Store(0)
 	g.tierDegradedScheduled.Store(0)
+	g.tierRetiringSkipped.Store(0)
 	g.slotDegraded.Store(0)
 	g.slotRetiredDegraded.Store(0)
 	g.connRotated.Store(0)
@@ -238,6 +243,7 @@ type Snapshot struct {
 	TierExpiringScheduled int64 `json:"tier_expiring_scheduled"`
 	TierHeavyScheduled    int64 `json:"tier_heavy_scheduled"`
 	TierDegradedScheduled int64 `json:"tier_degraded_scheduled"`
+	TierRetiringSkipped   int64 `json:"tier_retiring_skipped"`
 
 	// Transport health (client-side only; zero on server)
 	SlotDegraded         int64 `json:"slot_degraded"`
@@ -332,6 +338,7 @@ func Collect() Snapshot {
 		TierExpiringScheduled:  g.tierExpiringScheduled.Load(),
 		TierHeavyScheduled:     g.tierHeavyScheduled.Load(),
 		TierDegradedScheduled:  g.tierDegradedScheduled.Load(),
+		TierRetiringSkipped:    g.tierRetiringSkipped.Load(),
 		SlotDegraded:           g.slotDegraded.Load(),
 		SlotRetiredDegraded:    g.slotRetiredDegraded.Load(),
 		ConnRotated:            g.connRotated.Load(),

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -69,6 +69,7 @@ func TestResetCounters(t *testing.T) {
 	RecordTierExpiring()
 	RecordTierHeavy()
 	RecordTierDegraded()
+	RecordTierRetiringSkipped()
 	RecordRTT(100 * time.Millisecond)
 	RecordServerTCPStream()
 	RecordServerUDPStream()
@@ -93,7 +94,7 @@ func TestResetCounters(t *testing.T) {
 		snap.PriorityStreamsOpened != 0 || snap.BulkStreamsOpened != 0 ||
 		snap.PriorityFallback != 0 || snap.BulkFallback != 0 ||
 		snap.TierExpiringScheduled != 0 || snap.TierHeavyScheduled != 0 ||
-		snap.TierDegradedScheduled != 0 ||
+		snap.TierDegradedScheduled != 0 || snap.TierRetiringSkipped != 0 ||
 		snap.RTTCount != 0 || snap.RTTEWMA != 0 ||
 		snap.UploadSpeed != 0 || snap.DownloadSpeed != 0 ||
 		snap.PeakUploadSpeedHuman != "0 B/s" || snap.PeakDownloadSpeedHuman != "0 B/s" ||

--- a/transport/http2/lifecycle_test.go
+++ b/transport/http2/lifecycle_test.go
@@ -481,3 +481,29 @@ func TestEvaluateRotation(t *testing.T) {
 		}
 	})
 }
+
+func TestResetConnClearsMarks(t *testing.T) {
+	s := &transportSlot{}
+	// A retiring slot (degraded+expiring) past its lifetime with bytes
+	// carried: after a fresh connection is established, the rotation state
+	// starts over and the degraded verdict of the old connection is void.
+	s.degraded.Store(true)
+	s.expiring.Store(true)
+	s.expireAt.Store(time.Now().Add(-time.Minute).UnixNano())
+	s.connBytes.Store(1024)
+
+	s.resetConn(time.Hour)
+
+	if s.degraded.Load() {
+		t.Fatal("expected degraded cleared on a fresh connection")
+	}
+	if s.expiring.Load() {
+		t.Fatal("expected expiring cleared on a fresh connection")
+	}
+	if s.connBytes.Load() != 0 {
+		t.Fatalf("connBytes = %d, want 0", s.connBytes.Load())
+	}
+	if expireAt := s.expireAt.Load(); expireAt <= time.Now().UnixNano() {
+		t.Fatalf("expireAt = %d, want a future deadline", expireAt)
+	}
+}

--- a/transport/http2/scheduler.go
+++ b/transport/http2/scheduler.go
@@ -39,6 +39,10 @@ import (
 //     the tier capacity, which doubles whenever the active layer is pushed
 //     to the next power-of-two multiple of the base — so a fully saturated
 //     pool keeps spreading load instead of piling onto one connection.
+//     A slot that is both degraded and expiring is classified as
+//     tierRetiring and never selected at all: it is due for rotation and
+//     confirmed slow, so new streams must not keep it alive — it drains to
+//     idle and the health loop retires it, replaced by a fresh connection.
 //
 //   - Growth prefers fresh connections over squeezing negative ones: when a
 //     pool's tiers are saturated it grows its own pool, and once a pool is
@@ -134,7 +138,12 @@ func (s *slotScheduler) poolOf(highPriority bool) *slotPool {
 //	                sharing stream down with them (head-of-line blocking
 //	                under loss), yet the connection itself is healthy;
 //	tierDegraded  — the connection proved persistently low throughput, the
-//	                worst candidate, used only as a last resort.
+//	                worst candidate, used only as a last resort;
+//	tierRetiring  — degraded AND expiring: due for rotation and confirmed
+//	                slow, with no recovery value (even a fast stream cannot
+//	                undo the overdue rotation). Never selected: the slot
+//	                drains to idle and the health loop retires it, replaced
+//	                by a fresh connection.
 type slotTier int
 
 const (
@@ -142,6 +151,7 @@ const (
 	tierExpiring
 	tierHeavy
 	tierDegraded
+	tierRetiring
 )
 
 // Negative-mark load weights, shared by slotWeight (multiplicative) and
@@ -157,8 +167,14 @@ const (
 
 // slotTierOf returns the tier a slot currently belongs to. Heavy+expiring
 // slots classify as heavy (the heavier mark wins), any degraded combination
-// classifies as degraded.
+// classifies as degraded — except that a slot both degraded and expiring
+// classifies as tierRetiring: it is due for rotation and confirmed slow, so
+// the scheduler never selects it (see leastActive) and the health loop
+// retires it once idle.
 func slotTierOf(s *transportSlot) slotTier {
+	if s.degraded.Load() && s.expiring.Load() {
+		return tierRetiring
+	}
 	if s.degraded.Load() {
 		return tierDegraded
 	}
@@ -284,7 +300,10 @@ func (p *slotPool) saturatedIn(live int) bool {
 // and tierCap). Once every tier is full, the fallback piles onto the
 // least-loaded slot overall (by weighted load, uncapped): piling there
 // keeps load balanced instead of stacking every stream onto one crowded
-// healthy connection.
+// healthy connection. Slots that are both degraded and expiring
+// (tierRetiring) are excluded from every search and from the fallback:
+// they are due for rotation and confirmed slow, so new streams must never
+// keep them alive — they drain to idle and are retired by the health loop.
 func (p *slotPool) tieredSelectAt(live int, recordStats bool) (*transportSlot, bool) {
 	if live == 0 {
 		return p.slots[0], false
@@ -361,8 +380,9 @@ func (p *slotPool) tieredSelectAt(live int, recordStats bool) (*transportSlot, b
 	// hosting far fewer streams than the piled-up healthy slots — piling
 	// there keeps load balanced instead of stacking every stream onto one
 	// crowded healthy connection (which is also what keeps the pressure
-	// level honest).
-	return p.leastActive(live), true
+	// level honest). Retiring slots (degraded+expiring) are excluded from
+	// the fallback too, so they drain to idle and are retired.
+	return p.leastActive(live, recordStats), true
 }
 
 // pressureLevel derives the current pressure level from the least-loaded
@@ -433,6 +453,11 @@ func tierCap(tier slotTier, level, base int32) int32 {
 		// active layer" is the fallback path in tieredSelect.
 		return 0
 	}
+	if tier == tierRetiring {
+		// tierRetiring is never searched: slots that are both degraded and
+		// expiring are excluded from selection entirely (see leastActive).
+		return 0
+	}
 	return base << (level - 1)
 }
 
@@ -473,22 +498,45 @@ func (p *slotPool) minActiveInRange(live int) int32 {
 // leastActive returns the slot with the fewest weighted streams among the
 // first `live` slots — the final uncapped fallback of the pressure
 // scheduler; among equally loaded slots the one with fewer negative marks
-// wins. With no live slots the first pre-allocated slot is returned.
-func (p *slotPool) leastActive(live int) *transportSlot {
+// wins. Retiring slots (degraded+expiring) are excluded: they are due for
+// rotation and confirmed slow, so new streams must never keep them alive —
+// they drain to idle and the health loop retires them, replaced by fresh
+// connections via grow. When every live slot is retiring, the least-loaded
+// retiring slot is returned so pick never fails (the health loop retires
+// them within a tick or two, closing the window). With no live slots the
+// first pre-allocated slot is returned. recordStats gates the
+// tier_retiring_skipped counter (the grow path's saturation check must not
+// record scheduling stats).
+func (p *slotPool) leastActive(live int, recordStats bool) *transportSlot {
 	if live == 0 {
 		return p.slots[0]
 	}
 	var best *transportSlot
 	var minWeighted int32 = math.MaxInt32
 	var minNeg int32 = math.MaxInt32
+	var retiring *transportSlot // least-loaded retiring slot, absolute last resort
+	var retWeighted int32 = math.MaxInt32
+	var retNeg int32 = math.MaxInt32
 	for i := 0; i < live; i++ {
 		sl := p.slots[i]
 		w := weightedActive(sl)
 		neg := negativeScore(sl)
+		if slotTierOf(sl) == tierRetiring {
+			if recordStats {
+				stats.RecordTierRetiringSkipped()
+			}
+			if w < retWeighted || (w == retWeighted && neg < retNeg) {
+				retiring, retWeighted, retNeg = sl, w, neg
+			}
+			continue
+		}
 		if w > minWeighted || (w == minWeighted && neg >= minNeg) {
 			continue
 		}
 		best, minWeighted, minNeg = sl, w, neg
+	}
+	if best == nil {
+		return retiring
 	}
 	return best
 }

--- a/transport/http2/scheduler_test.go
+++ b/transport/http2/scheduler_test.go
@@ -86,15 +86,15 @@ func TestSlotTierOf(t *testing.T) {
 			s.expiring.Store(true)
 		}, tierHeavy},
 		{"degraded", func(s *transportSlot) { s.degraded.Store(true) }, tierDegraded},
-		{"degraded and expiring classifies as degraded", func(s *transportSlot) {
+		{"degraded and expiring is retiring", func(s *transportSlot) {
 			s.degraded.Store(true)
 			s.expiring.Store(true)
-		}, tierDegraded},
-		{"all marks classifies as degraded", func(s *transportSlot) {
+		}, tierRetiring},
+		{"all marks is retiring", func(s *transportSlot) {
 			s.degraded.Store(true)
 			s.heavy.Store(1)
 			s.expiring.Store(true)
-		}, tierDegraded},
+		}, tierRetiring},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -345,6 +345,54 @@ func TestTieredSelectPrefersLessNegative(t *testing.T) {
 	})
 }
 
+func TestTieredSelectExcludesRetiring(t *testing.T) {
+	t.Run("degraded tier prefers degraded-only over idle retiring", func(t *testing.T) {
+		p := newTestPool(8, [2]int32{8, 0}, [2]int32{4, 0}, [2]int32{4, 0}, [2]int32{0, 0}, [2]int32{1, 0})
+		p.slots[1].expiring.Store(true)
+		p.slots[2].heavy.Store(1)
+		p.slots[3].degraded.Store(true)
+		p.slots[3].expiring.Store(true) // idle retiring slot: weighted load 0
+		p.slots[4].degraded.Store(true)
+		// The idle retiring slot must NOT win the degraded tier: even
+		// though its weighted load is 0, retiring slots are excluded, so
+		// the degraded-only slot hosting one stream is picked.
+		slot, saturated := p.tieredSelect()
+		if saturated || slot != p.slots[4] {
+			t.Fatalf("got slot %d saturated=%v, want degraded-only slot 4 (active=1, weighted 6 < 8)", slot.idx, saturated)
+		}
+	})
+
+	t.Run("uncapped fallback excludes idle retiring", func(t *testing.T) {
+		p := newTestPool(8, [2]int32{8, 0}, [2]int32{4, 0}, [2]int32{4, 0}, [2]int32{2, 0}, [2]int32{0, 0})
+		p.slots[1].expiring.Store(true)
+		p.slots[2].heavy.Store(1)
+		p.slots[3].degraded.Store(true)
+		p.slots[4].degraded.Store(true)
+		p.slots[4].expiring.Store(true)
+		// Every tier is at capacity; the idle retiring slot (weighted 0)
+		// would be the globally least-loaded slot, but it must be passed
+		// over in favor of the least-loaded healthy slot.
+		slot, saturated := p.tieredSelect()
+		if !saturated || slot != p.slots[0] {
+			t.Fatalf("got slot %d saturated=%v, want fallback slot 0 with saturated=true", slot.idx, saturated)
+		}
+	})
+
+	t.Run("all live slots retiring returns the least-loaded retiring slot", func(t *testing.T) {
+		p := newTestPool(8, [2]int32{2, 0}, [2]int32{0, 0})
+		p.slots[0].degraded.Store(true)
+		p.slots[0].expiring.Store(true)
+		p.slots[1].degraded.Store(true)
+		p.slots[1].expiring.Store(true)
+		// No alternative exists: pick must never fail, so the least-loaded
+		// retiring slot is returned (the health loop retires both shortly).
+		slot, saturated := p.tieredSelect()
+		if !saturated || slot != p.slots[1] {
+			t.Fatalf("got slot %d saturated=%v, want least-loaded retiring slot 1", slot.idx, saturated)
+		}
+	})
+}
+
 func TestTieredSelectNoHealthyEngagesLowerTiers(t *testing.T) {
 	t.Run("all expiring picks least-active below base/2", func(t *testing.T) {
 		p := newTestPool(8, [2]int32{0, 0}, [2]int32{1, 0})
@@ -458,6 +506,38 @@ func TestPickBorrowsOtherPoolWhenSaturated(t *testing.T) {
 	})
 }
 
+func TestPickExcludesRetiringInBorrow(t *testing.T) {
+	t.Run("borrows healthy bulk slot over idle retiring bulk slot", func(t *testing.T) {
+		sch := newTwoPoolScheduler(
+			[][2]int32{{4, 0}}, // priority pool saturated at base 4
+			[][2]int32{{0, 0}, {1, 0}},
+		)
+		sch.bulk.slots[0].degraded.Store(true)
+		sch.bulk.slots[0].expiring.Store(true)
+		// The idle retiring bulk slot must not win the borrow: the healthy
+		// bulk slot (active=1) is borrowed instead.
+		if got := sch.pick(true); got != sch.bulk.slots[1] {
+			t.Fatalf("pick(true) = slot %d, want borrowed healthy bulk slot 1", got.idx)
+		}
+	})
+
+	t.Run("all bulk slots retiring still borrows the least-loaded one", func(t *testing.T) {
+		sch := newTwoPoolScheduler(
+			[][2]int32{{4, 0}},
+			[][2]int32{{1, 0}, {0, 0}},
+		)
+		sch.bulk.slots[0].degraded.Store(true)
+		sch.bulk.slots[0].expiring.Store(true)
+		sch.bulk.slots[1].degraded.Store(true)
+		sch.bulk.slots[1].expiring.Store(true)
+		// No non-retiring slot exists anywhere: the least-loaded retiring
+		// bulk slot is the absolute last resort (pick never fails).
+		if got := sch.pick(true); got != sch.bulk.slots[1] {
+			t.Fatalf("pick(true) = slot %d, want least-loaded retiring bulk slot 1", got.idx)
+		}
+	})
+}
+
 // newGrowTestScheduler builds a scheduler via the production constructor
 // with maxSlots total slots, prioritySlots priority-class slots, threshold 4
 // and the given live counts per pool (all remaining slots live as bulk).
@@ -534,6 +614,22 @@ func TestNoGrowthWhileNegativeTiersHaveCapacity(t *testing.T) {
 	sch.grow(false)
 	if got := sch.bulk.liveCount.Load(); got != 3 {
 		t.Fatalf("bulk liveCount = %d, want 3 when every tier is saturated", got)
+	}
+}
+
+func TestGrowWhenOnlyRetiringCapacityRemains(t *testing.T) {
+	sch := newGrowTestScheduler(10, 5, 0, 2)
+
+	// One healthy slot saturated at 8; the other slot is retiring
+	// (degraded+expiring) and idle. Its weighted load is 0, but retiring
+	// slots are excluded from selection, so the pool counts as saturated
+	// and a fresh connection is grown to replace the doomed slot.
+	sch.bulk.slots[0].active.Store(8)
+	sch.bulk.slots[1].degraded.Store(true)
+	sch.bulk.slots[1].expiring.Store(true)
+	sch.grow(false)
+	if got := sch.bulk.liveCount.Load(); got != 3 {
+		t.Fatalf("bulk liveCount = %d, want 3 when the only remaining capacity is a retiring slot", got)
 	}
 }
 

--- a/transport/http2/slot.go
+++ b/transport/http2/slot.go
@@ -52,9 +52,16 @@ type transportSlot struct {
 
 // resetConn (re)initializes the rotation state for a freshly established
 // connection: the lifetime deadline (with per-connection jitter), the bytes
-// carried and the expiring mark all start fresh.
+// carried and the expiring mark all start fresh. The degraded mark is
+// cleared too: degradation is a verdict about the previous connection's
+// throughput, and a freshly dialed connection deserves a clean slate until
+// the sampler or a probe re-evaluates it — in particular a slot retired
+// while degraded and later re-activated by grow reuses this same
+// transportSlot object, and its new connection must not inherit the old
+// verdict.
 func (s *transportSlot) resetConn(connLifetime time.Duration) {
 	s.expireAt.Store(time.Now().Add(rotationLifetime(connLifetime)).UnixNano())
 	s.connBytes.Store(0)
 	s.expiring.Store(false)
+	s.degraded.Store(false)
 }


### PR DESCRIPTION
## 背景与动机

客户端调度中，同时带 `degraded`（确认持续低吞吐）+ `expiring`（已超连接寿命/字节上限）标记的槽位是"又老又慢"的最差候选：即便吞吐恢复它也必然要轮换，没有任何恢复价值。但现有加权机制无法表达"永不选中"——空闲 combo 槽位加权负载为 0，反而会在 degraded 分层搜索与 `leastActive` 兜底中被优先选中，导致新流持续喂给最该淘汰的连接，且 combo 持续忙碌无法被 `retire`（要求 active==0），淘汰被无限推迟。

## 改动

- `transport/http2/scheduler.go`：新增 `tierRetiring` 层（degraded && expiring），从所有选择路径排除（分层搜索、`leastActive` 兜底、跨池借调）；仅当池内所有 live 槽位均为 retiring 时返回最轻的 retiring 槽位，保证 `pick` 永不返回 nil
- `transport/http2/slot.go`：`resetConn` 在新连接建立时同时清除 `degraded` 标记——被 retire 后经 grow 复用的槽位（同一 transportSlot 对象）拨号新连接不应继承旧连接的判决
- `stats/`：新增 `tier_retiring_skipped` 计数与快照字段，用于观测排除行为

## 行为闭环

combo 槽位不再接新流 → 排空至 idle → 健康循环 `retire` → 下次 Open `grow` 激活槽位并拨号全新连接 → 完成替换。degraded-only 槽位仍保留最后手段地位与恢复路径。

## 测试

- `go test ./...` 全量通过（含 `-race`）
- `make lint` 0 issues
- 新增用例：分层搜索排除、兜底排除、全 retiring 兜底、跨池借调排除、grow 替换、`resetConn` 清除标记
