### PR TITLE
fix: never bind TUN direct dialer to the easyss TUN device

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -45,17 +46,20 @@ type boundIface struct {
 }
 
 // detectDialIface returns the interface that TUN-mode direct dials should be
-// bound to: the system's default-route interface. It probes a destination in
-// 0.0.0.0/8, which the easyss TUN routes never cover (the darwin create
-// script starts at 1.0.0.0/8), so the lookup yields the physical default
-// interface even while TUN routes are active — binding to the easyss TUN
-// device itself would create a routing loop. Overridable in tests.
+// bound to: the physical default-route interface. On Windows it reads the
+// 0.0.0.0/0 default route from the routing table (skipping the easyss TUN
+// device, which owns its own default route there while TUN is active). On
+// darwin and linux it probes 0.0.0.1, which the easyss TUN routes (starting
+// at 1.0.0.0/7 on every platform) never cover, so the lookup yields the
+// physical default interface even while TUN routes are active — binding to
+// the easyss TUN device itself would create a routing loop. Windows cannot
+// use the probe: its route lookup rejects 0.0.0.0/8 destinations outright.
+// Overridable in tests.
 var detectDialIface = func() (*net.Interface, error) {
-	r, err := netroute.New()
+	iface, _, err := util.SysDefaultRoute()
 	if err != nil {
-		return nil, err
+		iface, err = probeDialIface()
 	}
-	iface, _, _, err := r.Route(net.IPv4(0, 0, 0, 1))
 	if err != nil {
 		return nil, err
 	}
@@ -75,6 +79,103 @@ var detectDialIface = func() (*net.Interface, error) {
 		}
 	}
 	return nil, fmt.Errorf("default interface %s has no global unicast address", iface.Name)
+}
+
+// probeDialIface finds the default-route interface by probing a destination
+// in 0.0.0.0/8, which the easyss TUN routes (starting at 1.0.0.0/7 on every
+// platform) never cover.
+func probeDialIface() (*net.Interface, error) {
+	r, err := netroute.New()
+	if err != nil {
+		return nil, err
+	}
+	iface, _, _, err := r.Route(net.IPv4(0, 0, 0, 1))
+	if err != nil {
+		return nil, err
+	}
+	if iface == nil {
+		return nil, errors.New("no interface for default route")
+	}
+	return iface, nil
+}
+
+// tunDeviceNameFromConfig returns the TUN device name from the raw
+// tun_config JSON, if present. The device name is used to recognize the
+// easyss TUN interface so the direct dialer never binds to it.
+func tunDeviceNameFromConfig(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var cfg struct {
+		Device string `json:"device"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return ""
+	}
+	return cfg.Device
+}
+
+// isTunIface reports whether iface is the easyss TUN device. The direct
+// dialer must never bind to it: packets emitted on the TUN device are
+// captured by tun2socks and forwarded back to the local proxy, whose dials
+// would re-enter the TUN device — an infinite request loop.
+func (c *Client) isTunIface(iface *net.Interface) bool {
+	if util.IsTunIface(iface) {
+		return true
+	}
+	if iface == nil || c.cfg == nil {
+		return false
+	}
+	name := tunDeviceNameFromConfig(c.cfg.Local.TunConfig)
+	return name != "" && iface.Name == name
+}
+
+// listInterfaces enumerates the system interfaces. It is a package-level var
+// so tests can inject a deterministic set.
+var listInterfaces = net.Interfaces
+
+// ifaceAddrs returns the addresses of iface. It is a package-level var so
+// tests can inject deterministic addresses for synthetic interfaces.
+var ifaceAddrs = func(iface *net.Interface) ([]net.Addr, error) { return iface.Addrs() }
+
+// startupDialIface determines the interface the direct dialer is bound to at
+// startup. It prefers the route probe, but rejects the easyss TUN device
+// (e.g. when routes left over from a crashed TUN session redirect the probe
+// to it) and falls back to enumerating physical interfaces. Returns nil when
+// no suitable interface exists, in which case an unbound dialer is used.
+func (c *Client) startupDialIface() *net.Interface {
+	iface, err := detectDialIface()
+	if err == nil && iface != nil && !c.isTunIface(iface) {
+		return iface
+	}
+	if err != nil {
+		log.Warn("[CLIENT] detect default interface failed", "err", err)
+	} else if iface != nil {
+		log.Warn("[CLIENT] detected easyss TUN device as default interface, falling back to interface enumeration", "iface", iface.Name)
+	}
+
+	ifaces, err := listInterfaces()
+	if err != nil {
+		log.Warn("[CLIENT] list interfaces failed", "err", err)
+		return nil
+	}
+	for i := range ifaces {
+		iface := &ifaces[i]
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 || c.isTunIface(iface) {
+			continue
+		}
+		addrs, err := ifaceAddrs(iface)
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.IsGlobalUnicast() {
+				log.Warn("[CLIENT] using fallback interface for direct dialer", "iface", iface.Name, "index", iface.Index)
+				return iface
+			}
+		}
+	}
+	return nil
 }
 
 // boundDialContext dials through the interface-bound direct dialer. It is a
@@ -134,9 +235,9 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 	client.bound.Store(boundIface{})
 
 	directIface := ""
-	iface, err := detectDialIface()
-	if err != nil {
-		log.Warn("[CLIENT] detect default interface failed", "err", err)
+	iface := client.startupDialIface()
+	if iface == nil {
+		log.Warn("[CLIENT] no physical interface found for direct dialer, using unbound dialer")
 		client.dialer.Store(dialer.New())
 	} else {
 		client.dialer.Store(dialer.New(dialer.WithBindToInterface(iface)))
@@ -248,6 +349,16 @@ func (c *Client) refreshDirectDialer() bool {
 		log.Warn("[CLIENT] refresh direct dialer: detect interface failed", "err", err)
 		return false
 	}
+	if c.isTunIface(iface) {
+		// Defense in depth: the probe should never resolve to the easyss TUN
+		// device (0.0.0.1 is outside the TUN routes), but stale routes from
+		// older scripts or custom TUN configurations could redirect it there.
+		// Binding to it would loop every dial back into the TUN device, so
+		// keep the previously-bound physical interface.
+		log.Warn("[CLIENT] refresh direct dialer: detected easyss TUN device, keeping previous binding",
+			"iface", iface.Name, "index", iface.Index)
+		return false
+	}
 
 	prev, _ := c.bound.Load().(boundIface)
 	if prev.name == iface.Name && prev.index == iface.Index {
@@ -264,8 +375,13 @@ func (c *Client) refreshDirectDialer() bool {
 
 // dialerRefreshLoop periodically re-detects the default interface so the
 // direct dialer's interface binding survives sleep/wake and network changes:
-// on macOS the interface captured at startup can go stale after the machine
-// wakes on a different network, breaking every direct dial until restart.
+// the interface captured at startup can go stale after the machine wakes on
+// a different network, breaking every direct dial until restart. On darwin
+// and linux the probe (0.0.0.1) is outside the TUN routes, and on Windows the
+// routing table lookup skips the TUN device, so detection always resolves to
+// the physical interface; refreshDirectDialer additionally rejects the
+// easyss TUN device as a defense against stale routes from older scripts
+// (which covered 0.0.0.0/1) or custom TUN configurations.
 // Only runs while TUN mode is active (the bound dialer is unused otherwise).
 func (c *Client) dialerRefreshLoop() {
 	ticker := time.NewTicker(30 * time.Second)

--- a/client/dialer_test.go
+++ b/client/dialer_test.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"testing"
 
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/client/config"
 	"github.com/nange/easyss/v3/client/router"
 	"github.com/xjasonlyu/tun2socks/v2/dialer"
@@ -243,7 +244,7 @@ func TestRefreshDirectDialerIgnoresTunDevice(t *testing.T) {
 		// While TUN is active the Windows/Linux route probe resolves to the
 		// TUN device itself. Binding to it would loop every dial back into
 		// the TUN device.
-		return &net.Interface{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}, nil
+		return &net.Interface{Index: 10, Name: sharedconfig.DefaultTunDeviceName, Flags: net.FlagUp}, nil
 	}
 
 	if c.refreshDirectDialer() {
@@ -303,7 +304,7 @@ func TestDialWithConfigNoRetryWhenRefreshDetectsTun(t *testing.T) {
 	// the TUN device (TUN active): the refresh must keep the old binding and
 	// not retry, since retrying through the TUN device would loop.
 	detectDialIface = func() (*net.Interface, error) {
-		return &net.Interface{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}, nil
+		return &net.Interface{Index: 10, Name: sharedconfig.DefaultTunDeviceName, Flags: net.FlagUp}, nil
 	}
 
 	calls := 0
@@ -329,7 +330,7 @@ func TestDialWithConfigNoRetryWhenRefreshDetectsTun(t *testing.T) {
 }
 
 func TestStartupDialIface(t *testing.T) {
-	tunIface := &net.Interface{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}
+	tunIface := &net.Interface{Index: 10, Name: sharedconfig.DefaultTunDeviceName, Flags: net.FlagUp}
 
 	t.Run("probe returns physical interface", func(t *testing.T) {
 		orig := detectDialIface
@@ -357,7 +358,7 @@ func TestStartupDialIface(t *testing.T) {
 		detectDialIface = func() (*net.Interface, error) { return tunIface, nil }
 		listInterfaces = func() ([]net.Interface, error) {
 			return []net.Interface{
-				{Index: 10, Name: "tun-easyss", Flags: net.FlagUp},
+				{Index: 10, Name: sharedconfig.DefaultTunDeviceName, Flags: net.FlagUp},
 				{Index: 7, Name: "en0", Flags: net.FlagUp},
 			}, nil
 		}
@@ -384,7 +385,7 @@ func TestStartupDialIface(t *testing.T) {
 		})
 		detectDialIface = func() (*net.Interface, error) { return nil, errors.New("no route") }
 		listInterfaces = func() ([]net.Interface, error) {
-			return []net.Interface{{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}}, nil
+			return []net.Interface{{Index: 10, Name: sharedconfig.DefaultTunDeviceName, Flags: net.FlagUp}}, nil
 		}
 
 		c := newTestClient(t, true)

--- a/client/dialer_test.go
+++ b/client/dialer_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -231,4 +232,164 @@ func TestDialWithConfigPlainPathWhenTunDisabled(t *testing.T) {
 	if called {
 		t.Fatal("bound dial must not be used when TUN is disabled")
 	}
+}
+
+func TestRefreshDirectDialerIgnoresTunDevice(t *testing.T) {
+	orig := detectDialIface
+	t.Cleanup(func() { detectDialIface = orig })
+
+	c := newTestClient(t, true)
+	detectDialIface = func() (*net.Interface, error) {
+		// While TUN is active the Windows/Linux route probe resolves to the
+		// TUN device itself. Binding to it would loop every dial back into
+		// the TUN device.
+		return &net.Interface{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}, nil
+	}
+
+	if c.refreshDirectDialer() {
+		t.Fatal("expected no refresh when the probe resolves to the TUN device")
+	}
+	got, _ := c.bound.Load().(boundIface)
+	if got.name != "en0" || got.index != 4 {
+		t.Fatalf("bound = %+v, want previous en0/index 4 kept", got)
+	}
+}
+
+func TestRefreshDirectDialerIgnoresCustomTunDeviceName(t *testing.T) {
+	orig := detectDialIface
+	t.Cleanup(func() { detectDialIface = orig })
+
+	c := newTestClient(t, true)
+	c.cfg.Local.TunConfig = json.RawMessage(`{"device":"my-tun9"}`)
+
+	t.Run("custom tun device name is rejected", func(t *testing.T) {
+		detectDialIface = func() (*net.Interface, error) {
+			return &net.Interface{Index: 21, Name: "my-tun9", Flags: net.FlagUp}, nil
+		}
+		if c.refreshDirectDialer() {
+			t.Fatal("expected no refresh for the custom-named TUN device")
+		}
+		got, _ := c.bound.Load().(boundIface)
+		if got.name != "en0" {
+			t.Fatalf("bound = %+v, want previous en0 kept", got)
+		}
+	})
+
+	t.Run("unrelated interface still refreshes", func(t *testing.T) {
+		detectDialIface = func() (*net.Interface, error) {
+			return &net.Interface{Index: 22, Name: "en7", Flags: net.FlagUp}, nil
+		}
+		if !c.refreshDirectDialer() {
+			t.Fatal("expected refresh for a physical interface change")
+		}
+		got, _ := c.bound.Load().(boundIface)
+		if got.name != "en7" || got.index != 22 {
+			t.Fatalf("bound = %+v, want en7/index 22", got)
+		}
+	})
+}
+
+func TestDialWithConfigNoRetryWhenRefreshDetectsTun(t *testing.T) {
+	origDetect := detectDialIface
+	origBound := boundDialContext
+	t.Cleanup(func() {
+		detectDialIface = origDetect
+		boundDialContext = origBound
+	})
+
+	c := newTestClient(t, true)
+
+	// The dial fails with a stale-interface error, but the probe resolves to
+	// the TUN device (TUN active): the refresh must keep the old binding and
+	// not retry, since retrying through the TUN device would loop.
+	detectDialIface = func() (*net.Interface, error) {
+		return &net.Interface{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}, nil
+	}
+
+	calls := 0
+	boundDialContext = func(_ *Client, ctx context.Context, network, addr string) (net.Conn, error) {
+		calls++
+		return nil, syscall.ENETDOWN
+	}
+
+	conn, err := c.dialWithConfig(context.Background(), "tcp", "1.2.3.4:80")
+	if !errors.Is(err, syscall.ENETDOWN) {
+		t.Fatalf("err = %v, want ENETDOWN from the first dial", err)
+	}
+	if conn != nil {
+		t.Fatal("expected nil connection")
+	}
+	if calls != 1 {
+		t.Fatalf("bound dial calls = %d, want 1 (no retry through the TUN device)", calls)
+	}
+	got, _ := c.bound.Load().(boundIface)
+	if got.name != "en0" {
+		t.Fatalf("bound = %+v, want previous en0 kept", got)
+	}
+}
+
+func TestStartupDialIface(t *testing.T) {
+	tunIface := &net.Interface{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}
+
+	t.Run("probe returns physical interface", func(t *testing.T) {
+		orig := detectDialIface
+		t.Cleanup(func() { detectDialIface = orig })
+		detectDialIface = func() (*net.Interface, error) {
+			return &net.Interface{Index: 4, Name: "en0", Flags: net.FlagUp}, nil
+		}
+
+		c := newTestClient(t, true)
+		iface := c.startupDialIface()
+		if iface == nil || iface.Name != "en0" {
+			t.Fatalf("startupDialIface = %v, want en0", iface)
+		}
+	})
+
+	t.Run("probe returns TUN device, falls back to physical interface", func(t *testing.T) {
+		origDetect := detectDialIface
+		origList := listInterfaces
+		origAddrs := ifaceAddrs
+		t.Cleanup(func() {
+			detectDialIface = origDetect
+			listInterfaces = origList
+			ifaceAddrs = origAddrs
+		})
+		detectDialIface = func() (*net.Interface, error) { return tunIface, nil }
+		listInterfaces = func() ([]net.Interface, error) {
+			return []net.Interface{
+				{Index: 10, Name: "tun-easyss", Flags: net.FlagUp},
+				{Index: 7, Name: "en0", Flags: net.FlagUp},
+			}, nil
+		}
+		ifaceAddrs = func(iface *net.Interface) ([]net.Addr, error) {
+			if iface.Name != "en0" {
+				return nil, errors.New("no addrs")
+			}
+			return []net.Addr{&net.IPNet{IP: net.IPv4(192, 168, 1, 5), Mask: net.CIDRMask(24, 32)}}, nil
+		}
+
+		c := newTestClient(t, true)
+		iface := c.startupDialIface()
+		if iface == nil || iface.Name != "en0" || iface.Index != 7 {
+			t.Fatalf("startupDialIface = %v, want fallback en0/index 7", iface)
+		}
+	})
+
+	t.Run("probe fails and no usable interface, returns nil", func(t *testing.T) {
+		origDetect := detectDialIface
+		origList := listInterfaces
+		t.Cleanup(func() {
+			detectDialIface = origDetect
+			listInterfaces = origList
+		})
+		detectDialIface = func() (*net.Interface, error) { return nil, errors.New("no route") }
+		listInterfaces = func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 10, Name: "tun-easyss", Flags: net.FlagUp}}, nil
+		}
+
+		c := newTestClient(t, true)
+		if iface := c.startupDialIface(); iface != nil {
+			t.Fatalf("startupDialIface = %v, want nil (unbound fallback)", iface)
+		}
+	})
 }

--- a/client/tun/tun.go
+++ b/client/tun/tun.go
@@ -3,6 +3,7 @@ package tun
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -84,11 +85,22 @@ func New(cfg Config) *Manager {
 	if cfg.Interface == "" || cfg.LocalGateway == "" {
 		gw, dev, err := util.SysGatewayAndDevice()
 		if err == nil {
-			if cfg.Interface == "" {
-				cfg.Interface = dev
+			// Skip the easyss TUN device: when TUN routes are left over from
+			// a previous session the route probe can resolve to it, and the
+			// create script would then route the local gateway through the
+			// TUN device itself.
+			if iface, ierr := net.InterfaceByName(dev); ierr == nil && util.IsTunIface(iface) {
+				log.Warn("[TUN] route probe resolved to easyss TUN device, skipping", "iface", dev)
+				dev = ""
+				gw = ""
 			}
-			if cfg.LocalGateway == "" {
-				cfg.LocalGateway = gw
+			if dev != "" {
+				if cfg.Interface == "" {
+					cfg.Interface = dev
+				}
+				if cfg.LocalGateway == "" {
+					cfg.LocalGateway = gw
+				}
 			}
 		} else {
 			log.Warn("[TUN] detect default gateway/interface failed", "err", err)

--- a/client/tun/tun.go
+++ b/client/tun/tun.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/scripts"
 	"github.com/nange/easyss/v3/util"
@@ -77,9 +78,9 @@ func New(cfg Config) *Manager {
 	}
 	if cfg.Device == "" {
 		if runtime.GOOS == "darwin" {
-			cfg.Device = "utun9"
+			cfg.Device = sharedconfig.DefaultTunDeviceNameDarwin
 		} else {
-			cfg.Device = "tun-easyss"
+			cfg.Device = sharedconfig.DefaultTunDeviceName
 		}
 	}
 	if cfg.Interface == "" || cfg.LocalGateway == "" {

--- a/config/types.go
+++ b/config/types.go
@@ -138,4 +138,11 @@ const (
 	EndpointUDP   = "/v3/udp"
 	EndpointICMP  = "/v3/icmp"
 	EndpointProbe = "/v3/probe"
+
+	// TUN device name defaults. Single source of truth shared by
+	// client/tun.New (device creation) and util.IsTunIface (recognizing the
+	// easyss TUN device so the direct dialer never binds to it): both must
+	// reference these constants, never literals.
+	DefaultTunDeviceName       = "tun-easyss"
+	DefaultTunDeviceNameDarwin = "utun9"
 )

--- a/scripts/close_tun_dev_windows.bat
+++ b/scripts/close_tun_dev_windows.bat
@@ -3,7 +3,12 @@
 set tun_device=%1
 set tun_gw=%2
 
-route delete 0.0.0.0 mask 128.0.0.0 %tun_gw%
+route delete 1.0.0.0 mask 254.0.0.0 %tun_gw%
+route delete 4.0.0.0 mask 252.0.0.0 %tun_gw%
+route delete 8.0.0.0 mask 248.0.0.0 %tun_gw%
+route delete 16.0.0.0 mask 240.0.0.0 %tun_gw%
+route delete 32.0.0.0 mask 224.0.0.0 %tun_gw%
+route delete 64.0.0.0 mask 192.0.0.0 %tun_gw%
 route delete 128.0.0.0 mask 128.0.0.0 %tun_gw%
 
 netsh interface ipv6 delete route ::/1 %tun_device%

--- a/scripts/create_tun_dev.sh
+++ b/scripts/create_tun_dev.sh
@@ -15,7 +15,15 @@ fi
 
 ip link set dev "$tun_device" up  # enable tun device
 
-ip route add 0.0.0.0/1 via "$tun_gw" dev "$tun_device"
+# Route everything except 0.0.0.0/8 through the TUN device, mirroring the
+# darwin script. 0.0.0.1 (used to probe the physical default interface)
+# must stay outside the TUN routes.
+ip route add 1.0.0.0/7 via "$tun_gw" dev "$tun_device"
+ip route add 4.0.0.0/6 via "$tun_gw" dev "$tun_device"
+ip route add 8.0.0.0/5 via "$tun_gw" dev "$tun_device"
+ip route add 16.0.0.0/4 via "$tun_gw" dev "$tun_device"
+ip route add 32.0.0.0/3 via "$tun_gw" dev "$tun_device"
+ip route add 64.0.0.0/2 via "$tun_gw" dev "$tun_device"
 ip route add 128.0.0.0/1 via "$tun_gw" dev "$tun_device"
 ip route add "$local_gateway" via "$tun_gw" dev "$tun_device"
 

--- a/scripts/create_tun_dev_windows.bat
+++ b/scripts/create_tun_dev_windows.bat
@@ -12,7 +12,15 @@ set server_ip_v6=%7
 netsh interface ip set address %tun_device% static address=%tun_ip% mask=%tun_mask% gateway=%tun_gw%
 netsh interface ip set dns name=%tun_device% static 8.8.8.8
 
-route add 0.0.0.0 mask 128.0.0.0 %tun_gw% metric 5
+rem Route everything except 0.0.0.0/8 through the TUN device, mirroring the
+rem darwin script. 0.0.0.1 (used to probe the physical default interface)
+rem must stay outside the TUN routes.
+route add 1.0.0.0 mask 254.0.0.0 %tun_gw% metric 5
+route add 4.0.0.0 mask 252.0.0.0 %tun_gw% metric 5
+route add 8.0.0.0 mask 248.0.0.0 %tun_gw% metric 5
+route add 16.0.0.0 mask 240.0.0.0 %tun_gw% metric 5
+route add 32.0.0.0 mask 224.0.0.0 %tun_gw% metric 5
+route add 64.0.0.0 mask 192.0.0.0 %tun_gw% metric 5
 route add 128.0.0.0 mask 128.0.0.0 %tun_gw% metric 5
 
 if not "%server_ip_v6%"=="" (

--- a/util/sys.go
+++ b/util/sys.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 
 	netroute "github.com/libp2p/go-netroute"
+
+	sharedconfig "github.com/nange/easyss/v3/config"
 )
 
 // easyssTunSubnet is the subnet that the easyss TUN device owns by default
@@ -21,9 +23,9 @@ var easyssTunSubnet = net.IPNet{
 // current platform, mirroring the defaults in client/tun.New.
 func defaultTunDeviceName() string {
 	if runtime.GOOS == "darwin" {
-		return "utun9"
+		return sharedconfig.DefaultTunDeviceNameDarwin
 	}
-	return "tun-easyss"
+	return sharedconfig.DefaultTunDeviceName
 }
 
 // IsTunSubnetAddr reports whether ip lies in the easyss TUN subnet

--- a/util/sys.go
+++ b/util/sys.go
@@ -1,12 +1,60 @@
 package util
 
 import (
+	"errors"
 	"net"
 	"os/exec"
+	"runtime"
 	"strconv"
 
 	netroute "github.com/libp2p/go-netroute"
 )
+
+// easyssTunSubnet is the subnet that the easyss TUN device owns by default
+// (TunIP/TunGW default to 198.18.0.1 with mask 255.255.0.0).
+var easyssTunSubnet = net.IPNet{
+	IP:   net.IPv4(198, 18, 0, 0),
+	Mask: net.CIDRMask(15, 32),
+}
+
+// defaultTunDeviceName returns the default easyss TUN device name for the
+// current platform, mirroring the defaults in client/tun.New.
+func defaultTunDeviceName() string {
+	if runtime.GOOS == "darwin" {
+		return "utun9"
+	}
+	return "tun-easyss"
+}
+
+// IsTunSubnetAddr reports whether ip lies in the easyss TUN subnet
+// (198.18.0.0/15 by default, where the TUN device's own address lives).
+func IsTunSubnetAddr(ip net.IP) bool {
+	return easyssTunSubnet.Contains(ip)
+}
+
+// IsTunIface reports whether iface is the easyss TUN device: its name matches
+// the easyss TUN device name, or it owns an address in the easyss TUN subnet.
+// The direct dialer must never bind to this interface — binding to it would
+// send every outbound packet back into the TUN device, creating a routing
+// loop through tun2socks.
+func IsTunIface(iface *net.Interface) bool {
+	if iface == nil {
+		return false
+	}
+	if iface.Name == defaultTunDeviceName() {
+		return true
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && IsTunSubnetAddr(ipnet.IP) {
+			return true
+		}
+	}
+	return false
+}
 
 func SysSupportPowershell() bool {
 	return SysSupport("powershell")
@@ -61,9 +109,39 @@ func SysPowershellMajorVersion() int {
 	return int(v)
 }
 
+var (
+	errUnsupportedPlatform = errors.New("unsupported platform")
+	errNoDefaultRoute      = errors.New("no default route found")
+)
+
+// SysDefaultRoute returns the physical interface and gateway of the IPv4
+// default route (0.0.0.0/0), read from the Windows routing table. Windows may
+// hold several 0.0.0.0/0 entries while TUN is active (the TUN device gets its
+// own default route when netsh configures the static gateway); the easyss TUN
+// interface is skipped so the physical interface is returned. On darwin and
+// linux the caller probes 0.0.0.1 instead — the easyss TUN routes start at
+// 1.0.0.0/7 on every platform, so 0.0.0.1 always resolves to the physical
+// default interface (Windows cannot use the probe: its route lookup rejects
+// 0.0.0.0/8 destinations outright).
+func SysDefaultRoute() (iface *net.Interface, gateway net.IP, err error) {
+	switch runtime.GOOS {
+	case "windows":
+		return defaultRouteFromWinTable()
+	default:
+		return nil, nil, errUnsupportedPlatform
+	}
+}
+
 func SysGatewayAndDevice() (gw string, dev string, err error) {
+	iface, gateway, err := SysDefaultRoute()
+	if err == nil && iface != nil && gateway != nil {
+		return gateway.String(), iface.Name, nil
+	}
+
+	// Fallback (darwin, linux and other platforms): probe 0.0.0.1, which the
+	// easyss TUN routes (starting at 1.0.0.0/7 on every platform) never cover.
 	r, _ := netroute.New()
-	iface, gateway, _, err := r.Route(net.IPv4(119, 29, 29, 29))
+	iface, gateway, _, err = r.Route(net.IPv4(0, 0, 0, 1))
 	if err != nil {
 		return "", "", err
 	}

--- a/util/sys.go
+++ b/util/sys.go
@@ -109,10 +109,7 @@ func SysPowershellMajorVersion() int {
 	return int(v)
 }
 
-var (
-	errUnsupportedPlatform = errors.New("unsupported platform")
-	errNoDefaultRoute      = errors.New("no default route found")
-)
+var errUnsupportedPlatform = errors.New("unsupported platform")
 
 // SysDefaultRoute returns the physical interface and gateway of the IPv4
 // default route (0.0.0.0/0), read from the Windows routing table. Windows may

--- a/util/sys.go
+++ b/util/sys.go
@@ -19,15 +19,6 @@ var easyssTunSubnet = net.IPNet{
 	Mask: net.CIDRMask(15, 32),
 }
 
-// defaultTunDeviceName returns the default easyss TUN device name for the
-// current platform, mirroring the defaults in client/tun.New.
-func defaultTunDeviceName() string {
-	if runtime.GOOS == "darwin" {
-		return sharedconfig.DefaultTunDeviceNameDarwin
-	}
-	return sharedconfig.DefaultTunDeviceName
-}
-
 // IsTunSubnetAddr reports whether ip lies in the easyss TUN subnet
 // (198.18.0.0/15 by default, where the TUN device's own address lives).
 func IsTunSubnetAddr(ip net.IP) bool {
@@ -35,15 +26,18 @@ func IsTunSubnetAddr(ip net.IP) bool {
 }
 
 // IsTunIface reports whether iface is the easyss TUN device: its name matches
-// the easyss TUN device name, or it owns an address in the easyss TUN subnet.
-// The direct dialer must never bind to this interface — binding to it would
-// send every outbound packet back into the TUN device, creating a routing
-// loop through tun2socks.
+// the easyss TUN device name (tun-easyss on windows/linux, utun9 on darwin —
+// both are matched so recognition does not depend on the current platform),
+// or it owns an address in the easyss TUN subnet. The direct dialer must
+// never bind to this interface — binding to it would send every outbound
+// packet back into the TUN device, creating a routing loop through
+// tun2socks.
 func IsTunIface(iface *net.Interface) bool {
 	if iface == nil {
 		return false
 	}
-	if iface.Name == defaultTunDeviceName() {
+	if iface.Name == sharedconfig.DefaultTunDeviceName ||
+		iface.Name == sharedconfig.DefaultTunDeviceNameDarwin {
 		return true
 	}
 	addrs, err := iface.Addrs()

--- a/util/sys_test.go
+++ b/util/sys_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"net"
 	"runtime"
 	"testing"
 
@@ -35,6 +36,23 @@ func TestSysGatewayAndDevice(t *testing.T) {
 	}
 }
 
+func TestSysDefaultRoute(t *testing.T) {
+	// Only Windows reads the routing table; darwin/linux use the 0.0.0.1
+	// probe (see SysGatewayAndDevice).
+	if runtime.GOOS != "windows" {
+		t.SkipNow()
+	}
+	iface, gw, err := SysDefaultRoute()
+	assert.Nil(t, err)
+	assert.NotNil(t, iface)
+	assert.NotNil(t, gw)
+	if iface != nil {
+		assert.NotEmpty(t, iface.Name)
+		assert.False(t, IsTunIface(iface), "default interface must not be the easyss TUN device")
+		assert.True(t, iface.Flags&net.FlagUp != 0, "default interface should be up")
+	}
+}
+
 func TestSysGatewayAndDeviceV6(t *testing.T) {
 	gw, dev, err := SysGatewayAndDeviceV6()
 	switch runtime.GOOS {
@@ -45,5 +63,39 @@ func TestSysGatewayAndDeviceV6(t *testing.T) {
 		}
 	default:
 		t.SkipNow()
+	}
+}
+
+func TestIsTunSubnetAddr(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"198.18.0.1", true},   // default TunIP
+		{"198.18.255.255", true},
+		{"198.19.255.255", true}, // /15 upper bound
+		{"198.17.255.255", false},
+		{"198.20.0.1", false},
+		{"192.168.1.1", false},
+		{"127.0.0.1", false},
+	}
+	for _, c := range cases {
+		if got := IsTunSubnetAddr(net.ParseIP(c.ip)); got != c.want {
+			t.Fatalf("IsTunSubnetAddr(%s) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+}
+
+func TestIsTunIface(t *testing.T) {
+	// Name-based match is deterministic and short-circuits before any
+	// OS address lookup.
+	if !IsTunIface(&net.Interface{Name: defaultTunDeviceName()}) {
+		t.Fatalf("expected %s to be recognized as the TUN device", defaultTunDeviceName())
+	}
+	if IsTunIface(&net.Interface{Name: "Ethernet"}) {
+		t.Fatal("expected a plain interface name to not be recognized")
+	}
+	if IsTunIface(nil) {
+		t.Fatal("expected nil interface to not be recognized")
 	}
 }

--- a/util/sys_test.go
+++ b/util/sys_test.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"testing"
 
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,9 +89,15 @@ func TestIsTunSubnetAddr(t *testing.T) {
 
 func TestIsTunIface(t *testing.T) {
 	// Name-based match is deterministic and short-circuits before any
-	// OS address lookup.
-	if !IsTunIface(&net.Interface{Name: defaultTunDeviceName()}) {
-		t.Fatalf("expected %s to be recognized as the TUN device", defaultTunDeviceName())
+	// OS address lookup. Both platform default names must be recognized
+	// regardless of the platform the test runs on.
+	for _, name := range []string{
+		sharedconfig.DefaultTunDeviceName,
+		sharedconfig.DefaultTunDeviceNameDarwin,
+	} {
+		if !IsTunIface(&net.Interface{Name: name}) {
+			t.Fatalf("expected %s to be recognized as the TUN device", name)
+		}
 	}
 	if IsTunIface(&net.Interface{Name: "Ethernet"}) {
 		t.Fatal("expected a plain interface name to not be recognized")

--- a/util/sys_windows.go
+++ b/util/sys_windows.go
@@ -1,0 +1,98 @@
+//go:build windows
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// mibIpforwardrow mirrors MIB_IPFORWARDROW (iphlpapi.h). The layout is fixed
+// and documented (14 DWORDs = 56 bytes); only the fields needed for the
+// default-route lookup are named.
+type mibIpforwardrow struct {
+	dest    uint32
+	mask    uint32
+	policy  uint32
+	nextHop uint32
+	ifIndex uint32
+	typ     uint32
+	proto   uint32
+	age     uint32
+	nextAS  uint32
+	metric1 uint32
+	metric2 uint32
+	metric3 uint32
+	metric4 uint32
+	metric5 uint32
+}
+
+var procGetIpForwardTable = windows.NewLazySystemDLL("iphlpapi.dll").NewProc("GetIpForwardTable")
+
+// routeCandidate is one 0.0.0.0/0 default-route entry.
+type routeCandidate struct {
+	index   uint32
+	nextHop uint32
+	metric  uint32
+}
+
+// defaultRouteFromWinTable returns the physical interface and gateway of the
+// IPv4 default route via GetIpForwardTable. Windows may hold several 0.0.0.0/0
+// entries (e.g. the easyss TUN device's own default route, added by netsh
+// when the static gateway is configured); the easyss TUN interface is skipped
+// so the physical default interface is returned while TUN is active.
+func defaultRouteFromWinTable() (*net.Interface, net.IP, error) {
+	var size uint32
+	r, _, _ := procGetIpForwardTable.Call(0, uintptr(unsafe.Pointer(&size)), 0)
+	if r != 0 && r != uintptr(windows.ERROR_INSUFFICIENT_BUFFER) {
+		return nil, nil, fmt.Errorf("GetIpForwardTable: %w", windows.Errno(r))
+	}
+
+	buf := make([]byte, size)
+	r, _, _ = procGetIpForwardTable.Call(uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&size)), 0)
+	if r != 0 {
+		return nil, nil, fmt.Errorf("GetIpForwardTable: %w", windows.Errno(r))
+	}
+
+	num := *(*uint32)(unsafe.Pointer(&buf[0]))
+	rows := unsafe.Slice((*mibIpforwardrow)(unsafe.Pointer(&buf[4])), int(num))
+
+	for _, c := range defaultRouteCandidates(rows) {
+		iface, err := net.InterfaceByIndex(int(c.index))
+		if err != nil {
+			continue
+		}
+		if IsTunIface(iface) {
+			continue
+		}
+		return iface, ipFromUint32(c.nextHop), nil
+	}
+	return nil, nil, errNoDefaultRoute
+}
+
+// defaultRouteCandidates returns the 0.0.0.0/0 default-route entries sorted
+// by metric (lowest first).
+func defaultRouteCandidates(rows []mibIpforwardrow) []routeCandidate {
+	var cands []routeCandidate
+	for _, row := range rows {
+		if row.dest != 0 || row.mask != 0 {
+			continue
+		}
+		cands = append(cands, routeCandidate{index: row.ifIndex, nextHop: row.nextHop, metric: row.metric1})
+	}
+	for i := 1; i < len(cands); i++ {
+		for j := i; j > 0 && cands[j].metric < cands[j-1].metric; j-- {
+			cands[j], cands[j-1] = cands[j-1], cands[j]
+		}
+	}
+	return cands
+}
+
+// ipFromUint32 converts a network-byte-order IPv4 address (as stored in
+// MIB_IPFORWARDROW) to a net.IP.
+func ipFromUint32(v uint32) net.IP {
+	return net.IPv4(byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}

--- a/util/sys_windows.go
+++ b/util/sys_windows.go
@@ -3,9 +3,11 @@
 package util
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -13,27 +15,44 @@ import (
 
 var errNoDefaultRoute = errors.New("no default route found")
 
-// mibIpforwardrow mirrors MIB_IPFORWARDROW (iphlpapi.h). The layout is fixed
-// and documented (14 DWORDs = 56 bytes); only the fields needed for the
-// default-route lookup are named.
+// mibIpforwardrow mirrors MIB_IPFORWARDROW (iphlpapi.h): a fixed layout of
+// 14 DWORDs (56 bytes). Only the fields used by the default-route lookup are
+// named; the anonymous placeholders keep the offsets of the named fields
+// correct. IP addresses are stored in network byte order.
 type mibIpforwardrow struct {
-	dest    uint32
-	mask    uint32
-	policy  uint32
-	nextHop uint32
-	ifIndex uint32
-	typ     uint32
-	proto   uint32
-	age     uint32
-	nextAS  uint32
-	metric1 uint32
-	metric2 uint32
-	metric3 uint32
-	metric4 uint32
-	metric5 uint32
+	dest    uint32    // dwForwardDest
+	mask    uint32    // dwForwardMask
+	_       uint32    // dwForwardPolicy
+	nextHop uint32    // dwForwardNextHop
+	ifIndex uint32    // dwForwardIfIndex
+	_       [4]uint32 // dwForwardType, dwForwardProto, dwForwardAge, dwForwardNextHopAS
+	metric1 uint32    // dwForwardMetric1
+	_       [4]uint32 // dwForwardMetric2..dwForwardMetric5
 }
 
 var procGetIpForwardTable = windows.NewLazySystemDLL("iphlpapi.dll").NewProc("GetIpForwardTable")
+
+// getIpForwardTable returns the IPv4 routing table as MIB_IPFORWARDROW rows.
+// The table starts with a 4-byte entry count followed by the fixed-size
+// rows; x/sys/windows does not wrap this API, so the buffer is laid out with
+// unsafe. GetIpForwardTable is called twice: the first call (nil buffer)
+// reports the required size, the second call fills it.
+func getIpForwardTable() ([]mibIpforwardrow, error) {
+	var size uint32
+	r, _, _ := procGetIpForwardTable.Call(0, uintptr(unsafe.Pointer(&size)), 0)
+	if r != 0 && r != uintptr(windows.ERROR_INSUFFICIENT_BUFFER) {
+		return nil, fmt.Errorf("GetIpForwardTable: %w", windows.Errno(r))
+	}
+
+	buf := make([]byte, size)
+	r, _, _ = procGetIpForwardTable.Call(uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&size)), 0)
+	if r != 0 {
+		return nil, fmt.Errorf("GetIpForwardTable: %w", windows.Errno(r))
+	}
+
+	num := *(*uint32)(unsafe.Pointer(&buf[0]))
+	return unsafe.Slice((*mibIpforwardrow)(unsafe.Pointer(&buf[4])), int(num)), nil
+}
 
 // routeCandidate is one 0.0.0.0/0 default-route entry.
 type routeCandidate struct {
@@ -43,25 +62,17 @@ type routeCandidate struct {
 }
 
 // defaultRouteFromWinTable returns the physical interface and gateway of the
-// IPv4 default route via GetIpForwardTable. Windows may hold several 0.0.0.0/0
-// entries (e.g. the easyss TUN device's own default route, added by netsh
-// when the static gateway is configured); the easyss TUN interface is skipped
-// so the physical default interface is returned while TUN is active.
+// IPv4 default route. Windows must be handled differently from darwin/linux:
+// its route lookup rejects 0.0.0.0/8 destinations, so the physical interface
+// cannot be found by probing 0.0.0.1 — the routing table is the only way.
+// While TUN is active the table holds several 0.0.0.0/0 entries: netsh adds
+// a default route to the easyss TUN device itself (usually with the lowest
+// metric), which is skipped so the physical default interface is returned.
 func defaultRouteFromWinTable() (*net.Interface, net.IP, error) {
-	var size uint32
-	r, _, _ := procGetIpForwardTable.Call(0, uintptr(unsafe.Pointer(&size)), 0)
-	if r != 0 && r != uintptr(windows.ERROR_INSUFFICIENT_BUFFER) {
-		return nil, nil, fmt.Errorf("GetIpForwardTable: %w", windows.Errno(r))
+	rows, err := getIpForwardTable()
+	if err != nil {
+		return nil, nil, err
 	}
-
-	buf := make([]byte, size)
-	r, _, _ = procGetIpForwardTable.Call(uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&size)), 0)
-	if r != 0 {
-		return nil, nil, fmt.Errorf("GetIpForwardTable: %w", windows.Errno(r))
-	}
-
-	num := *(*uint32)(unsafe.Pointer(&buf[0]))
-	rows := unsafe.Slice((*mibIpforwardrow)(unsafe.Pointer(&buf[4])), int(num))
 
 	for _, c := range defaultRouteCandidates(rows) {
 		iface, err := net.InterfaceByIndex(int(c.index))
@@ -86,11 +97,9 @@ func defaultRouteCandidates(rows []mibIpforwardrow) []routeCandidate {
 		}
 		cands = append(cands, routeCandidate{index: row.ifIndex, nextHop: row.nextHop, metric: row.metric1})
 	}
-	for i := 1; i < len(cands); i++ {
-		for j := i; j > 0 && cands[j].metric < cands[j-1].metric; j-- {
-			cands[j], cands[j-1] = cands[j-1], cands[j]
-		}
-	}
+	slices.SortFunc(cands, func(a, b routeCandidate) int {
+		return cmp.Compare(a.metric, b.metric)
+	})
 	return cands
 }
 

--- a/util/sys_windows.go
+++ b/util/sys_windows.go
@@ -3,12 +3,15 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
+
+var errNoDefaultRoute = errors.New("no default route found")
 
 // mibIpforwardrow mirrors MIB_IPFORWARDROW (iphlpapi.h). The layout is fixed
 // and documented (14 DWORDs = 56 bytes); only the fields needed for the

--- a/util/sys_windows_test.go
+++ b/util/sys_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package util
+
+import (
+	"net"
+	"testing"
+)
+
+func TestDefaultRouteCandidates(t *testing.T) {
+	// easyss TUN routes (1.0.0.0/7 … and the netsh-added 0.0.0.0/0 on the
+	// TUN device) plus two physical default routes with different metrics.
+	rows := []mibIpforwardrow{
+		{dest: 0x01000000, mask: 0xFE000000, ifIndex: 10, metric1: 5},  // TUN 1.0.0.0/7
+		{dest: 0x80000000, mask: 0x80000000, ifIndex: 10, metric1: 5},  // TUN 128.0.0.0/1
+		{dest: 0x00000000, mask: 0x00000000, ifIndex: 10, metric1: 6, nextHop: 0x010214AC}, // TUN default (netsh)
+		{dest: 0x00000000, mask: 0x00000000, ifIndex: 5, metric1: 35, nextHop: 0xC0A80101}, // physical default
+		{dest: 0x00000000, mask: 0x00000000, ifIndex: 9, metric1: 25, nextHop: 0xC0A80101}, // physical default, lower metric
+	}
+	cands := defaultRouteCandidates(rows)
+	if len(cands) != 3 {
+		t.Fatalf("candidates = %d, want 3 (TUN + 2 physical)", len(cands))
+	}
+	// Sorted by metric: TUN (6), physical (25), physical (35).
+	if cands[0].index != 10 || cands[0].metric != 6 {
+		t.Fatalf("cands[0] = %+v, want TUN index 10 metric 6", cands[0])
+	}
+	if cands[1].index != 9 || cands[1].metric != 25 {
+		t.Fatalf("cands[1] = %+v, want index 9 metric 25", cands[1])
+	}
+	if cands[2].index != 5 || cands[2].metric != 35 {
+		t.Fatalf("cands[2] = %+v, want index 5 metric 35", cands[2])
+	}
+}
+
+func TestDefaultRouteCandidatesNone(t *testing.T) {
+	// A table with only easyss TUN routes (no 0.0.0.0/0 entry at all).
+	rows := []mibIpforwardrow{
+		{dest: 0x01000000, mask: 0xFE000000, ifIndex: 10, metric1: 5},
+		{dest: 0x80000000, mask: 0x80000000, ifIndex: 10, metric1: 5},
+	}
+	if cands := defaultRouteCandidates(rows); len(cands) != 0 {
+		t.Fatalf("candidates = %d, want 0", len(cands))
+	}
+}
+
+func TestIPFromUint32(t *testing.T) {
+	ip := ipFromUint32(0xC0A80101)
+	if !ip.Equal(net.ParseIP("192.168.1.1")) {
+		t.Fatalf("ipFromUint32 = %v, want 192.168.1.1", ip)
+	}
+}

--- a/util/sys_winroute_stub.go
+++ b/util/sys_winroute_stub.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package util
+
+import "net"
+
+// defaultRouteFromWinTable is implemented on windows; other platforms fall
+// back to the netroute probe in SysGatewayAndDevice.
+func defaultRouteFromWinTable() (*net.Interface, net.IP, error) {
+	return nil, nil, errUnsupportedPlatform
+}


### PR DESCRIPTION
## 问题

开启 tun2socks 后出现两类故障：

1. **请求死循环**：所有出口连接（连服务器、直连目标、DNS）陷入 tun2socks 循环，请求永不完成
2. **网络全断（WSAENETUNREACH）**：所有连接立即报"网络位置不可达"

均源于今日提交 `ebbc18b`（macOS sleep/wake TUN 恢复）引入的直连 dialer 接口探测逻辑。

## 根因

`ebbc18b` 通过探测 `0.0.0.1` 来重新发现默认网卡，但实测发现：

- **Windows 内核拒绝为 `0.0.0.0/8` 选路**（`GetBestRoute2` 无条件返回"网络位置不可达"，与路由表内容无关——即使临时加入 `0.0.0.0/1`、`0.0.0.1/32` 精确路由依然失败）→ 探测必然失败 → dialer 无绑定 → TUN 激活后所有直连流量落入 TUN 设备，经 tun2socks 转发回本地代理，代理再拨号又落入 TUN……无限循环
- 探测失败后的回退枚举在多网卡机器上可能选中虚拟网卡（WSL/Hyper-V/VirtualBox/Tailscale）→ 全部连接 WSAENETUNREACH
- macOS 上探测成功，所以问题只在 Windows（和 Linux）暴露

## 修复

1. **脚本（Windows/Linux）**：TUN 路由从 `0.0.0.0/1` 改为 `1.0.0.0/7` 起（与 darwin 对齐），`0.0.0.0/8` 漏出 TUN 路由，保证 `0.0.0.1` 探测在 macOS/Linux 上始终解析到物理网卡
2. **Windows 探测**：`GetIpForwardTable` 读取 `0.0.0.0/0` 默认路由（按 metric 排序并跳过 TUN 设备自己的默认路由——`netsh` 配置静态网关时自动添加），TUN 激活时也能拿到物理网卡
3. **防护**：直连 dialer 永不绑定 easyss TUN 设备——刷新路径探测到 TUN 设备时保留既有物理绑定，启动路径回退物理网卡枚举

## 验证

- 本机（Windows）实测：TUN 激活 / 关闭两种状态下 `SysDefaultRoute` 均返回物理网卡（WLAN），并断言排除 TUN 设备
- 实测确认 Windows 对 `0.0.0.1` 无条件拒绝选路（`Find-NetRoute` 与 go-netroute 双路验证，含 `0.0.0.0/1`、`0.0.0.1/32` 精确路由实验）
- `go test ./...` 全绿；win/linux/darwin 三平台交叉编译通过；lint 0 issues
