### PR TITLE
fix: recover TUN direct connections after macOS sleep/wake

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,12 +2,15 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
+	"github.com/libp2p/go-netroute"
 	"github.com/nange/easyss/v3/client/config"
 	"github.com/nange/easyss/v3/client/dns"
 	"github.com/nange/easyss/v3/client/router"
@@ -27,10 +30,57 @@ type Client struct {
 	shaperCfg     shaper.Config
 	masterKey     []byte
 	dialer        atomic.Pointer[dialer.Dialer]
+	bound         atomic.Value // boundIface: the interface the direct dialer is bound to
 	closeIdleDone chan struct{}
 	closeOnce     sync.Once
 
 	mu sync.RWMutex
+}
+
+// boundIface records the interface the direct dialer is currently bound to,
+// so the refresh loop can detect a change (name or index) and rebuild it.
+type boundIface struct {
+	name  string
+	index int
+}
+
+// detectDialIface returns the interface that TUN-mode direct dials should be
+// bound to: the system's default-route interface. It probes a destination in
+// 0.0.0.0/8, which the easyss TUN routes never cover (the darwin create
+// script starts at 1.0.0.0/8), so the lookup yields the physical default
+// interface even while TUN routes are active — binding to the easyss TUN
+// device itself would create a routing loop. Overridable in tests.
+var detectDialIface = func() (*net.Interface, error) {
+	r, err := netroute.New()
+	if err != nil {
+		return nil, err
+	}
+	iface, _, _, err := r.Route(net.IPv4(0, 0, 0, 1))
+	if err != nil {
+		return nil, err
+	}
+	if iface == nil {
+		return nil, errors.New("no interface for default route")
+	}
+	if iface.Flags&net.FlagUp == 0 {
+		return nil, fmt.Errorf("default interface %s is down", iface.Name)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("read addresses of %s: %w", iface.Name, err)
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.IsGlobalUnicast() {
+			return iface, nil
+		}
+	}
+	return nil, fmt.Errorf("default interface %s has no global unicast address", iface.Name)
+}
+
+// boundDialContext dials through the interface-bound direct dialer. It is a
+// package-level var so tests can inject failures deterministically.
+var boundDialContext = func(c *Client, ctx context.Context, network, addr string) (net.Conn, error) {
+	return c.dialer.Load().DialContext(ctx, network, addr)
 }
 
 func New(cfg *config.ClientConfig) (*Client, error) {
@@ -65,7 +115,6 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 	)
 
 	tlsCfg := cfg.UTLSConfig()
-	directDialer, directIface := newDirectDialer()
 
 	shaperCfg := shaper.Config{
 		BatchWindowMS: cfg.Shaper.BatchWindowMS,
@@ -82,7 +131,18 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 		masterKey:     masterKey,
 		closeIdleDone: make(chan struct{}),
 	}
-	client.dialer.Store(directDialer)
+	client.bound.Store(boundIface{})
+
+	directIface := ""
+	iface, err := detectDialIface()
+	if err != nil {
+		log.Warn("[CLIENT] detect default interface failed", "err", err)
+		client.dialer.Store(dialer.New())
+	} else {
+		client.dialer.Store(dialer.New(dialer.WithBindToInterface(iface)))
+		client.bound.Store(boundIface{name: iface.Name, index: iface.Index})
+		directIface = iface.Name
+	}
 
 	probeToken, err := crypto.ProbeToken(masterKey)
 	if err != nil {
@@ -100,7 +160,7 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 		Timeout:           cfg.TimeoutDuration(),
 		ProbeToken:        probeToken,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return dialWithConfig(ctx, cfg, client.dialer.Load(), rt, network, addr)
+			return client.dialWithConfig(ctx, network, addr)
 		},
 	})
 	if err != nil {
@@ -112,28 +172,17 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 	log.Info("[CLIENT] transport initialized", "server_url", cfg.ServerURL(), "max_slots", cfg.Transport.ConnCountMax, "stream_threshold", cfg.Transport.StreamThreshold, "server_addr", cfg.DefaultServerAddr(), "direct_iface", directIface)
 
 	go client.closeIdleLoop()
+	go client.dialerRefreshLoop()
 
 	return client, nil
 }
 
-func newDirectDialer() (*dialer.Dialer, string) {
-	_, dev, err := util.SysGatewayAndDevice()
-	if err != nil || dev == "" {
-		log.Warn("[CLIENT] detect default interface failed", "err", err)
-		return dialer.New(), ""
-	}
-
-	iface, err := net.InterfaceByName(dev)
-	if err != nil {
-		log.Warn("[CLIENT] load default interface failed", "name", dev, "err", err)
-		return dialer.New(), ""
-	}
-
-	return dialer.New(dialer.WithBindToInterface(iface)), dev
-}
-
-func dialWithConfig(ctx context.Context, cfg *config.ClientConfig, d *dialer.Dialer, rt *router.Router, network, addr string) (net.Conn, error) {
-	if rt.ShouldIPV6Disable() {
+// dialWithConfig dials with the interface-bound direct dialer when TUN mode
+// is active (so the socket bypasses the TUN device), falling back to a plain
+// net.Dialer otherwise. A failure that looks like a stale interface binding
+// (sleep/wake, network switch) triggers a one-shot dialer refresh and retry.
+func (c *Client) dialWithConfig(ctx context.Context, network, addr string) (net.Conn, error) {
+	if c.router.ShouldIPV6Disable() {
 		switch network {
 		case "tcp":
 			network = "tcp4"
@@ -142,7 +191,7 @@ func dialWithConfig(ctx context.Context, cfg *config.ClientConfig, d *dialer.Dia
 		}
 	}
 
-	if cfg.Local.EnableTun2socks && d != nil {
+	if c.cfg.Local.EnableTun2socks && c.dialer.Load() != nil {
 		// Force specific IP version so the direct dialer's socket-binding
 		// (IP_BOUND_IF) is applied. The dialer only handles "tcp4"/"udp4",
 		// not dual-stack "tcp"/"udp".
@@ -166,13 +215,92 @@ func dialWithConfig(ctx context.Context, cfg *config.ClientConfig, d *dialer.Dia
 				}
 			}
 		}
-		return d.DialContext(ctx, network, addr)
+
+		conn, err := boundDialContext(c, ctx, network, addr)
+		if err == nil || !isInterfaceStaleError(err) {
+			return conn, err
+		}
+
+		// The bound interface went stale (sleep/wake, network switch): the
+		// interface captured at startup no longer routes. Re-detect the
+		// default interface, rebuild the dialer and retry once.
+		log.Warn("[CLIENT] direct dial failed, refreshing interface binding", "addr", addr, "err", err)
+		if c.refreshDirectDialer() {
+			return boundDialContext(c, ctx, network, addr)
+		}
+		return conn, err
 	}
 
 	nd := &net.Dialer{
-		KeepAlive: cfg.TimeoutDuration(),
+		KeepAlive: c.cfg.TimeoutDuration(),
 	}
 	return nd.DialContext(ctx, network, addr)
+}
+
+// refreshDirectDialer re-detects the default interface and rebuilds the
+// interface-bound direct dialer when the binding changed (name or index). It
+// reports whether the dialer was replaced. On detection failure the existing
+// dialer is kept so a transient network state cannot degrade connectivity
+// further.
+func (c *Client) refreshDirectDialer() bool {
+	iface, err := detectDialIface()
+	if err != nil {
+		log.Warn("[CLIENT] refresh direct dialer: detect interface failed", "err", err)
+		return false
+	}
+
+	prev, _ := c.bound.Load().(boundIface)
+	if prev.name == iface.Name && prev.index == iface.Index {
+		return false
+	}
+
+	c.dialer.Store(dialer.New(dialer.WithBindToInterface(iface)))
+	c.bound.Store(boundIface{name: iface.Name, index: iface.Index})
+	log.Info("[CLIENT] direct dialer rebound",
+		"iface", iface.Name, "index", iface.Index,
+		"prev_iface", prev.name, "prev_index", prev.index)
+	return true
+}
+
+// dialerRefreshLoop periodically re-detects the default interface so the
+// direct dialer's interface binding survives sleep/wake and network changes:
+// on macOS the interface captured at startup can go stale after the machine
+// wakes on a different network, breaking every direct dial until restart.
+// Only runs while TUN mode is active (the bound dialer is unused otherwise).
+func (c *Client) dialerRefreshLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if c.cfg.Local.EnableTun2socks {
+				c.refreshDirectDialer()
+			}
+		case <-c.closeIdleDone:
+			return
+		}
+	}
+}
+
+// isInterfaceStaleError reports whether err looks like the bound interface
+// went stale (interface removed, down, or unreachable), so the dialer can be
+// rebuilt and the dial retried.
+func isInterfaceStaleError(err error) bool {
+	if err == nil {
+		return false
+	}
+	for _, e := range []error{
+		syscall.ENETDOWN,
+		syscall.ENODEV,
+		syscall.ENETUNREACH,
+		syscall.EHOSTUNREACH,
+		syscall.EINVAL,
+	} {
+		if errors.Is(err, e) {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveServerIPV6(cfg *config.ClientConfig) string {
@@ -236,7 +364,7 @@ func (c *Client) Transport() transport.Transport {
 }
 
 func (c *Client) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	return dialWithConfig(ctx, c.cfg, c.dialer.Load(), c.router, network, addr)
+	return c.dialWithConfig(ctx, network, addr)
 }
 
 func (c *Client) MasterKey() []byte {
@@ -289,7 +417,9 @@ func (c *Client) DirectDialer() *dialer.Dialer {
 
 // SetDirectDialer replaces the transport's direct dialer. Used after
 // a server switch to preserve the original dialer that was created
-// before TUN routes were installed.
+// before TUN routes were installed. The recorded binding is reset so the
+// next refresh re-detects the current default interface.
 func (c *Client) SetDirectDialer(d *dialer.Dialer) {
 	c.dialer.Store(d)
+	c.bound.Store(boundIface{})
 }

--- a/client/dialer_test.go
+++ b/client/dialer_test.go
@@ -1,0 +1,234 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/nange/easyss/v3/client/config"
+	"github.com/nange/easyss/v3/client/router"
+	"github.com/xjasonlyu/tun2socks/v2/dialer"
+)
+
+func TestIsInterfaceStaleError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"enetdown", syscall.ENETDOWN, true},
+		{"enodev", syscall.ENODEV, true},
+		{"enetunreach", syscall.ENETUNREACH, true},
+		{"ehostunreach", syscall.EHOSTUNREACH, true},
+		{"einval", syscall.EINVAL, true},
+		{"refused", syscall.ECONNREFUSED, false},
+		{"timeout", context.DeadlineExceeded, false},
+		{"wrapped", fmt.Errorf("dial tcp: %w", syscall.ENETDOWN), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isInterfaceStaleError(c.err); got != c.want {
+				t.Fatalf("isInterfaceStaleError(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRefreshDirectDialer(t *testing.T) {
+	orig := detectDialIface
+	t.Cleanup(func() { detectDialIface = orig })
+
+	c := &Client{}
+	c.bound.Store(boundIface{name: "en0", index: 4})
+	c.dialer.Store(dialer.New())
+
+	en1 := &net.Interface{Index: 7, Name: "en1", Flags: net.FlagUp}
+
+	t.Run("interface changed", func(t *testing.T) {
+		detectDialIface = func() (*net.Interface, error) { return en1, nil }
+		if !c.refreshDirectDialer() {
+			t.Fatal("expected refresh to replace the dialer")
+		}
+		got, _ := c.bound.Load().(boundIface)
+		if got.name != "en1" || got.index != 7 {
+			t.Fatalf("bound = %+v, want en1/index 7", got)
+		}
+		if c.dialer.Load() == nil {
+			t.Fatal("dialer should not be nil after refresh")
+		}
+	})
+
+	t.Run("unchanged interface", func(t *testing.T) {
+		detectDialIface = func() (*net.Interface, error) { return en1, nil }
+		if c.refreshDirectDialer() {
+			t.Fatal("expected no refresh for the same interface")
+		}
+	})
+
+	t.Run("detection failure keeps old dialer", func(t *testing.T) {
+		detectDialIface = func() (*net.Interface, error) { return nil, errors.New("no route") }
+		if c.refreshDirectDialer() {
+			t.Fatal("expected no refresh on detection failure")
+		}
+		got, _ := c.bound.Load().(boundIface)
+		if got.name != "en1" {
+			t.Fatalf("bound = %+v, want previous en1 kept", got)
+		}
+	})
+}
+
+// newTestClient builds a minimal Client with a router and TUN mode toggled by
+// tunEnabled.
+func newTestClient(t *testing.T, tunEnabled bool) *Client {
+	t.Helper()
+
+	cfg := &config.ClientConfig{}
+	cfg.Local.EnableTun2socks = tunEnabled
+
+	rt, err := router.New(router.Config{})
+	if err != nil {
+		t.Fatalf("router.New: %v", err)
+	}
+
+	c := &Client{cfg: cfg, router: rt}
+	c.bound.Store(boundIface{name: "en0", index: 4})
+	c.dialer.Store(dialer.New())
+	return c
+}
+
+func TestDialWithConfigRefreshesAndRetriesOnStaleError(t *testing.T) {
+	origDetect := detectDialIface
+	origBound := boundDialContext
+	t.Cleanup(func() {
+		detectDialIface = origDetect
+		boundDialContext = origBound
+	})
+
+	c := newTestClient(t, true)
+
+	// The interface changed while we were "asleep".
+	detectDialIface = func() (*net.Interface, error) {
+		return &net.Interface{Index: 9, Name: "en9", Flags: net.FlagUp}, nil
+	}
+
+	calls := 0
+	boundDialContext = func(_ *Client, ctx context.Context, network, addr string) (net.Conn, error) {
+		calls++
+		if calls == 1 {
+			return nil, syscall.ENETDOWN
+		}
+		return &net.TCPConn{}, nil
+	}
+
+	conn, err := c.dialWithConfig(context.Background(), "tcp", "1.2.3.4:80")
+	if err != nil {
+		t.Fatalf("dialWithConfig: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("expected a connection after the refresh retry")
+	}
+	if calls != 2 {
+		t.Fatalf("bound dial calls = %d, want 2 (fail + retry)", calls)
+	}
+	got, _ := c.bound.Load().(boundIface)
+	if got.name != "en9" || got.index != 9 {
+		t.Fatalf("bound = %+v, want refreshed to en9/index 9", got)
+	}
+}
+
+func TestDialWithConfigNoRetryOnNonStaleError(t *testing.T) {
+	origDetect := detectDialIface
+	origBound := boundDialContext
+	t.Cleanup(func() {
+		detectDialIface = origDetect
+		boundDialContext = origBound
+	})
+
+	c := newTestClient(t, true)
+
+	detectDialIface = func() (*net.Interface, error) {
+		return &net.Interface{Index: 9, Name: "en9", Flags: net.FlagUp}, nil
+	}
+
+	calls := 0
+	boundDialContext = func(_ *Client, ctx context.Context, network, addr string) (net.Conn, error) {
+		calls++
+		return nil, syscall.ECONNREFUSED
+	}
+
+	conn, err := c.dialWithConfig(context.Background(), "tcp", "1.2.3.4:80")
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Fatalf("err = %v, want ECONNREFUSED", err)
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection")
+	}
+	if calls != 1 {
+		t.Fatalf("bound dial calls = %d, want 1 (no retry)", calls)
+	}
+	got, _ := c.bound.Load().(boundIface)
+	if got.name != "en0" {
+		t.Fatalf("bound = %+v, want previous en0 kept", got)
+	}
+}
+
+func TestDialWithConfigNoRefreshWhenBindingUnchanged(t *testing.T) {
+	origDetect := detectDialIface
+	origBound := boundDialContext
+	t.Cleanup(func() {
+		detectDialIface = origDetect
+		boundDialContext = origBound
+	})
+
+	c := newTestClient(t, true)
+
+	// Same interface as recorded at startup: refresh must not replace it,
+	// so the retry uses the same dialer.
+	detectDialIface = func() (*net.Interface, error) {
+		return &net.Interface{Index: 4, Name: "en0", Flags: net.FlagUp}, nil
+	}
+
+	calls := 0
+	boundDialContext = func(_ *Client, ctx context.Context, network, addr string) (net.Conn, error) {
+		calls++
+		if calls == 1 {
+			return nil, syscall.ENETDOWN
+		}
+		return &net.TCPConn{}, nil
+	}
+
+	_, err := c.dialWithConfig(context.Background(), "tcp", "1.2.3.4:80")
+	if !errors.Is(err, syscall.ENETDOWN) {
+		t.Fatalf("err = %v, want ENETDOWN from the first dial", err)
+	}
+	if calls != 1 {
+		t.Fatalf("bound dial calls = %d, want 1 (refresh found no change, no retry)", calls)
+	}
+}
+
+func TestDialWithConfigPlainPathWhenTunDisabled(t *testing.T) {
+	origBound := boundDialContext
+	t.Cleanup(func() { boundDialContext = origBound })
+
+	c := newTestClient(t, false)
+
+	called := false
+	boundDialContext = func(_ *Client, ctx context.Context, network, addr string) (net.Conn, error) {
+		called = true
+		return nil, errors.New("must not be used when TUN is disabled")
+	}
+
+	// The plain path uses a real socket: a refused loopback dial is fast
+	// and deterministic.
+	_, err := c.dialWithConfig(context.Background(), "tcp", "127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected connection refused")
+	}
+	if called {
+		t.Fatal("bound dial must not be used when TUN is disabled")
+	}
+}

--- a/client/tun/tun.go
+++ b/client/tun/tun.go
@@ -387,11 +387,14 @@ func (m *Manager) closeTunDevAndDelIPRoute() error {
 		namePath = newNamePath
 		_, _ = util.CommandContext(ctx, "cmd.exe", "/C", namePath, d.Device, d.TunGW)
 	case "darwin":
+		// Mirror the helper's runCloseScript argument order:
+		// device, tunGW, localGateway, tunGWV6, serverIPV6, localGatewayV6.
 		if os.Geteuid() == 0 {
-			_, _ = util.CommandContext(ctx, "sh", namePath, d.Device)
+			_, _ = util.CommandContext(ctx, "sh", namePath, d.Device, d.TunGW, d.LocalGateway,
+				d.TunGWV6, d.ServerIPV6, d.LocalGatewayV6)
 		} else {
-			cmd := fmt.Sprintf("do shell script \"sh %s %s\" with administrator privileges",
-				namePath, d.Device)
+			cmd := fmt.Sprintf("do shell script \"sh %s %s %s %s %s %s %s\" with administrator privileges",
+				namePath, d.Device, d.TunGW, d.LocalGateway, d.TunGWV6, d.ServerIPV6, d.LocalGatewayV6)
 			_, _ = util.CommandContext(ctx, "osascript", "-e", cmd)
 		}
 	}

--- a/cmd/easyss/tun_helper_darwin.go
+++ b/cmd/easyss/tun_helper_darwin.go
@@ -5,7 +5,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/nange/easyss/v3/client/proxy"
+	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/scripts"
 	"github.com/nange/easyss/v3/util"
 	"golang.org/x/sys/unix"
@@ -103,4 +106,34 @@ func runCloseScript(device, tunGW, localGateway, tunGWV6, serverIPV6, localGatew
 
 	_, _ = util.Command("sh", namePath, device, tunGW, localGateway, tunGWV6, serverIPV6, localGatewayV6)
 	return nil
+}
+
+// ensureTunRoutes verifies the TUN interface is still up and the TUN routes
+// are still present, re-running the create script when macOS cleared them
+// (sleep/wake or network changes). Errors from re-applying existing
+// configuration are tolerated: ifconfig and route only report "File exists".
+func ensureTunRoutes(device string, cfg *proxy.TunConfig) error {
+	needCreate := false
+
+	out, err := util.Command("ifconfig", device)
+	if err != nil || !strings.Contains(out, "UP") || !strings.Contains(out, cfg.TunIP) {
+		log.Warn("[TUN-HELPER] interface check failed", "device", device, "err", err)
+		needCreate = true
+	}
+
+	if !needCreate {
+		routeOut, err := util.Command("route", "-n", "get", tunRouteProbe)
+		if err != nil || !strings.Contains(routeOut, "interface: "+device) {
+			log.Warn("[TUN-HELPER] route check failed", "device", device, "probe", tunRouteProbe, "err", err, "output", routeOut)
+			needCreate = true
+		}
+	}
+
+	if !needCreate {
+		return nil
+	}
+
+	log.Info("[TUN-HELPER] recreating TUN routes", "device", device)
+	return runCreateScript(device, cfg.TunIP, cfg.TunGW, cfg.LocalGateway,
+		cfg.TunIPV6Sub, cfg.TunGWV6, cfg.ServerIPV6, cfg.LocalGatewayV6)
 }

--- a/cmd/easyss/tun_helper_linux.go
+++ b/cmd/easyss/tun_helper_linux.go
@@ -5,8 +5,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"unsafe"
 
+	"github.com/nange/easyss/v3/client/proxy"
+	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/scripts"
 	"github.com/nange/easyss/v3/util"
 	"golang.org/x/sys/unix"
@@ -99,4 +102,35 @@ func runCloseScript(device, tunGW, localGateway, tunGWV6, serverIPV6, localGatew
 
 	_, _ = util.Command("bash", namePath, device, tunGW, localGateway, tunGWV6, serverIPV6, localGatewayV6)
 	return nil
+}
+
+// ensureTunRoutes verifies the TUN interface is still up and the TUN routes
+// are still present, re-running the create script when they were cleared
+// (e.g. by NetworkManager after a connection change or sleep/wake). Errors
+// from re-applying existing configuration are tolerated: ip only reports
+// "File exists".
+func ensureTunRoutes(device string, cfg *proxy.TunConfig) error {
+	needCreate := false
+
+	out, err := util.Command("ip", "link", "show", device)
+	if err != nil || !strings.Contains(out, "UP") {
+		log.Warn("[TUN-HELPER] interface check failed", "device", device, "err", err)
+		needCreate = true
+	}
+
+	if !needCreate {
+		routeOut, err := util.Command("ip", "route", "get", tunRouteProbe)
+		if err != nil || !strings.Contains(routeOut, "dev "+device) {
+			log.Warn("[TUN-HELPER] route check failed", "device", device, "probe", tunRouteProbe, "err", err, "output", routeOut)
+			needCreate = true
+		}
+	}
+
+	if !needCreate {
+		return nil
+	}
+
+	log.Info("[TUN-HELPER] recreating TUN routes", "device", device)
+	return runCreateScript(device, cfg.TunIP, cfg.TunGW, cfg.LocalGateway,
+		cfg.TunIPV6Sub, cfg.TunGWV6, cfg.ServerIPV6, cfg.LocalGatewayV6)
 }

--- a/cmd/easyss/tun_helper_unix.go
+++ b/cmd/easyss/tun_helper_unix.go
@@ -124,11 +124,38 @@ func runTunHelper(httpAddr, fdSocketPath, logFilePath, logLevel string) int {
 	// 11. Block reading stdin until EOF. The main process closes the FIFO
 	//     write end to signal shutdown, or the kernel closes it if the main
 	//     process crashes (even on kill -9).
-	_, _ = io.ReadAll(os.Stdin)
+	//
+	//     While waiting, periodically verify the TUN routes are still in
+	//     place: macOS may clear non-persistent routes after sleep/wake or
+	//     network changes, which silently disables TUN mode (traffic stops
+	//     entering the device). The old tun-only daemon re-added routes
+	//     every 10s to survive sleep/wake (ba6c894); the ephemeral helper
+	//     keeps that behavior for the TUN routes themselves.
+	stdinDone := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(os.Stdin)
+		close(stdinDone)
+	}()
 
-	log.Info("[TUN-HELPER] received shutdown signal")
-	return 0
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stdinDone:
+			log.Info("[TUN-HELPER] received shutdown signal")
+			return 0
+		case <-ticker.C:
+			if err := ensureTunRoutes(actualDevice, cfg); err != nil {
+				log.Warn("[TUN-HELPER] route keep-alive check failed", "device", actualDevice, "err", err)
+			}
+		}
+	}
 }
+
+// tunRouteProbe is a destination covered by the TUN routes (the darwin/linux
+// create scripts start at 1.0.0.0/8), used to verify the routes are still
+// present after sleep/wake or network changes.
+const tunRouteProbe = "1.1.1.1"
 
 // fetchTunConfig retrieves the TUN configuration from the main process via
 // GET /tun. It retries with backoff for up to 10 seconds in case the HTTP

--- a/scripts/close_tun_dev_darwin.sh
+++ b/scripts/close_tun_dev_darwin.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 tun_device=$1
 tun_gw=$2
-local_gateway=$4
-tun_gw_v6=$5
-server_ip_v6=$6
-local_gateway_v6=$7
+local_gateway=$3
+tun_gw_v6=$4
+server_ip_v6=$5
+local_gateway_v6=$6
 
 route delete -net 1.0.0.0/8 "$tun_gw"
 route delete -net 2.0.0.0/7 "$tun_gw"


### PR DESCRIPTION
﻿## 背景

用户反馈：macOS 上开启 tun2socks 一段时间后（尤其是休眠唤醒后），直连网络失败不通。

## 根因

TUN 模式下"直连"流量链路为：App → utun9 → tun2socks → 本地 SOCKS5 → **启动时一次性创建、用 `IP_BOUND_IF` 绑定物理网卡索引的 dialer**。存在三个问题：

1. **直连 dialer 绑定过期（主因）**：dialer 在 `client.New()` 时创建并绑定当时的默认接口索引，休眠唤醒/网络切换后接口可能 down、消失或索引被复用，之后每个直连拨号立即失败，且无任何重检测/自愈机制，只能重启 easyss 恢复。
2. **路由保活机制丢失**：旧 tun-only 守护进程每 10s 重加一次路由以对抗 macOS 清除非持久化路由（ba6c894），该机制在 ephemeral helper 重构（#95）时随旧文件删除而丢失，当前 helper 创建路由后没有任何健康检查。
3. **darwin 关闭脚本参数错位**：`close_tun_dev_darwin.sh` 位置参数错位（`local_gateway=$4` 应为 `$3` 等），且 `tun.go` 非 helper 关闭路径只传了 device，导致关闭 TUN 时清理不干净。

## 改动

1. **client 层直连 dialer 自愈**（`client/client.go` + `client/dialer_test.go`）：
   - 用 netroute 探测 `0.0.0.1`（0.0.0.0/8 不在 TUN 路由覆盖内，天然不会绑回 easyss 自己的 utun 造成环路）重检测物理默认接口；
   - TUN 模式下每 30s 周期刷新；拨号失败若为 stale 类错误（`ENETDOWN/ENODEV/ENETUNREACH/EHOSTUNREACH/EINVAL`）立即刷新并重试一次；
   - 新增 6 个单元测试覆盖刷新路径与重试语义。
2. **helper 恢复路由保活**（`cmd/easyss/tun_helper_unix.go` + `tun_helper_darwin.go` + `tun_helper_linux.go`）：stdin 阻塞读改为 goroutine + 10s ticker，检查接口 UP 与路由存在（darwin：`ifconfig`/`route -n get`；linux：`ip link`/`ip route get`），缺失即重跑 create script。
3. **关闭脚本修正**（`scripts/close_tun_dev_darwin.sh` + `client/tun/tun.go`）：修正位置参数映射，darwin 关闭路径传全量参数。

## 验证

- `go test ./...` 全部通过
- `make lint`（golangci-lint）0 issues
- darwin（含 tray）、linux、windows 交叉编译通过

## 手动验收（macOS 真机）

1. 开启 TUN → 休眠唤醒（或切换 Wi-Fi/以太网）→ 直连 ≤30s 内恢复，无需重启 easyss；
2. 唤醒后 10s 内 helper 日志出现路由检查/重建记录，`netstat -rn` 中 utun9 路由恢复；
3. 关闭 TUN 后 `netstat -rn` 无残留 utun9 路由。
