### PR TITLE
fix: reap proxied-DNS UDP exchanges that stay silent beyond timeout

### DIFF
--- a/client/proxy/close_race_test.go
+++ b/client/proxy/close_race_test.go
@@ -28,7 +28,7 @@ func TestSocks5CloseRacingStart(t *testing.T) {
 		l.Close()
 
 		h := newTestStreamHandler(&mockTransport{})
-		srv, err := NewSocks5Server(addr, "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, nil)
+		srv, err := NewSocks5Server(addr, "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, 0, nil)
 		if err != nil {
 			t.Fatalf("NewSocks5Server #%d: %v", i, err)
 		}

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -41,6 +41,13 @@ type Socks5Server struct {
 	quit           chan struct{}
 	closeOnce      sync.Once
 	udpIdleTimeout time.Duration
+	// dnsRespTimeout bounds how long a proxied-DNS exchange may go without
+	// any server response before it is closed (read-idle timeout). Only DNS
+	// exchanges enable it; 0 disables the mechanism. It exists because the
+	// 60s udpIdleTimeout never fires for exchanges whose client keeps
+	// retrying queries (each Send refreshes lastSeen) while the upstream DNS
+	// server stays silent.
+	dnsRespTimeout time.Duration
 	started        atomic.Bool
 	closing        atomic.Bool
 }
@@ -52,7 +59,7 @@ type directUDPConn struct {
 	lastSeen atomic.Int64 // UnixNano, refreshed on every datagram written
 }
 
-func NewSocks5Server(listenAddr, username, password string, handler *StreamHandler, rt *router.Router, serverDomain string, method protocol.Method, disableQUIC bool, dialTimeout, udpIdleTimeout time.Duration, directDialContext func(context.Context, string, string) (net.Conn, error)) (*Socks5Server, error) {
+func NewSocks5Server(listenAddr, username, password string, handler *StreamHandler, rt *router.Router, serverDomain string, method protocol.Method, disableQUIC bool, dialTimeout, udpIdleTimeout, dnsRespTimeout time.Duration, directDialContext func(context.Context, string, string) (net.Conn, error)) (*Socks5Server, error) {
 	if dialTimeout <= 0 {
 		dialTimeout = 10 * time.Second
 	}
@@ -79,6 +86,7 @@ func NewSocks5Server(listenAddr, username, password string, handler *StreamHandl
 		directUDP:         make(map[string]*directUDPConn),
 		quit:              make(chan struct{}),
 		udpIdleTimeout:    udpIdleTimeout,
+		dnsRespTimeout:    dnsRespTimeout,
 	}
 	srv, err := socks5.NewClassicServer(listenAddr, "127.0.0.1", username, password, 0, 0)
 	if err != nil {

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -206,7 +206,7 @@ func (s *Socks5Server) proxyDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr
 		return err
 	}
 	if created {
-		go s.receiveLoop(ue, srv, clientAddr, dst, key)
+		go s.receiveLoop(ue, srv, clientAddr, dst, key, s.dnsRespTimeout)
 		return nil // first payload already sent in handshake
 	}
 
@@ -330,7 +330,22 @@ func (s *Socks5Server) evictOldestExchangeLocked() *UDPExchange {
 	return evicted
 }
 
-func (s *Socks5Server) receiveLoop(ue *UDPExchange, srv *socks5.Server, clientAddr *net.UDPAddr, target, key string) {
+func (s *Socks5Server) receiveLoop(ue *UDPExchange, srv *socks5.Server, clientAddr *net.UDPAddr, target, key string, respTimeout time.Duration) {
+	// Read-idle timeout for proxied-DNS exchanges: the query was already
+	// sent (Send refreshes lastSeen, so the 60s idle reaper never fires for
+	// a client that keeps retrying while the upstream stays silent), so a
+	// long silence from the server means the upstream DNS is not answering.
+	// Close the exchange so the stream and goroutine cannot pile up; the
+	// next query transparently rebuilds it. Any received datagram resets
+	// the timer. respTimeout <= 0 disables the mechanism (non-DNS UDP).
+	var timer *time.Timer
+	if respTimeout > 0 {
+		timer = time.AfterFunc(respTimeout, func() {
+			log.Debug("[UDP_PROXY] dns response timeout, closing exchange", "key", key, "target", target)
+			ue.Close() //nolint:errcheck // closeOnce makes this safe against concurrent Close
+		})
+		defer timer.Stop()
+	}
 	defer func() {
 		s.udpMu.Lock()
 		delete(s.udpExch, key)
@@ -345,6 +360,9 @@ func (s *Socks5Server) receiveLoop(ue *UDPExchange, srv *socks5.Server, clientAd
 				log.Debug("[UDP_PROXY] receive", "err", err)
 			}
 			return
+		}
+		if timer != nil {
+			timer.Reset(respTimeout)
 		}
 
 		msg := &dns.Msg{}
@@ -477,7 +495,10 @@ func (s *Socks5Server) proxyUDPRelay(srv *socks5.Server, clientAddr *net.UDPAddr
 		return err
 	}
 	if created {
-		go s.receiveLoop(ue, srv, clientAddr, dst, key)
+		// Non-DNS UDP must not use the short read-idle timeout: a session
+		// may legitimately stay silent for a long time (e.g. an upload-only
+		// flow), so it keeps the 60s bidirectional idle reaper only.
+		go s.receiveLoop(ue, srv, clientAddr, dst, key, 0)
 		return nil // first payload already sent in handshake
 	}
 

--- a/client/proxy/udp_timeout_test.go
+++ b/client/proxy/udp_timeout_test.go
@@ -1,0 +1,150 @@
+package proxy
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/transport"
+)
+
+// blockingStream is a transport.Stream whose Read blocks until Close is
+// called, simulating a server that never answers (e.g. an upstream DNS
+// server that silently drops queries). Write succeeds so the bootstrap
+// handshake completes.
+type blockingStream struct {
+	mu     sync.Mutex
+	closed bool
+	wake   chan struct{}
+}
+
+func newBlockingStream() *blockingStream {
+	return &blockingStream{wake: make(chan struct{})}
+}
+
+func (s *blockingStream) Read(p []byte) (int, error) {
+	<-s.wake
+	return 0, net.ErrClosed
+}
+
+func (s *blockingStream) Write(p []byte) (int, error) { return len(p), nil }
+
+func (s *blockingStream) CloseWrite() error { return nil }
+
+func (s *blockingStream) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		s.closed = true
+		close(s.wake)
+	}
+	return nil
+}
+
+func (s *blockingStream) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+var _ transport.Stream = (*blockingStream)(nil)
+
+const testDNSRespTimeout = 200 * time.Millisecond
+
+// newTimeoutTestServer builds a Socks5Server whose proxied-DNS exchanges run
+// with testDNSRespTimeout and whose transport serves the given streams.
+func newTimeoutTestServer(t *testing.T, streams []transport.Stream) *Socks5Server {
+	t.Helper()
+	h := newTestStreamHandler(&mockTransport{streams: streams})
+	srv, err := NewSocks5Server("127.0.0.1:0", "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, testDNSRespTimeout, nil)
+	if err != nil {
+		t.Fatalf("NewSocks5Server: %v", err)
+	}
+	return srv
+}
+
+func (s *Socks5Server) hasExchange(key string) bool {
+	s.udpMu.RLock()
+	defer s.udpMu.RUnlock()
+	_, ok := s.udpExch[key]
+	return ok
+}
+
+// waitExchangeReaped polls until the key disappears from s.udpExch (the
+// receiveLoop defer removes it) or the deadline expires.
+func waitExchangeReaped(t *testing.T, s *Socks5Server, key string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for s.hasExchange(key) {
+		if time.Now().After(deadline) {
+			t.Fatalf("exchange %q not reaped within deadline", key)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestUDPExchangeDNSResponseTimeout verifies that a proxied-DNS exchange
+// with no server response is closed (stream closed, key removed) once
+// dnsRespTimeout elapses, so silent upstream DNS servers cannot pile up
+// HTTP/2 streams and receiveLoop goroutines.
+func TestUDPExchangeDNSResponseTimeout(t *testing.T) {
+	bs := newBlockingStream()
+	srv := newTimeoutTestServer(t, []transport.Stream{bs})
+
+	key := "127.0.0.1:12345_8.8.8.8:53"
+	ue, created, err := srv.getOrCreateUDPExchange(key, "8.8.8.8:53", []byte("dns query payload"))
+	if err != nil {
+		t.Fatalf("getOrCreateUDPExchange: %v", err)
+	}
+	if !created {
+		t.Fatal("expected exchange to be created")
+	}
+
+	clientAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
+	go srv.receiveLoop(ue, nil, clientAddr, "8.8.8.8:53", key, srv.dnsRespTimeout)
+
+	if !srv.hasExchange(key) {
+		t.Fatal("expected exchange to be registered before the timeout")
+	}
+
+	waitExchangeReaped(t, srv, key)
+
+	if !bs.isClosed() {
+		t.Error("expected exchange stream to be closed after response timeout")
+	}
+}
+
+// TestUDPExchangeNoTimeoutWhenDisabled verifies that respTimeout=0 (the
+// non-DNS UDP path) leaves the exchange untouched even past dnsRespTimeout:
+// a long downlink silence must not kill regular UDP sessions.
+func TestUDPExchangeNoTimeoutWhenDisabled(t *testing.T) {
+	bs := newBlockingStream()
+	srv := newTimeoutTestServer(t, []transport.Stream{bs})
+
+	key := "127.0.0.1:12345_8.8.8.8:443"
+	ue, created, err := srv.getOrCreateUDPExchange(key, "8.8.8.8:443", []byte("udp payload"))
+	if err != nil {
+		t.Fatalf("getOrCreateUDPExchange: %v", err)
+	}
+	if !created {
+		t.Fatal("expected exchange to be created")
+	}
+
+	clientAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
+	go srv.receiveLoop(ue, nil, clientAddr, "8.8.8.8:443", key, 0)
+
+	time.Sleep(testDNSRespTimeout * 2)
+	if !srv.hasExchange(key) {
+		t.Fatal("exchange must not be reaped when the response timeout is disabled")
+	}
+	if bs.isClosed() {
+		t.Error("stream must not be closed when the response timeout is disabled")
+	}
+
+	// Tear down: close the exchange so the blocked receiveLoop exits and
+	// the key is cleaned up, then wait for the goroutine to finish.
+	ue.Close() //nolint:errcheck
+	waitExchangeReaped(t, srv, key)
+}

--- a/cmd/easyss/easyss_test.go
+++ b/cmd/easyss/easyss_test.go
@@ -319,7 +319,7 @@ func newTestHarness(t *testing.T) *testHarness {
 
 	// Start SOCKS5 proxy
 	socksAddr := testServerAddr + ":" + strconv.Itoa(testSocks5Port)
-	socksServer, err := proxy.NewSocks5Server(socksAddr, "", "", handler, cli.Router(), "", method, true, dialTimeout, udpIdleTimeout, cli.DialContext)
+	socksServer, err := proxy.NewSocks5Server(socksAddr, "", "", handler, cli.Router(), "", method, true, dialTimeout, udpIdleTimeout, timeout/3, cli.DialContext)
 	require.NoError(t, err)
 	h.socksServer = socksServer
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -102,7 +102,7 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 			serverDomain = svr.Address
 		}
 		socksServer, err := proxy.NewSocks5Server(socksAddr, cfg.AuthUsername, cfg.AuthPassword,
-			streamHandler, cli.Router(), serverDomain, method, !cfg.Local.EnableQUIC, dialTimeout, udpIdleTimeout, cli.DialContext)
+			streamHandler, cli.Router(), serverDomain, method, !cfg.Local.EnableQUIC, dialTimeout, udpIdleTimeout, timeout/3, cli.DialContext)
 		if err != nil {
 			_ = cli.Close()
 			return nil, err


### PR DESCRIPTION
## 背景

代理 DNS 查询（经隧道发往 `config.ProxyDNSServer`）在服务端/上游 DNS 无响应时，exchange 会无限悬挂：查询发出后 `receiveLoop` 永远阻塞在 `ue.Receive()` 上，而客户端重试会通过 `Send` 持续刷新 `lastSeen`，导致 60s 的 idle 回收永远不会触发。上游 DNS 故障时，HTTP/2 流 + receiveLoop goroutine 可无限堆积（直到触发 128 上限的 LRU 颠簸）。

## 修复

对 **DNS 用途**的 UDP exchange 启用下行静默超时：

- `receiveLoop` 新增 `respTimeout` 参数：`time.AfterFunc` 超时后关闭 exchange（推 FIN，服务端同步回收 UDP socket），收到任何服务端数据则重置计时器；
- 超时后 exchange 从 map 移除，后续查询自动重建（表现为一次丢包+重建延迟，DNS 应用层重试自愈）；
- 超时值 = `timeout/3`（默认配置 30s/3 = **10s**），由 `runner` 传入，`Socks5Server` 新增 `dnsRespTimeout` 字段；
- 非 DNS UDP（`proxyUDPRelay` 传 0）行为完全不变，维持 60s 双向 idle 回收，避免误杀下行静默的合法长会话。

## 测试

- 新增 `client/proxy/udp_timeout_test.go`：
  - `TestUDPExchangeDNSResponseTimeout`：阻塞流模拟静默上游，断言超时后流被关闭、key 从 `s.udpExch` 移除；
  - `TestUDPExchangeNoTimeoutWhenDisabled`：`respTimeout=0` 时超过 2 倍超时窗口 exchange 仍存活。
- `go test ./client/... ./runner/... ./cmd/...` 全绿；`make lint` 0 issues。