### PR TITLE
feat: evict idle expiring/degraded slots faster

### DIFF
--- a/transport/http2/scheduler.go
+++ b/transport/http2/scheduler.go
@@ -32,17 +32,22 @@ import (
 //     heavy slots and finally degraded slots (worst candidate, last
 //     resort). Negative tiers are compared by weighted load — the active
 //     stream count times the compounded weight of the slot's negative
-//     marks (heavy ×2, expiring ×4, degraded ×6, see slotWeight), so 2
+//     marks (heavy ×2, expiring ×4, degraded ×8, see slotWeight), so 2
 //     streams on a heavy slot weigh like 4 healthy ones and 1 on a
-//     degraded slot like 6, while a heavy+expiring+degraded slot compounds
-//     to ×48. A slot only counts as full once its weighted load reaches
-//     the tier capacity, which doubles whenever the active layer is pushed
-//     to the next power-of-two multiple of the base — so a fully saturated
-//     pool keeps spreading load instead of piling onto one connection.
-//     A slot that is both degraded and expiring is classified as
-//     tierRetiring and never selected at all: it is due for rotation and
-//     confirmed slow, so new streams must not keep it alive — it drains to
-//     idle and the health loop retires it, replaced by a fresh connection.
+//     degraded slot like 8, while a heavy+expiring+degraded slot compounds
+//     to ×64. An idle slot (active == 0) carrying expiring or degraded
+//     marks still weighs its mark weight — never 0, see weightedActive:
+//     it must not look free, or new streams would keep the tired
+//     connection alive and postpone its eviction. A slot only counts as
+//     full once its weighted load reaches the tier capacity, which
+//     doubles whenever the active layer is pushed to the next power-of-two
+//     multiple of the base — so a fully saturated pool keeps spreading
+//     load instead of piling onto one connection. Slots due for eviction
+//     are never selected at all: a slot both degraded and expiring is
+//     classified as tierRetiring, and an idle slot carrying expiring or
+//     degraded marks is draining (see draining) — new streams must not
+//     keep either alive, they drain to idle and the health loop
+//     rotates/retires them, replaced by fresh connections.
 //
 //   - Growth prefers fresh connections over squeezing negative ones: when a
 //     pool's tiers are saturated it grows its own pool, and once a pool is
@@ -138,7 +143,8 @@ func (s *slotScheduler) poolOf(highPriority bool) *slotPool {
 //	tierExpiring  — rotation overdue, but the connection is likely still
 //	                fine: routing new streams onto it keeps it alive until
 //	                its stream gap, spreading same-batch re-dials instead of
-//	                clustering them;
+//	                clustering them; once idle the slot is draining and
+//	                excluded from selection so the rotation completes;
 //	tierHeavy     — heavy streams monopolize the TCP window, dragging any
 //	                sharing stream down with them (head-of-line blocking
 //	                under loss), yet the connection itself is healthy;
@@ -161,13 +167,14 @@ const (
 
 // Negative-mark load weights, shared by slotWeight (multiplicative) and
 // negativeScore (additive), so the severity order always stays aligned:
-// degraded 6 > expiring 4 > heavy 2. An expiring connection is worse than
+// degraded 8 > expiring 4 > heavy 2. An expiring connection is worse than
 // a merely heavy one — it is due for rotation and should be recycled
-// quickly — hence its weight sits above heavy's.
+// quickly — hence its weight sits above heavy's; degraded sits above both
+// so persistently slow connections are drained and retired first.
 const (
 	weightHeavy    = 2
 	weightExpiring = 4
-	weightDegraded = 6
+	weightDegraded = 8
 )
 
 // slotTierOf returns the tier a slot currently belongs to. Heavy+expiring
@@ -216,11 +223,14 @@ func negativeScore(s *transportSlot) int32 {
 // product of the shared negative-mark weights (weightHeavy, weightExpiring,
 // weightDegraded; no mark: 1). A stream on a heavy+expiring slot weighs
 // weightHeavy×weightExpiring = 8× a healthy stream, one on a
-// heavy+expiring+degraded slot 2×4×6 = 48× — multiple negative states
+// heavy+expiring+degraded slot 2×4×8 = 64× — multiple negative states
 // compound, so a slot is only considered full once its weighted load
 // reaches the pool's threshold. Expiring is weighted deliberately high
 // (4, above heavy's 2): the slot is due for rotation, so streams should
-// avoid it and let it go idle and be recycled quickly.
+// avoid it and let it go idle and be recycled quickly; degraded sits even
+// higher (8) so a slow connection reaches capacity with a single stream
+// and drains to retirement fast. The idle floor for expiring/degraded
+// marks is applied by weightedActive.
 func slotWeight(s *transportSlot) int32 {
 	w := int32(1)
 	if s.heavy.Load() > 0 {
@@ -236,9 +246,30 @@ func slotWeight(s *transportSlot) int32 {
 }
 
 // weightedActive returns the slot's weighted load: its active stream count
-// scaled by the compounded weight of all its negative marks.
+// scaled by the compounded weight of all its negative marks. An idle slot
+// (active == 0) carrying expiring or degraded marks counts as one stream,
+// so it weighs its mark weight (expiring 4, degraded 8, both 32) instead
+// of 0: without the floor it would look free and new streams would pile
+// onto it, keeping the tired connection alive and starving the health
+// loop's rotation/retirement. Heavy needs no floor: heavy > 0 implies at
+// least one active heavy stream (the mark is released exactly once per
+// stream on close), so a heavy-marked slot is never idle.
 func weightedActive(s *transportSlot) int32 {
-	return s.active.Load() * slotWeight(s)
+	n := s.active.Load()
+	if n == 0 && (s.expiring.Load() || s.degraded.Load()) {
+		n = 1
+	}
+	return n * slotWeight(s)
+}
+
+// draining reports whether the slot is idle (active == 0) while carrying
+// an expiring or degraded mark. Such a slot is due for eviction — rotation
+// or retirement — and must not be revived by new streams: the scheduler
+// excludes it from selection exactly like retiring slots, so it stays idle
+// until the health loop closes the connection. A draining slot is still
+// used as the absolute last resort when every live slot is negative.
+func draining(s *transportSlot) bool {
+	return s.active.Load() == 0 && (s.expiring.Load() || s.degraded.Load())
 }
 
 // pick returns the slot a new stream should use: the stream's class selects
@@ -266,7 +297,11 @@ func (s *slotScheduler) pick(highPriority bool) *transportSlot {
 		// would index its empty slot array.
 		if other := s.otherPool(pool); other.maxSlots > 0 {
 			otherSlot, otherSat := other.tieredSelect()
-			if !otherSat || otherSlot.active.Load() < slot.active.Load() {
+			// Borrow only when the sibling's fallback is strictly less
+			// loaded, compared in weighted load so negative marks are
+			// priced consistently (an idle draining slot must not look
+			// free to the borrow path either).
+			if !otherSat || weightedActive(otherSlot) < weightedActive(slot) {
 				return otherSlot
 			}
 		}
@@ -305,15 +340,16 @@ func (p *slotPool) saturatedIn(live int) bool {
 // expiring, heavy and degraded — and within a tier prefers the slot with
 // the fewest active streams, breaking ties by negativeScore. A tier only
 // accepts a slot whose weighted load (active × compounded negative-mark
-// weight, see slotWeight) stays below the
-// tier's capacity, which scales with the pressure level (see pressureLevel
-// and tierCap). Once every tier is full, the fallback piles onto the
-// least-loaded slot overall (by weighted load, uncapped): piling there
-// keeps load balanced instead of stacking every stream onto one crowded
-// healthy connection. Slots that are both degraded and expiring
-// (tierRetiring) are excluded from every search and from the fallback:
-// they are due for rotation and confirmed slow, so new streams must never
-// keep them alive — they drain to idle and are retired by the health loop.
+// weight, floored at the mark weight for idle negative slots, see
+// weightedActive) stays below the tier's capacity, which scales with the
+// pressure level (see pressureLevel and tierCap). Once every tier is full,
+// the fallback piles onto the least-loaded slot overall (by weighted load,
+// uncapped): piling there keeps load balanced instead of stacking every
+// stream onto one crowded healthy connection. Slots due for eviction are
+// excluded from every search and from the fallback: slots that are both
+// degraded and expiring (tierRetiring) and idle slots carrying expiring or
+// degraded marks (draining, see draining) — new streams must never keep
+// them alive, they drain to idle and the health loop rotates/retires them.
 func (p *slotPool) tieredSelectAt(live int, recordStats bool) (*transportSlot, bool) {
 	if live == 0 {
 		return p.slots[0], false
@@ -323,11 +359,13 @@ func (p *slotPool) tieredSelectAt(live int, recordStats bool) (*transportSlot, b
 
 	// consider picks the least-active, least-negative slot of one tier
 	// within the current capacity; it reports whether such a slot exists.
-	// Capacity is compared in weighted load: active × the compounded weight
-	// of the slot's negative marks, so a slot with 2 streams and one heavy
-	// mark (weight 4) is still open while the pool's threshold is 8 — only
-	// once every candidate slot's weighted load reaches the threshold does
-	// the pool grow.
+	// Capacity is compared in weighted load (active × the compounded weight
+	// of the slot's negative marks, floored at the mark weight for idle
+	// negative slots), so a slot with 2 streams and one heavy mark (weight
+	// 4) is still open while the pool's threshold is 8 — only once every
+	// candidate slot's weighted load reaches the threshold does the pool
+	// grow. Draining slots (idle with expiring/degraded marks) are skipped
+	// entirely: reviving them would postpone their rotation/retirement.
 	var best *transportSlot
 	consider := func(tier slotTier) bool {
 		cap := tierCap(tier, level, p.base)
@@ -339,13 +377,13 @@ func (p *slotPool) tieredSelectAt(live int, recordStats bool) (*transportSlot, b
 		var bestNeg int32 = math.MaxInt32
 		for i := 0; i < live; i++ {
 			sl := p.slots[i]
-			if slotTierOf(sl) != tier {
+			if slotTierOf(sl) != tier || draining(sl) {
+				continue
+			}
+			if weightedActive(sl) >= cap {
 				continue
 			}
 			a := sl.active.Load()
-			if a*slotWeight(sl) >= cap {
-				continue
-			}
 			neg := negativeScore(sl)
 			if a < bestActive || (a == bestActive && neg < bestNeg) {
 				best, bestActive, bestNeg = sl, a, neg
@@ -441,8 +479,8 @@ func floorLog2(v int32) int32 {
 //	level k>=1: every negative tier has cap = 2^(k-1)*base.
 //
 // At level 1 that means a heavy slot holds at most base/2 streams, an
-// expiring one base/4, a degraded one base/6 — 2 heavy streams count like
-// 4 healthy ones, 1 degraded like 6, 1 expiring like 4. Every level-up
+// expiring one base/4, a degraded one base/8 — 2 heavy streams count like
+// 4 healthy ones, 1 degraded like 8, 1 expiring like 4. Every level-up
 // doubles the negative-tier
 // capacities: the model first spills onto the negative tiers, then piles
 // back onto the active layer until it doubles, then the negative-tier
@@ -508,15 +546,15 @@ func (p *slotPool) minActiveInRange(live int) int32 {
 // leastActive returns the slot with the fewest weighted streams among the
 // first `live` slots — the final uncapped fallback of the pressure
 // scheduler; among equally loaded slots the one with fewer negative marks
-// wins. Retiring slots (degraded+expiring) are excluded: they are due for
-// rotation and confirmed slow, so new streams must never keep them alive —
-// they drain to idle and the health loop retires them, replaced by fresh
-// connections via grow. When every live slot is retiring, the least-loaded
-// retiring slot is returned so pick never fails (the health loop retires
-// them within a tick or two, closing the window). With no live slots the
-// first pre-allocated slot is returned. recordStats gates the
-// tier_retiring_skipped counter (the grow path's saturation check must not
-// record scheduling stats).
+// wins. Slots due for eviction are excluded: retiring slots (degraded and
+// expiring) and draining slots (idle with expiring or degraded marks) must
+// never be kept alive by new streams — they drain to idle and the health
+// loop rotates/retires them, replaced by fresh connections via grow. When
+// every live slot is due for eviction, the least-loaded such slot is
+// returned so pick never fails (the health loop retires them within a tick
+// or two, closing the window). With no live slots the first pre-allocated
+// slot is returned. recordStats gates the tier_retiring_skipped counter
+// (the grow path's saturation check must not record scheduling stats).
 func (p *slotPool) leastActive(live int, recordStats bool) *transportSlot {
 	if live == 0 {
 		return p.slots[0]
@@ -524,19 +562,25 @@ func (p *slotPool) leastActive(live int, recordStats bool) *transportSlot {
 	var best *transportSlot
 	var minWeighted int32 = math.MaxInt32
 	var minNeg int32 = math.MaxInt32
-	var retiring *transportSlot // least-loaded retiring slot, absolute last resort
-	var retWeighted int32 = math.MaxInt32
-	var retNeg int32 = math.MaxInt32
+	var lastResort *transportSlot // least-loaded retiring/draining slot, absolute last resort
+	var resWeighted int32 = math.MaxInt32
+	var resNeg int32 = math.MaxInt32
 	for i := 0; i < live; i++ {
 		sl := p.slots[i]
 		w := weightedActive(sl)
 		neg := negativeScore(sl)
-		if slotTierOf(sl) == tierRetiring {
-			if recordStats {
+		tier := slotTierOf(sl)
+		if tier == tierRetiring || draining(sl) {
+			if recordStats && tier == tierRetiring {
 				stats.RecordTierRetiringSkipped()
 			}
-			if w < retWeighted || (w == retWeighted && neg < retNeg) {
-				retiring, retWeighted, retNeg = sl, w, neg
+			// Among equally loaded last-resort candidates a busy slot wins
+			// over a draining one: the draining slot stays idle and is
+			// evicted by the health loop instead of being revived.
+			better := w < resWeighted ||
+				(w == resWeighted && (neg < resNeg || (neg == resNeg && !draining(sl) && draining(lastResort))))
+			if better {
+				lastResort, resWeighted, resNeg = sl, w, neg
 			}
 			continue
 		}
@@ -546,7 +590,7 @@ func (p *slotPool) leastActive(live int, recordStats bool) *transportSlot {
 		best, minWeighted, minNeg = sl, w, neg
 	}
 	if best == nil {
-		return retiring
+		return lastResort
 	}
 	return best
 }

--- a/transport/http2/scheduler_bench_test.go
+++ b/transport/http2/scheduler_bench_test.go
@@ -78,13 +78,13 @@ func pickSaturation(sch *slotScheduler, mode string) {
 		sch.priority.slots[1].active.Store(4)
 		sch.priority.slots[2].active.Store(2) // heavy: 2×2 = 4 ≥ base 4
 		sch.priority.slots[3].active.Store(1) // expiring: 1×4 = 4 ≥ base 4
-		sch.priority.slots[4].active.Store(1) // degraded: 1×6 = 6 ≥ base 4
+		sch.priority.slots[4].active.Store(1) // degraded: 1×8 = 8 ≥ base 4
 		for i := 0; i < 3; i++ {
 			sch.bulk.slots[i].active.Store(8)
 		}
 		sch.bulk.slots[3].active.Store(4) // heavy: 4×2 = 8 ≥ base 8
 		sch.bulk.slots[4].active.Store(2) // expiring: 2×4 = 8 ≥ base 8
-		sch.bulk.slots[5].active.Store(2) // degraded: 2×6 = 12 ≥ base 8
+		sch.bulk.slots[5].active.Store(2) // degraded: 2×8 = 16 ≥ base 8
 	}
 }
 

--- a/transport/http2/scheduler_test.go
+++ b/transport/http2/scheduler_test.go
@@ -214,9 +214,10 @@ func TestTierCap(t *testing.T) {
 		{tierActive, 0, 8, 8},   // level 0: active holds up to the base
 		{tierActive, 1, 8, 0},   // level>=1: active is served by fallback only
 		{tierExpiring, 0, 8, 0}, // negative tiers disabled at level 0
-		// Weighted-load capacities at level 1: expiring/heavy slots hold
-		// base/2 streams (weight 2), degraded base/4 (weight 4) — 2 heavy
-		// streams count like 4 healthy ones, 1 degraded like 4.
+		// Weighted-load capacities at level 1: a heavy slot holds at most
+		// base/2 streams (weight 2), an expiring one base/4 (weight 4), a
+		// degraded one base/8 (weight 8) — 2 heavy streams count like 4
+		// healthy ones, 1 degraded like 8, 1 expiring like 4.
 		{tierExpiring, 1, 8, 8},
 		{tierHeavy, 1, 8, 8},
 		{tierDegraded, 1, 8, 8},
@@ -241,20 +242,29 @@ func TestWeightedActive(t *testing.T) {
 		{"healthy weighs 1", func(s *transportSlot) {}, 4, 4},
 		{"expiring weighs 4", func(s *transportSlot) { s.expiring.Store(true) }, 2, 8},
 		{"heavy weighs 2", func(s *transportSlot) { s.heavy.Store(1) }, 2, 4},
-		{"degraded weighs 6", func(s *transportSlot) { s.degraded.Store(true) }, 1, 6},
+		{"degraded weighs 8", func(s *transportSlot) { s.degraded.Store(true) }, 1, 8},
+		{"expiring idle floors to 4", func(s *transportSlot) { s.expiring.Store(true) }, 0, 4},
+		{"degraded idle floors to 8", func(s *transportSlot) { s.degraded.Store(true) }, 0, 8},
+		{"expiring and degraded idle compound to 32", func(s *transportSlot) {
+			s.expiring.Store(true)
+			s.degraded.Store(true)
+		}, 0, 32},
+		{"heavy idle stays 0 (heavy implies an active stream)", func(s *transportSlot) {
+			s.heavy.Store(1)
+		}, 0, 0},
 		{"heavy and expiring compound to 8", func(s *transportSlot) {
 			s.heavy.Store(1)
 			s.expiring.Store(true)
 		}, 2, 16},
-		{"heavy and degraded compound to 12", func(s *transportSlot) {
+		{"heavy and degraded compound to 16", func(s *transportSlot) {
 			s.heavy.Store(1)
 			s.degraded.Store(true)
-		}, 1, 12},
-		{"all marks compound to 48", func(s *transportSlot) {
+		}, 1, 16},
+		{"all marks compound to 128", func(s *transportSlot) {
 			s.heavy.Store(1)
 			s.expiring.Store(true)
 			s.degraded.Store(true)
-		}, 2, 96}, // 2 streams × 2(heavy) × 4(expiring) × 6(degraded)
+		}, 2, 128}, // 2 streams × 2(heavy) × 4(expiring) × 8(degraded)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -323,14 +333,17 @@ func TestTieredSelectLevel1(t *testing.T) {
 		}
 	})
 
-	t.Run("heavy full (base/2) spills onto degraded below base/4", func(t *testing.T) {
+	t.Run("degraded slot with one stream is already full at bulk level 1", func(t *testing.T) {
 		p := newTestPool(8, [2]int32{8, 0}, [2]int32{4, 0}, [2]int32{4, 0}, [2]int32{1, 0})
 		p.slots[1].expiring.Store(true)
 		p.slots[2].heavy.Store(1)
 		p.slots[3].degraded.Store(true)
+		// One degraded stream weighs 8 = the tier capacity: the degraded
+		// tier is full, so the pool falls back to the least-loaded slot —
+		// the healthy one (ties broken by negativeScore).
 		slot, saturated := p.tieredSelect()
-		if saturated || slot != p.slots[3] {
-			t.Fatalf("got slot %d saturated=%v, want degraded slot 3 (active=1, weighted 4 < 8)", slot.idx, saturated)
+		if !saturated || slot != p.slots[0] {
+			t.Fatalf("got slot %d saturated=%v, want fallback slot 0 with saturated=true", slot.idx, saturated)
 		}
 	})
 
@@ -381,7 +394,9 @@ func TestTieredSelectPrefersLessNegative(t *testing.T) {
 	})
 
 	t.Run("among degraded slots prefers degraded-only over degraded+heavy", func(t *testing.T) {
-		p := newTestPool(8, [2]int32{8, 0}, [2]int32{1, 0}, [2]int32{1, 1})
+		// Level 2 (capacity 16): a single degraded stream (weighted 8) is
+		// still open, while degraded+heavy (weighted 16) is full.
+		p := newTestPool(8, [2]int32{16, 0}, [2]int32{1, 0}, [2]int32{1, 1})
 		p.slots[1].degraded.Store(true)
 		p.slots[2].degraded.Store(true)
 		slot, saturated := p.tieredSelect()
@@ -393,18 +408,21 @@ func TestTieredSelectPrefersLessNegative(t *testing.T) {
 
 func TestTieredSelectExcludesRetiring(t *testing.T) {
 	t.Run("degraded tier prefers degraded-only over idle retiring", func(t *testing.T) {
-		p := newTestPool(8, [2]int32{8, 0}, [2]int32{4, 0}, [2]int32{4, 0}, [2]int32{0, 0}, [2]int32{1, 0})
+		// Level 2 (capacity 16): the expiring/heavy tiers are full and a
+		// single degraded stream (weighted 8 < 16) is still open; the idle
+		// retiring slot is excluded and must not win the tier.
+		p := newTestPool(8, [2]int32{16, 0}, [2]int32{4, 0}, [2]int32{8, 0}, [2]int32{0, 0}, [2]int32{1, 0})
 		p.slots[1].expiring.Store(true)
 		p.slots[2].heavy.Store(1)
 		p.slots[3].degraded.Store(true)
-		p.slots[3].expiring.Store(true) // idle retiring slot: weighted load 0
+		p.slots[3].expiring.Store(true) // idle retiring slot: excluded
 		p.slots[4].degraded.Store(true)
-		// The idle retiring slot must NOT win the degraded tier: even
-		// though its weighted load is 0, retiring slots are excluded, so
-		// the degraded-only slot hosting one stream is picked.
+		// The idle retiring slot must NOT win the degraded tier: retiring
+		// slots are excluded, so the degraded-only slot hosting one stream
+		// is picked.
 		slot, saturated := p.tieredSelect()
 		if saturated || slot != p.slots[4] {
-			t.Fatalf("got slot %d saturated=%v, want degraded-only slot 4 (active=1, weighted 6 < 8)", slot.idx, saturated)
+			t.Fatalf("got slot %d saturated=%v, want degraded-only slot 4 (active=1, weighted 8 < 16)", slot.idx, saturated)
 		}
 	})
 
@@ -431,22 +449,125 @@ func TestTieredSelectExcludesRetiring(t *testing.T) {
 		p.slots[1].degraded.Store(true)
 		p.slots[1].expiring.Store(true)
 		// No alternative exists: pick must never fail, so the least-loaded
-		// retiring slot is returned (the health loop retires both shortly).
+		// retiring slot is returned (the health loop retires both shortly);
+		// the idle one (floored weight 64) wins over the busy one (128).
 		slot, saturated := p.tieredSelect()
 		if !saturated || slot != p.slots[1] {
 			t.Fatalf("got slot %d saturated=%v, want least-loaded retiring slot 1", slot.idx, saturated)
 		}
 	})
+
+	t.Run("all live slots retiring prefers the busy slot on a tie", func(t *testing.T) {
+		p := newTestPool(8, [2]int32{1, 0}, [2]int32{0, 0})
+		p.slots[0].degraded.Store(true)
+		p.slots[0].expiring.Store(true)
+		p.slots[1].degraded.Store(true)
+		p.slots[1].expiring.Store(true)
+		// Both weigh 64 (the idle slot is floored at its mark weight): the
+		// tie goes to the busy slot, so the idle one stays idle and is
+		// retired by the health loop instead of being revived.
+		slot, saturated := p.tieredSelect()
+		if !saturated || slot != p.slots[0] {
+			t.Fatalf("got slot %d saturated=%v, want busy retiring slot 0", slot.idx, saturated)
+		}
+	})
+}
+
+func TestTieredSelectDraining(t *testing.T) {
+	t.Run("idle expiring slot is not revived at bulk level 1", func(t *testing.T) {
+		p := newTestPool(8, [2]int32{8, 0}, [2]int32{0, 0})
+		p.slots[1].expiring.Store(true)
+		// The healthy slot is at the base (level 1) and the expiring slot
+		// is idle — draining: the tier search skips it and the fallback
+		// excludes it, so the stream lands on the healthy slot and the
+		// pool reports saturated (grow then dials a fresh connection
+		// instead of reviving the tired one).
+		slot, saturated := p.tieredSelect()
+		if !saturated || slot != p.slots[0] {
+			t.Fatalf("got slot %d saturated=%v, want healthy slot 0 with saturated=true", slot.idx, saturated)
+		}
+	})
+
+	t.Run("busy degraded slot preferred over idle degraded slot", func(t *testing.T) {
+		// Level 2 (capacity 16): a single degraded stream (weighted 8) is
+		// still open; the idle one is draining and skipped.
+		p := newTestPool(8, [2]int32{16, 0}, [2]int32{1, 0}, [2]int32{0, 0})
+		p.slots[1].degraded.Store(true)
+		p.slots[2].degraded.Store(true)
+		slot, saturated := p.tieredSelect()
+		if saturated || slot != p.slots[1] {
+			t.Fatalf("got slot %d saturated=%v, want busy degraded slot 1", slot.idx, saturated)
+		}
+	})
+
+	t.Run("uncapped fallback excludes idle negative slots", func(t *testing.T) {
+		p := newTestPool(8, [2]int32{8, 0}, [2]int32{4, 0}, [2]int32{4, 0}, [2]int32{2, 0}, [2]int32{0, 0})
+		p.slots[1].expiring.Store(true)
+		p.slots[2].heavy.Store(1)
+		p.slots[3].degraded.Store(true)
+		p.slots[4].expiring.Store(true)
+		// Every tier is at capacity; the idle expiring slot (weighted 4)
+		// would be the globally least-loaded slot, but it is draining and
+		// must be passed over in favor of the least-loaded healthy slot.
+		slot, saturated := p.tieredSelect()
+		if !saturated || slot != p.slots[0] {
+			t.Fatalf("got slot %d saturated=%v, want fallback slot 0 with saturated=true", slot.idx, saturated)
+		}
+	})
+
+	t.Run("all live slots draining returns the least-loaded draining slot", func(t *testing.T) {
+		p := newTestPool(8, [2]int32{0, 0}, [2]int32{0, 0})
+		p.slots[0].expiring.Store(true)
+		p.slots[1].degraded.Store(true)
+		// No alternative exists: pick must never fail, so the least-loaded
+		// draining slot is returned (the health loop rotates/retires them
+		// shortly); the idle expiring slot (weight 4) wins over the idle
+		// degraded one (weight 8).
+		slot, saturated := p.tieredSelect()
+		if !saturated || slot != p.slots[0] {
+			t.Fatalf("got slot %d saturated=%v, want least-loaded draining slot 0", slot.idx, saturated)
+		}
+	})
+}
+
+func TestGrowReplacesDrainingSlot(t *testing.T) {
+	// A healthy slot at the base plus an idle expiring slot: the draining
+	// slot is excluded from selection, so the pool counts as saturated and
+	// a fresh connection is grown instead of reviving the tired one.
+	sch := newGrowTestScheduler(10, 5, 0, 2)
+	sch.bulk.slots[0].active.Store(8)
+	sch.bulk.slots[1].expiring.Store(true)
+	sch.grow(false)
+	if got := sch.bulk.liveCount.Load(); got != 3 {
+		t.Fatalf("bulk liveCount = %d, want 3 (fresh connection replaces the draining slot)", got)
+	}
+}
+
+func TestPickDoesNotBorrowDrainingSlot(t *testing.T) {
+	sch := newTwoPoolScheduler(
+		[][2]int32{{4, 0}}, // priority pool saturated at base 4
+		[][2]int32{{8, 0}, {0, 0}},
+	)
+	sch.bulk.slots[1].expiring.Store(true)
+	// The bulk pool's only non-draining slot is at the base; the idle
+	// expiring slot is draining and must not be borrowed — the stream
+	// stays on the own pool's fallback.
+	if got := sch.pick(true); got != sch.priority.slots[0] {
+		t.Fatalf("pick(true) = slot %d, want own pool fallback slot 0", got.idx)
+	}
 }
 
 func TestTieredSelectNoHealthyEngagesLowerTiers(t *testing.T) {
-	t.Run("all expiring picks least-active below base/2", func(t *testing.T) {
+	t.Run("all expiring picks the busy slot over the idle draining one", func(t *testing.T) {
 		p := newTestPool(8, [2]int32{0, 0}, [2]int32{1, 0})
 		p.slots[0].expiring.Store(true)
 		p.slots[1].expiring.Store(true)
+		// Slot 0 is idle and expiring — draining: new streams must not
+		// revive it (reviving would postpone its rotation), so the busy
+		// expiring slot 1 is picked instead.
 		slot, saturated := p.tieredSelect()
-		if saturated || slot != p.slots[0] {
-			t.Fatalf("got slot %d saturated=%v, want expiring slot 0", slot.idx, saturated)
+		if saturated || slot != p.slots[1] {
+			t.Fatalf("got slot %d saturated=%v, want busy expiring slot 1", slot.idx, saturated)
 		}
 	})
 
@@ -567,7 +688,7 @@ func TestPickExcludesRetiringInBorrow(t *testing.T) {
 		}
 	})
 
-	t.Run("all bulk slots retiring still borrows the least-loaded one", func(t *testing.T) {
+	t.Run("all bulk slots retiring keeps the own pool fallback", func(t *testing.T) {
 		sch := newTwoPoolScheduler(
 			[][2]int32{{4, 0}},
 			[][2]int32{{1, 0}, {0, 0}},
@@ -576,10 +697,12 @@ func TestPickExcludesRetiringInBorrow(t *testing.T) {
 		sch.bulk.slots[0].expiring.Store(true)
 		sch.bulk.slots[1].degraded.Store(true)
 		sch.bulk.slots[1].expiring.Store(true)
-		// No non-retiring slot exists anywhere: the least-loaded retiring
-		// bulk slot is the absolute last resort (pick never fails).
-		if got := sch.pick(true); got != sch.bulk.slots[1] {
-			t.Fatalf("pick(true) = slot %d, want least-loaded retiring bulk slot 1", got.idx)
+		// The bulk pool is entirely retiring: its fallback (the busy slot,
+		// weighted 64 — the idle one is floored to the same 64) outweighs
+		// the own pool's fallback (weighted 4), so the stream stays in the
+		// own pool instead of reviving a doomed connection.
+		if got := sch.pick(true); got != sch.priority.slots[0] {
+			t.Fatalf("pick(true) = slot %d, want own pool fallback slot 0", got.idx)
 		}
 	})
 }


### PR DESCRIPTION
## 背景

带 expiring/degraded 标记的 slot 在空闲（active==0）时，加权负载为 0，成为调度器眼中最"轻"的目标：tier 搜索、leastActive 兜底、跨池借用都会把新流放上去，导致活跃流持续霸占 slot，底层连接迟迟无法被轮换/淘汰。

## 改动（transport/http2/scheduler.go）

1. **空闲权重下限**：空闲且带 expiring/degraded 标记的 slot 按 1 个流计权（expiring 4、degraded 8、组合 32），不再为 0。
2. **degraded 权重 6 → 8**：bulk 池（base=8）压力级别 1 时，degraded slot 仅 1 个流即达容量，不再接收新流，更快排空淘汰。
3. **调度排除（draining）**：空闲且带 expiring 或 degraded 标记的 slot 与 retiring 一致，从 tier 搜索与 leastActive 兜底中排除（仅当所有 live slot 均负面时作为最后手段返回，pick 永不失败）；池因此饱和时按既有逻辑 grow 新连接顶替。
4. **跨池借用改按加权负载比较**：负面标记在所有路径统一定价，空闲负面 slot 不会被当作"0 负载"借走。

heavy 无需调整：heavy 是活跃 heavy 流计数器，heavy>0 意味着至少一个活跃流，不存在"heavy 且空闲"状态。

## 测试

- TestWeightedActive 增加空闲下限与 heavy 不变式用例；
- 新增 TestTieredSelectDraining / TestGrowReplacesDrainingSlot / TestPickDoesNotBorrowDrainingSlot；
- 更新受权重变化影响的既有用例（degraded 1 流即满等）。