### PR TITLE
feat: drain idle streams on expiring/degraded slots faster

### DIFF
--- a/client/proxy/stream.go
+++ b/client/proxy/stream.go
@@ -40,6 +40,12 @@ type StreamHandler struct {
 	masterKey         []byte
 	shaperCfg         shaper.Config
 	streamIdleTimeout time.Duration
+	// drainIdle bounds how long a stream may stay idle on a slot due for
+	// eviction (expiring/degraded) before the relay closes it early; 0 uses
+	// the default config.ExpiringStreamDrainIdle. Not exposed as a user
+	// config option — kept as a field so tests can exercise the drain with
+	// short durations.
+	drainIdle time.Duration
 }
 
 func NewStreamHandler(tr transport.Transport, masterKey []byte, shaperCfg shaper.Config, streamIdleTimeout time.Duration) *StreamHandler {
@@ -268,10 +274,33 @@ func (h *StreamHandler) relay(target string, localConn net.Conn, tx shaper.Shape
 		_ = localConn.Close()
 	}
 
-	result := relay.Bidirectional(h.streamIdleTimeout, closeAll,
+	// Drain idle streams on slots due for eviction: once the slot is
+	// expiring (connection over age/bytes) or degraded (confirmed slow),
+	// a stream that has been idle for ExpiringStreamDrainIdle is a lingering
+	// keep-alive or half-closed connection — close it early so the slot's
+	// rotation/retirement is not postponed until the full idle timeout.
+	// Active streams (data flowing) restart the relay's idle clock and are
+	// never drained. Streams whose transport does not implement
+	// SlotDrainingStream simply keep the previous behavior.
+	var drainWhen func() bool
+	if ds, ok := stream.(transport.SlotDrainingStream); ok {
+		drainWhen = ds.SlotDraining
+	}
+	drainIdle := h.drainIdle
+	if drainIdle <= 0 {
+		drainIdle = config.ExpiringStreamDrainIdle
+	}
+
+	result := relay.BidirectionalWithDrain(h.streamIdleTimeout, drainWhen, drainIdle, closeAll,
 		func(signal func()) error { return h.copyLocalToRemote(localConn, tx, signal) },
 		func(signal func()) error { return h.copyRemoteToLocal(rx, localConn, signal, m) },
 	)
+
+	if result.Drained {
+		stats.RecordStreamDrained()
+		log.Debug("[STREAM] drained idle stream on slot due for eviction", "target", target)
+		return fmt.Errorf("%w: drained (slot due for eviction)", ErrStreamIdleTimeout)
+	}
 
 	if result.TimedOut {
 		log.Debug("[STREAM] idle timeout", "timeout", h.streamIdleTimeout)

--- a/client/proxy/stream_drain_test.go
+++ b/client/proxy/stream_drain_test.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nange/easyss/v3/config"
+	"github.com/nange/easyss/v3/crypto"
+	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/shaper"
+	"github.com/nange/easyss/v3/stats"
+)
+
+// drainMockStream is a transport.Stream whose Read blocks until Close, with
+// a configurable SlotDraining verdict, so tests can exercise the relay drain
+// without a real HTTP/2 transport.
+type drainMockStream struct {
+	slotDraining bool
+	closedCh     chan struct{}
+	closeOnce    sync.Once
+}
+
+func newDrainMockStream(slotDraining bool) *drainMockStream {
+	return &drainMockStream{slotDraining: slotDraining, closedCh: make(chan struct{})}
+}
+
+func (s *drainMockStream) Read(p []byte) (int, error) {
+	<-s.closedCh
+	return 0, io.ErrClosedPipe
+}
+
+func (s *drainMockStream) Write(p []byte) (int, error) { return len(p), nil }
+func (s *drainMockStream) CloseWrite() error            { return nil }
+func (s *drainMockStream) Close() error {
+	s.closeOnce.Do(func() { close(s.closedCh) })
+	return nil
+}
+
+func (s *drainMockStream) SlotDraining() bool { return s.slotDraining }
+
+func (s *drainMockStream) closed() bool {
+	select {
+	case <-s.closedCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// newDrainHandler builds a StreamHandler with a short drain idle (so tests
+// run fast) plus the crypto plumbing a relay needs over stream.
+func newDrainHandler(stream *drainMockStream, drainIdle time.Duration) (*StreamHandler, shaper.Shaper, *crypto.DecryptedReader, net.Conn, net.Conn) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	endpoint := config.EndpointTCP
+	method := protocol.MethodAES256GCM
+
+	salt, err := crypto.GenerateSalt()
+	if err != nil {
+		panic(err)
+	}
+	sk, err := crypto.NewStreamKeys(key, salt, endpoint)
+	if err != nil {
+		panic(err)
+	}
+
+	aadC2S := crypto.BuildAAD(endpoint, salt, "c2s", "session", method)
+	c2sEnc, c2sCounter, err := sk.Encryptor("c2s", "session", method)
+	if err != nil {
+		panic(err)
+	}
+	tx := shaper.New(crypto.NewRecordWriter(stream, c2sEnc, c2sCounter, aadC2S), shaper.Config{})
+
+	aadS2C := crypto.BuildAAD(endpoint, salt, "s2c", "session", method)
+	s2cEnc, s2cCounter, err := sk.Encryptor("s2c", "session", method)
+	if err != nil {
+		panic(err)
+	}
+	rx := crypto.NewDecryptedReader(stream, aadS2C, s2cEnc, s2cCounter)
+
+	lc, lcPeer := net.Pipe()
+	h := &StreamHandler{
+		transport:         &mockTransport{},
+		masterKey:         key,
+		shaperCfg:         shaper.Config{},
+		streamIdleTimeout: time.Minute, // the drain, not the idle timeout, must end the relay
+		drainIdle:         drainIdle,
+	}
+	return h, tx, rx, lc, lcPeer
+}
+
+// TestStreamRelayDrainsIdleStreamOnDrainingSlot verifies the end-to-end drain
+// wiring: a stream on a slot due for eviction that sits idle past the drain
+// grace is closed early by the relay, reported as an idle-timeout error and
+// counted in the stats.
+func TestStreamRelayDrainsIdleStreamOnDrainingSlot(t *testing.T) {
+	stats.ResetCounters()
+	stream := newDrainMockStream(true)
+	h, tx, rx, lc, lcPeer := newDrainHandler(stream, 100*time.Millisecond)
+	defer lcPeer.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- h.relay("example.com:443", lc, tx, rx, stream) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrStreamIdleTimeout) {
+			t.Fatalf("expected ErrStreamIdleTimeout (drained), got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("relay did not drain the idle stream in time")
+	}
+	if !stream.closed() {
+		t.Fatal("expected the stream to be closed by the drain")
+	}
+	if got := stats.Collect().StreamsDrained; got != 1 {
+		t.Fatalf("StreamsDrained = %d, want 1", got)
+	}
+}
+
+// TestStreamRelayKeepsIdleStreamOnHealthySlot verifies the drain never fires
+// while the slot is healthy: the relay survives far beyond the drain grace
+// and only ends when the stream is closed externally.
+func TestStreamRelayKeepsIdleStreamOnHealthySlot(t *testing.T) {
+	stream := newDrainMockStream(false)
+	h, tx, rx, lc, lcPeer := newDrainHandler(stream, 100*time.Millisecond)
+	defer lcPeer.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- h.relay("example.com:443", lc, tx, rx, stream) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("relay ended early on a healthy slot: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	if stream.closed() {
+		t.Fatal("stream must not be closed while the slot is healthy")
+	}
+
+	// Close the stream to end the relay cleanly.
+	_ = stream.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("relay did not end after the stream was closed")
+	}
+}

--- a/config/types.go
+++ b/config/types.go
@@ -38,6 +38,18 @@ const (
 	DefaultConnLifetimeSec = 420               // 7min
 	DefaultConnMaxBytes    = 256 * 1024 * 1024 // 256MB，双向（上下行）累计
 
+	// ExpiringStreamDrainIdle bounds how long a stream may stay idle on a
+	// slot that is due for eviction (expiring or degraded) before the
+	// client closes it early (see relay.BidirectionalWithDrain). Lingering
+	// keep-alive and half-closed streams otherwise pin the slot's active
+	// count and postpone rotation/retirement until the full relay idle
+	// timeout (10 x DefaultTimeout = 300s). 30s of total silence means the
+	// stream is effectively dead — normal transfers cannot pause that long,
+	// and cover/padding traffic is not counted as activity by the relay —
+	// so closing it interrupts nothing. Active streams (data flowing) are
+	// never drained.
+	ExpiringStreamDrainIdle = 30 * time.Second
+
 	// Fallback timeouts used by the server-side constructors when no
 	// explicit value is provided. DefaultStreamIdleTimeout mirrors the
 	// server's derivation (10 x DefaultTimeout = 300s); the others are

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -21,6 +21,12 @@ type Result struct {
 	Err      error
 	IdleMsg  string
 	TimedOut bool
+	// Drained reports that the relay was terminated early by the drain
+	// mechanism (BidirectionalWithDrain): the stream sat idle beyond
+	// drainIdle while drainWhen reported the owning slot is due for
+	// eviction, so the lingering connection was closed before the full idle
+	// timeout.
+	Drained bool
 }
 
 // Bidirectional runs two copy goroutines concurrently with a shared idle
@@ -35,6 +41,23 @@ type Result struct {
 // first non-nil, non-EOF error is returned. If both copies complete without
 // error, nil is returned.
 func Bidirectional(idleTimeout time.Duration, onClose func(), srcToDst, dstToSrc func(signalActivity func()) error) Result {
+	return bidirectional(idleTimeout, nil, 0, onClose, srcToDst, dstToSrc)
+}
+
+// BidirectionalWithDrain is Bidirectional plus an early-close drain
+// mechanism: while drainWhen reports the relay should wind down (e.g. the
+// owning connection slot is due for rotation or retirement), a relay that has
+// been idle for at least drainIdle is closed instead of waiting out the full
+// idle timeout. Activity (signalActivity or a completed copy) restarts the
+// idle clock, so streams that keep flowing are never drained — only
+// lingering idle connections, which is exactly what postpones slot rotation.
+// drainWhen == nil or drainIdle <= 0 disables the mechanism and the behavior
+// is identical to Bidirectional.
+func BidirectionalWithDrain(idleTimeout time.Duration, drainWhen func() bool, drainIdle time.Duration, onClose func(), srcToDst, dstToSrc func(signalActivity func()) error) Result {
+	return bidirectional(idleTimeout, drainWhen, drainIdle, onClose, srcToDst, dstToSrc)
+}
+
+func bidirectional(idleTimeout time.Duration, drainWhen func() bool, drainIdle time.Duration, onClose func(), srcToDst, dstToSrc func(signalActivity func()) error) Result {
 	activity := make(chan struct{}, 1)
 	signalActivity := func() {
 		select {
@@ -49,6 +72,31 @@ func Bidirectional(idleTimeout time.Duration, onClose func(), srcToDst, dstToSrc
 
 	timer := time.NewTimer(idleTimeout)
 	defer timer.Stop()
+
+	// idleSince tracks the moment the relay's idle clock started, kept in
+	// lockstep with the timer: both restart on activity and on a completed
+	// copy. The drain check compares against it so the drain grace is
+	// measured from the same reference as the idle timeout.
+	idleSince := time.Now()
+	resetIdle := func() {
+		idleSince = time.Now()
+		resetTimer(timer, idleTimeout)
+	}
+
+	// Drain ticker: sampled periodically rather than re-armed on every
+	// state change, because the slot marks (drainWhen) flip asynchronously
+	// from the health loop. The tick is a fraction of drainIdle so the
+	// drain fires within ~drainIdle..drainIdle+tick of going idle.
+	var drainC <-chan time.Time
+	if drainWhen != nil && drainIdle > 0 {
+		tick := drainIdle / 6
+		if tick < 10*time.Millisecond {
+			tick = 10 * time.Millisecond
+		}
+		drainTicker := time.NewTicker(tick)
+		defer drainTicker.Stop()
+		drainC = drainTicker.C
+	}
 
 	done := 0
 	var firstErr error
@@ -65,9 +113,28 @@ func Bidirectional(idleTimeout time.Duration, onClose func(), srcToDst, dstToSrc
 				}
 				return Result{Err: firstErr}
 			}
-			resetTimer(timer, idleTimeout)
+			resetIdle()
 		case <-activity:
-			resetTimer(timer, idleTimeout)
+			resetIdle()
+		case <-drainC:
+			if drainWhen() && time.Since(idleSince) >= drainIdle {
+				if onClose != nil {
+					onClose()
+				}
+				// Drain both goroutine results so they can exit cleanly.
+				for i := 0; i < 2; i++ {
+					select {
+					case <-errCh:
+					default:
+					}
+				}
+				return Result{
+					Err:      fmt.Errorf("stream drained: idle for %v while the slot is due for eviction", drainIdle),
+					IdleMsg:  fmt.Sprintf("drained after %v idle (slot due for eviction)", drainIdle),
+					TimedOut: true,
+					Drained:  true,
+				}
+			}
 		case <-timer.C:
 			if onClose != nil {
 				onClose()

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -1,0 +1,160 @@
+package relay
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockPair returns two copy functions that block until onClose fires, and
+// the onClose callback itself, which closes the block channel exactly once so
+// the copy goroutines exit after the relay terminates.
+func blockPair() (func(func()) error, func(func()) error, func()) {
+	block := make(chan struct{})
+	var once sync.Once
+	onClose := func() { once.Do(func() { close(block) }) }
+	copyBlock := func(signal func()) error {
+		<-block
+		return nil
+	}
+	return copyBlock, copyBlock, onClose
+}
+
+func TestBidirectionalCompletion(t *testing.T) {
+	closed := 0
+	onClose := func() { closed++ }
+	result := Bidirectional(time.Minute, onClose,
+		func(signal func()) error { return nil },
+		func(signal func()) error { return nil },
+	)
+	if result.Err != nil || result.TimedOut || result.Drained {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if closed != 1 {
+		t.Fatalf("onClose called %d times, want 1", closed)
+	}
+}
+
+func TestBidirectionalFirstError(t *testing.T) {
+	sentinel := errors.New("copy failed")
+	closed := 0
+	_, copy2, onClose := blockPair()
+	result := Bidirectional(time.Minute, func() { closed++; onClose() },
+		func(signal func()) error { return sentinel },
+		copy2,
+	)
+	if !errors.Is(result.Err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", result.Err)
+	}
+	if result.TimedOut || result.Drained {
+		t.Fatalf("unexpected flags: %+v", result)
+	}
+	if closed != 1 {
+		t.Fatalf("onClose called %d times, want 1", closed)
+	}
+}
+
+func TestBidirectionalIdleTimeout(t *testing.T) {
+	copy1, copy2, onClose := blockPair()
+	closed := 0
+	start := time.Now()
+	result := Bidirectional(50*time.Millisecond, func() { closed++; onClose() }, copy1, copy2)
+	if !result.TimedOut {
+		t.Fatalf("expected TimedOut, got %+v", result)
+	}
+	if result.Drained {
+		t.Fatal("plain Bidirectional must never report Drained")
+	}
+	if closed != 1 {
+		t.Fatalf("onClose called %d times, want 1", closed)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("timeout took %v, want ~50ms", elapsed)
+	}
+}
+
+// TestBidirectionalWithDrainFires verifies the drain mechanism closes a
+// relay that has been idle beyond drainIdle while drainWhen is true.
+func TestBidirectionalWithDrainFires(t *testing.T) {
+	copy1, copy2, onClose := blockPair()
+	closed := 0
+	start := time.Now()
+	result := BidirectionalWithDrain(time.Minute, func() bool { return true }, 100*time.Millisecond,
+		func() { closed++; onClose() }, copy1, copy2)
+	if !result.Drained || !result.TimedOut {
+		t.Fatalf("expected drained+timed out result, got %+v", result)
+	}
+	if closed != 1 {
+		t.Fatalf("onClose called %d times, want 1", closed)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("drain took %v, want ~100ms", elapsed)
+	}
+}
+
+// TestBidirectionalWithDrainNotFiredWithoutSlotMark verifies the drain never
+// fires while drainWhen reports the slot is not due for eviction; the relay
+// only ends when a copy errors.
+func TestBidirectionalWithDrainNotFiredWithoutSlotMark(t *testing.T) {
+	_, copy2, onClose := blockPair()
+	closed := 0
+	start := time.Now()
+	// copy1 signals activity for 300ms (well beyond drainIdle) then errors;
+	// without the slot mark the relay must survive that whole window.
+	result := BidirectionalWithDrain(time.Minute, func() bool { return false }, 100*time.Millisecond,
+		func() { closed++; onClose() },
+		func(signal func()) error {
+			deadline := time.Now().Add(300 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				signal()
+				time.Sleep(10 * time.Millisecond)
+			}
+			return errors.New("copy done")
+		},
+		copy2,
+	)
+	if result.Drained || result.TimedOut {
+		t.Fatalf("expected a plain copy-error result, got %+v", result)
+	}
+	if result.Err == nil {
+		t.Fatal("expected the copy error")
+	}
+	if closed != 1 {
+		t.Fatalf("onClose called %d times, want 1", closed)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("relay took %v, want ~300ms", elapsed)
+	}
+}
+
+// TestBidirectionalWithDrainResetByActivity verifies that a stream which
+// keeps flowing is never drained: activity restarts the idle clock, so even
+// with drainWhen true the relay survives far beyond drainIdle and only ends
+// when a copy errors.
+func TestBidirectionalWithDrainResetByActivity(t *testing.T) {
+	copyBlock, _, onCloseBlock := blockPair()
+	closed := 0
+	result := BidirectionalWithDrain(time.Minute, func() bool { return true }, 100*time.Millisecond,
+		func() { closed++; onCloseBlock() },
+		func(signal func()) error {
+			// Keep flowing for 400ms, far beyond drainIdle.
+			deadline := time.Now().Add(400 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				signal()
+				time.Sleep(10 * time.Millisecond)
+			}
+			return errors.New("copy done")
+		},
+		copyBlock,
+	)
+	if result.Drained {
+		t.Fatal("expected not drained while activity keeps flowing")
+	}
+	if result.Err == nil {
+		t.Fatal("expected the copy error")
+	}
+	if closed != 1 {
+		t.Fatalf("onClose called %d times, want 1", closed)
+	}
+}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -59,6 +59,11 @@ type stats struct {
 	slotProbes           atomic.Int64
 	slotProbeSlow        atomic.Int64
 	slotProbeUnsupported atomic.Int64
+	// streamsDrained counts streams closed early by the relay drain
+	// mechanism: idle streams on slots due for eviction (expiring/degraded)
+	// closed before the full idle timeout so rotation/retirement completes
+	// promptly (see relay.BidirectionalWithDrain).
+	streamsDrained atomic.Int64
 
 	rttMu    sync.Mutex
 	rttEWMA  int64 // nanoseconds, EWMA-smoothed pure path RTT
@@ -120,6 +125,7 @@ func RecordSlotProbeSlow()       { g.slotProbeSlow.Add(1) }
 func RecordSlotProbeUnsupported() {
 	g.slotProbeUnsupported.Add(1)
 }
+func RecordStreamDrained() { g.streamsDrained.Add(1) }
 
 const rttAlpha = 0.35
 
@@ -188,6 +194,7 @@ func ResetCounters() {
 	g.slotProbes.Store(0)
 	g.slotProbeSlow.Store(0)
 	g.slotProbeUnsupported.Store(0)
+	g.streamsDrained.Store(0)
 
 	g.rttMu.Lock()
 	g.rttEWMA = 0
@@ -252,6 +259,7 @@ type Snapshot struct {
 	SlotProbes           int64 `json:"slot_probes"`
 	SlotProbeSlow        int64 `json:"slot_probe_slow"`
 	SlotProbeUnsupported int64 `json:"slot_probe_unsupported"`
+	StreamsDrained       int64 `json:"streams_drained"`
 
 	// Speed
 	UploadSpeed            int64  `json:"upload_speed"`
@@ -345,6 +353,7 @@ func Collect() Snapshot {
 		SlotProbes:             g.slotProbes.Load(),
 		SlotProbeSlow:          g.slotProbeSlow.Load(),
 		SlotProbeUnsupported:   g.slotProbeUnsupported.Load(),
+		StreamsDrained:         g.streamsDrained.Load(),
 		UploadSpeed:            upSpeed,
 		DownloadSpeed:          downSpeed,
 		UploadSpeedHuman:       HumanBytes(upSpeed) + "/s",

--- a/transport/http2/stream.go
+++ b/transport/http2/stream.go
@@ -257,3 +257,15 @@ func (s *HTTP2Stream) Close() error {
 }
 
 var _ transport.Stream = (*HTTP2Stream)(nil)
+
+// SlotDraining reports whether the stream's slot is due for eviction: the
+// connection exceeded its lifetime or bytes limit (expiring) or was confirmed
+// persistently slow (degraded), so it should be recycled. The proxy layer
+// asserts transport.SlotDrainingStream on the stream and closes idle streams
+// early via relay.BidirectionalWithDrain, so lingering keep-alive and
+// half-closed connections cannot postpone the slot's rotation/retirement
+// until the full relay idle timeout. Active streams are never drained: the
+// relay only closes them once they have been idle for ExpiringStreamDrainIdle.
+func (s *HTTP2Stream) SlotDraining() bool {
+	return s.slot != nil && (s.slot.expiring.Load() || s.slot.degraded.Load())
+}

--- a/transport/http2/stream_test.go
+++ b/transport/http2/stream_test.go
@@ -217,3 +217,38 @@ func TestHTTP2Stream_RecordsPathRTTOnResponse(t *testing.T) {
 		}
 	})
 }
+
+// TestHTTP2Stream_SlotDraining verifies the drain signal reflects the slot's
+// eviction marks (expiring/degraded), which drives the proxy's early close of
+// idle streams (relay.BidirectionalWithDrain).
+func TestHTTP2Stream_SlotDraining(t *testing.T) {
+	s, pr := newTestStream()
+	defer pr.Close()
+	defer s.Close()
+
+	slot := &transportSlot{}
+	s.slot = slot
+
+	if s.SlotDraining() {
+		t.Fatal("fresh slot must not report draining")
+	}
+	slot.expiring.Store(true)
+	if !s.SlotDraining() {
+		t.Fatal("expected draining when the slot is expiring")
+	}
+	slot.expiring.Store(false)
+	slot.degraded.Store(true)
+	if !s.SlotDraining() {
+		t.Fatal("expected draining when the slot is degraded")
+	}
+	slot.expiring.Store(true)
+	if !s.SlotDraining() {
+		t.Fatal("expected draining when the slot is expiring+degraded")
+	}
+
+	// A stream without a slot must not panic and never drains.
+	ns := &HTTP2Stream{}
+	if ns.SlotDraining() {
+		t.Fatal("nil slot must not report draining")
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -38,6 +38,17 @@ type Stream interface {
 	Close() error
 }
 
+// SlotDrainingStream is implemented by streams whose underlying connection
+// slot is due for eviction: expiring (the connection exceeded its lifetime or
+// bytes limit) or degraded (confirmed persistently low throughput). The proxy
+// layer asserts this optional interface to drain idle streams early (see
+// relay.BidirectionalWithDrain), so lingering keep-alive and half-closed
+// connections cannot postpone the slot's rotation/retirement until the full
+// relay idle timeout. Streams that do not implement it simply never drain.
+type SlotDrainingStream interface {
+	SlotDraining() bool
+}
+
 type OpenRequest struct {
 	Endpoint     string
 	Salt         string


### PR DESCRIPTION
## 背景

客户端的统计信息中经常出现 expiring 的 slot 长时间存在 1-2 个活跃流，导致 slot 迟迟无法轮换。审计后发现：

- 流本身没有泄漏（所有路径都会关闭流），但"尽快回收"不达标；
- relay 等待双向结束 + 300s 空闲超时，使空闲 keep-alive 流和半关闭流（源站 keep-alive 不关闭连接）在最后一个字节后继续存活最多 300s；
- 健康循环的轮换只在 `active == 0` 时执行（不打断在途流），这 1-2 个残留流把 expiring/degraded slot 钉住最长 300s。

## 改动

新增"槽位排干（slot drain）"机制，让 relay 在槽位需要轮换时主动提前关闭空闲流：

- `relay` 包：新增 `BidirectionalWithDrain(idleTimeout, drainWhen, drainIdle, ...)`，与原 `Bidirectional` 共享实现（服务端/直连中继零改动）。relay 内部跟踪 idleSince（与空闲计时器同源），当 `drainWhen()` 为真且流空闲超过 `ExpiringStreamDrainIdle`（默认 30s）时提前关闭；活跃流（持续有数据）永远不会被排干。
- `transport` 包：新增可选接口 `SlotDrainingStream`（`HTTP2Stream` 实现：槽位 expiring 或 degraded 时为 true），不实现的流保持原行为。
- `client/proxy`：`StreamHandler.relay()` 接入排干，Drained 结果按瞬时空闲超时处理并计数。
- `stats`：新增 `streams_drained` 计数器，可在 `/stats` 中观察验证。
- 效果：expiring/degraded 槽位上的空闲流在其空闲后 ≤ ~35s 内被关闭（原来最长 300s），健康循环下一 tick（≤5s）即完成轮换/退役。

## 测试

- `relay/relay_test.go`（新增）：排干触发 / 无槽位标记不触发 / 活动重置不触发 / 原有语义不变。
- `client/proxy/stream_drain_test.go`（新增）：端到端验证排干接入与健康槽位不排干。
- `transport/http2/stream_test.go`：`SlotDraining()` 单元测试。
- `go test ./...` 全量通过，`make lint` 0 issues。
