### PR TITLE
fix: reset rotation state when grow revives a slot

### DIFF
--- a/transport/http2/consistency_test.go
+++ b/transport/http2/consistency_test.go
@@ -55,10 +55,16 @@ func TestStatsConnsStatusConsistencyUnderShrink(t *testing.T) {
 				return
 			default:
 			}
+			// Render under the scheduler read lock, exactly like the
+			// production Stats() snapshot: shrink/grow swap-remove slots
+			// under the write lock, so an unlocked render would race with
+			// the array swaps.
+			sch.mu.RLock()
 			pLive := int(sch.priority.liveCount.Load())
 			bLive := int(sch.bulk.liveCount.Load())
 			pStr := slotStatusString(sch.priority, pLive)
 			bStr := slotStatusString(sch.bulk, bLive)
+			sch.mu.RUnlock()
 			pIdxs := parseIndices(pStr)
 			bIdxs := parseIndices(bStr)
 			if len(pIdxs) > pLive {

--- a/transport/http2/lifecycle.go
+++ b/transport/http2/lifecycle.go
@@ -256,6 +256,15 @@ func (lc *slotLifecycle) evaluateRotation(idx int, s *transportSlot) {
 		if s.active.Load() == 0 {
 			s.t.CloseIdleConnections()
 			s.expiring.Store(false)
+			// The tired connection has been recycled: zero the deadline
+			// and bytes so rotationDue cannot re-trigger on the old
+			// connection's state — otherwise a slot whose connection was
+			// already closed (idle timeout, server close) would be marked
+			// expiring again on every health tick until the next dial
+			// resets the state via resetConn. The next stream dials a
+			// fresh connection and starts a new lifetime.
+			s.expireAt.Store(0)
+			s.connBytes.Store(0)
 			stats.RecordConnRotated()
 			log.Info("[TRANSPORT] connection rotated", "slot", idx)
 		}

--- a/transport/http2/lifecycle_test.go
+++ b/transport/http2/lifecycle_test.go
@@ -457,6 +457,7 @@ func TestEvaluateRotation(t *testing.T) {
 		lc := &slotLifecycle{connLifetime: time.Minute}
 		s := &transportSlot{t: &http.Transport{}}
 		s.expireAt.Store(time.Now().Add(-2 * time.Minute).UnixNano())
+		s.connBytes.Store(1024)
 		s.active.Store(1)
 		// First pass: still busy, only mark expiring.
 		lc.evaluateRotation(0, s)
@@ -464,10 +465,24 @@ func TestEvaluateRotation(t *testing.T) {
 			t.Fatal("expected expiring mark")
 		}
 		// Second pass: idle now, rotation completes and clears the mark.
+		// The deadline and bytes are zeroed too, so the completed rotation
+		// cannot re-trigger on the recycled connection's state.
 		s.active.Store(0)
 		lc.evaluateRotation(0, s)
 		if s.expiring.Load() {
 			t.Fatal("expected expiring cleared after rotation")
+		}
+		if s.expireAt.Load() != 0 {
+			t.Fatalf("expireAt = %d, want 0 after rotation completed", s.expireAt.Load())
+		}
+		if s.connBytes.Load() != 0 {
+			t.Fatalf("connBytes = %d, want 0 after rotation completed", s.connBytes.Load())
+		}
+		// Third pass: the slot has no connection anymore, so it must not
+		// be marked expiring again on every tick.
+		lc.evaluateRotation(0, s)
+		if s.expiring.Load() {
+			t.Fatal("expected no expiring mark after rotation completed")
 		}
 	})
 
@@ -480,6 +495,39 @@ func TestEvaluateRotation(t *testing.T) {
 			t.Fatal("fresh connection must not expire")
 		}
 	})
+}
+
+func TestResetRotationClearsMarks(t *testing.T) {
+	s := &transportSlot{}
+	// A slot revived by grow (or after a completed rotation) carries the
+	// previous connection's state: an overdue deadline, bytes carried and
+	// expiring/degraded verdicts. resetRotation must return it to the "no
+	// connection" baseline: no marks, zero deadline, zero bytes — so
+	// rotationDue never triggers on the recycled connection's state.
+	s.degraded.Store(true)
+	s.expiring.Store(true)
+	s.expireAt.Store(time.Now().Add(-time.Minute).UnixNano())
+	s.connBytes.Store(1024)
+
+	s.resetRotation()
+
+	if s.degraded.Load() {
+		t.Fatal("expected degraded cleared")
+	}
+	if s.expiring.Load() {
+		t.Fatal("expected expiring cleared")
+	}
+	if s.connBytes.Load() != 0 {
+		t.Fatalf("connBytes = %d, want 0", s.connBytes.Load())
+	}
+	if s.expireAt.Load() != 0 {
+		t.Fatalf("expireAt = %d, want 0 (no connection yet)", s.expireAt.Load())
+	}
+	// A slot without a connection must never be judged overdue.
+	lc := &slotLifecycle{connLifetime: time.Minute}
+	if lc.rotationDue(s, time.Now()) {
+		t.Fatal("slot without a connection must not be due for rotation")
+	}
 }
 
 func TestResetConnClearsMarks(t *testing.T) {

--- a/transport/http2/scheduler.go
+++ b/transport/http2/scheduler.go
@@ -637,9 +637,18 @@ func (s *slotScheduler) grow(highPriority bool) {
 	if target == nil {
 		return
 	}
+	// A revived slot must not inherit the previous connection's rotation
+	// state: shrink/retire swap-remove slots out of the live set without
+	// clearing their marks, so a re-activated slot would otherwise show
+	// stale expiring/degraded verdicts and an overdue deadline until its
+	// first dial completes. Zero the connection-scoped state before the
+	// slot becomes live; the actual dial resets the deadline via resetConn.
 	if live == 0 && target.maxSlots >= 2 {
+		target.slots[live].resetRotation()
+		target.slots[live+1].resetRotation()
 		target.liveCount.Add(2)
 	} else {
+		target.slots[live].resetRotation()
 		target.liveCount.Add(1)
 	}
 }

--- a/transport/http2/scheduler_test.go
+++ b/transport/http2/scheduler_test.go
@@ -1008,6 +1008,54 @@ func TestGrowFirstActivationPerPool(t *testing.T) {
 	}
 }
 
+func TestGrowResetsRevivedSlotState(t *testing.T) {
+	// A slot revived by grow must not inherit the previous connection's
+	// rotation state: shrink/retire swap-remove slots out of the live set
+	// without clearing their marks, so a re-activated slot would otherwise
+	// be judged overdue (expiring) and stay degraded until its first dial
+	// completes — the "fresh slot immediately expiring" symptom.
+	sch := newGrowTestScheduler(6, 3, 0, 0)
+	// Bulk slots 0/1 were shrunk while carrying the old connection's
+	// state: expired deadline, bytes carried, degraded/expiring verdicts.
+	sch.bulk.slots[0].degraded.Store(true)
+	sch.bulk.slots[0].expiring.Store(true)
+	sch.bulk.slots[0].expireAt.Store(time.Now().Add(-time.Minute).UnixNano())
+	sch.bulk.slots[0].connBytes.Store(1024)
+	sch.bulk.slots[1].degraded.Store(true)
+	sch.bulk.slots[1].expireAt.Store(time.Now().Add(-time.Minute).UnixNano())
+
+	// First activation revives two slots at once and must reset both.
+	sch.grow(false)
+	if got := sch.bulk.liveCount.Load(); got != 2 {
+		t.Fatalf("bulk liveCount = %d, want 2 on first activation", got)
+	}
+	lc := &slotLifecycle{connLifetime: time.Minute}
+	for i, s := range []*transportSlot{sch.bulk.slots[0], sch.bulk.slots[1]} {
+		if s.degraded.Load() {
+			t.Fatalf("slot %d: degraded must be cleared on revival", i)
+		}
+		if s.expiring.Load() {
+			t.Fatalf("slot %d: expiring must be cleared on revival", i)
+		}
+		if s.expireAt.Load() != 0 {
+			t.Fatalf("slot %d: expireAt = %d, want 0 until dialed", i, s.expireAt.Load())
+		}
+		if s.connBytes.Load() != 0 {
+			t.Fatalf("slot %d: connBytes = %d, want 0", i, s.connBytes.Load())
+		}
+		if lc.rotationDue(s, time.Now()) {
+			t.Fatalf("slot %d: revived slot without a connection must not be due for rotation", i)
+		}
+		if slotTierOf(s) != tierActive {
+			t.Fatalf("slot %d: tier = %v, want tierActive", i, slotTierOf(s))
+		}
+	}
+	// The revived slots are immediately selectable (not draining/retiring).
+	if got := sch.pick(false); got != sch.bulk.slots[0] {
+		t.Fatalf("pick(false) = slot %d, want revived bulk slot 0", got.idx)
+	}
+}
+
 func TestRemoveShrinksLiveCountAndLocatesPool(t *testing.T) {
 	s0 := &transportSlot{t: &http.Transport{}}
 	s0.active.Store(1)

--- a/transport/http2/slot.go
+++ b/transport/http2/slot.go
@@ -50,6 +50,22 @@ type transportSlot struct {
 	lastProbeAt    time.Time
 }
 
+// resetRotation clears the connection-scoped state of a slot whose
+// connection no longer exists (closed by shrink/retire/rotation, or never
+// established): the deadline, bytes carried and the expiring/degraded marks
+// all go back to the "no connection" baseline. expireAt is zeroed rather
+// than set to a fresh deadline — rotationDue only triggers on expireAt > 0,
+// so a slot without a connection is never judged overdue. The next dial
+// calls resetConn, which sets the real deadline. grow calls this when it
+// re-activates a pre-allocated slot, so a revived slot cannot inherit the
+// previous connection's expired deadline or verdicts.
+func (s *transportSlot) resetRotation() {
+	s.expireAt.Store(0)
+	s.connBytes.Store(0)
+	s.expiring.Store(false)
+	s.degraded.Store(false)
+}
+
 // resetConn (re)initializes the rotation state for a freshly established
 // connection: the lifetime deadline (with per-connection jitter), the bytes
 // carried and the expiring mark all start fresh. The degraded mark is
@@ -60,8 +76,6 @@ type transportSlot struct {
 // transportSlot object, and its new connection must not inherit the old
 // verdict.
 func (s *transportSlot) resetConn(connLifetime time.Duration) {
+	s.resetRotation()
 	s.expireAt.Store(time.Now().Add(rotationLifetime(connLifetime)).UnixNano())
-	s.connBytes.Store(0)
-	s.expiring.Store(false)
-	s.degraded.Store(false)
 }


### PR DESCRIPTION
## 问题

在 macOS 客户端上观察 `/stats`，刷新页面触发连接扩容后，`priority_conns_status` 出现大量 `degraded+expiring`，例如：

```
[0:0:degraded, 1:0:degraded+expiring, 2:0:degraded+expiring, 3:0:degraded+expiring, 4:2:heavy+expiring, 5:0:degraded]
```

前一秒还只有 1 个 slot，后一秒扩容出 6 个，且新激活的 slot 立即显示 `degraded+expiring`。

## 根因

slot 不是"新申请的"，而是被复活的旧对象：

1. `New()` 一次性预分配全部 `transportSlot`，`grow()` 只增加 `liveCount` 复活数组中的旧对象，且不立即拨号（连接懒加载，`RoundTrip` 时才建立）。
2. 状态清除只发生在 `resetConn()`（位于 `DialTLSContext`，拨号成功才执行）。
3. `closeIdleLoop` 的 `shrinkIdleLocked()` 把空闲 slot swap-remove 出 live set，但 `expireAt`（过去的时间戳）、`degraded`、`expiring`、`connBytes` 全部残留。
4. 复活后拨号前：旧 `expireAt` 已过期 → 健康循环 `evaluateRotation` 立即打上 `expiring`；旧 `degraded` 残留 → 显示 `degraded+expiring`（tierRetiring，调度器完全不选）。若激活的 slot 未被新流 pick 拨号，该假状态持续可见。
5. 次要问题：连接已死但 `expireAt` 已过的 slot，健康循环每 5s 打一次 expiring 再清除一次（闪烁），stats 约一半概率抓到 expiring。

## 修复

- **slot.go**：抽出 `resetRotation()`，清空 `expireAt`（置 0，`rotationDue` 已有 `expireAt > 0` 前置检查，无连接永不判过期）、`connBytes`、`expiring`、`degraded`；`resetConn` 复用。
- **scheduler.go**：`grow()` 在锁内激活 slot 前调用 `resetRotation()`，复活 slot 以"从未拨号"的干净状态进入 live set，直到真实拨号由 `resetConn` 设定新 deadline。
- **lifecycle.go**：旋转完成分支在 `CloseIdleConnections()` 后把 `expireAt`/`connBytes` 归零，消除"假 expiring 闪烁"。
- **测试**：新增 `TestResetRotationClearsMarks`、`TestGrowResetsRevivedSlotState`，扩展 `TestEvaluateRotation`；顺带修复 `consistency_test.go` 中预先存在的竞态（渲染未持调度器读锁，与生产 `Stats()` 的锁契约不一致）。

## 验证

- `go test -race ./transport/http2/...` 全部通过
- `make lint` 0 issues
- 全量 `go test ./...` 仅 `util.TestIsTunIface` 失败（macOS 环境问题，改动前同样失败，与本次修复无关）

修复后：扩容激活的 slot 显示 `active`；连接真正到期时 `expiring` 出现一次、完成旋转后不再闪烁。