### PR TITLE
Rotate connections sooner with symmetric lifetime jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Easyss v3 支持两种配置模式，自动识别：
     "conn_count_max": 15,
     "stream_threshold": 4,
     "priority_slot_ratio": 0.4,
-    "conn_lifetime_sec": 420,
+    "conn_lifetime_sec": 360,
     "conn_max_bytes": 268435456
   },
   "shaper": {
@@ -185,7 +185,7 @@ Easyss v3 支持两种配置模式，自动识别：
 | `transport.conn_count_max` | 15 | 最大连接数，懒加载扩容的上限 |
 | `transport.stream_threshold` | 4 | 活跃流达到该阈值且连接数未达上限时，新建连接 |
 | `transport.priority_slot_ratio` | 0.4 | 优先（交互式）槽位占连接数的比例，其余为批量槽位 |
-| `transport.conn_lifetime_sec` | 420 | 单连接最大存活时间（秒），0 使用默认值；到期后停止接收新流并轮换连接 |
+| `transport.conn_lifetime_sec` | 360 | 单连接最大存活时间（秒），0 使用默认值；到期后停止接收新流并轮换连接 |
 | `transport.conn_max_bytes` | 268435456 | 单连接双向累计最大字节数（256MB），0 使用默认值；超限后轮换连接 |
 
 **shaper 参数说明：**

--- a/config/types.go
+++ b/config/types.go
@@ -35,7 +35,7 @@ const (
 	// why a reconnect feels fast again. A slot whose connection exceeded
 	// either limit stops accepting new streams and its idle connection is
 	// closed, so the next stream dials a fresh one (invisible to users).
-	DefaultConnLifetimeSec = 420               // 7min
+	DefaultConnLifetimeSec = 360               // 6min
 	DefaultConnMaxBytes    = 256 * 1024 * 1024 // 256MB，双向（上下行）累计
 
 	// ExpiringStreamDrainIdle bounds how long a stream may stay idle on a

--- a/transport/http2/lifecycle.go
+++ b/transport/http2/lifecycle.go
@@ -292,19 +292,21 @@ func (lc *slotLifecycle) rotationDue(s *transportSlot, now time.Time) bool {
 }
 
 // rotationLifetime returns the connection lifetime with a per-connection
-// random jitter of up to 50%. Connections created in the same burst (e.g.
-// several slots dialing together) then expire in different health ticks,
-// so rotations and the subsequent TLS handshakes do not cluster into a
-// single fingerprintable burst. With the default 7-minute lifetime the
-// jitter spreads a same-batch expiry over a 3.5-minute window (roughly 42
-// health ticks), so a batch never tips into expiring at once and the
-// scheduler keeps healthy slots to spread new streams onto.
+// symmetric random jitter of ±30% (within [0.7×base, 1.3×base]).
+// Connections created in the same burst (e.g. several slots dialing
+// together) then expire in different health ticks, so rotations and the
+// subsequent TLS handshakes do not cluster into a single fingerprintable
+// burst. The jitter is symmetric around the configured lifetime, so the
+// mean stays at the base (6 minutes by default) while a same-batch expiry
+// spreads over a 3.6-minute window (roughly 43 health ticks) — no long
+// tail, and a batch never tips into expiring at once, keeping healthy
+// slots available to spread new streams onto.
 func rotationLifetime(base time.Duration) time.Duration {
-	span := int64(base) / 2
+	span := int64(base) * 3 / 10
 	if span <= 0 {
 		return base
 	}
-	return base + time.Duration(rand.Int64N(span+1))
+	return base - time.Duration(span) + time.Duration(rand.Int64N(2*span+1))
 }
 
 // retire closes a degraded slot's idle connection and removes the slot from

--- a/transport/http2/lifecycle_test.go
+++ b/transport/http2/lifecycle_test.go
@@ -443,11 +443,12 @@ func TestRotationDue(t *testing.T) {
 
 func TestRotationLifetimeJitter(t *testing.T) {
 	const base = 15 * time.Minute
-	max := base + base/2
+	span := base * 3 / 10
+	min, max := base-span, base+span
 	for i := 0; i < 1000; i++ {
 		got := rotationLifetime(base)
-		if got < base || got > max {
-			t.Fatalf("rotationLifetime(%v) = %v, want within [%v, %v]", base, got, base, max)
+		if got < min || got > max {
+			t.Fatalf("rotationLifetime(%v) = %v, want within [%v, %v]", base, got, min, max)
 		}
 	}
 }


### PR DESCRIPTION
## 背景

HTTP/2 长连接在高峰时段容易被中间盒限速，因此需要周期性轮换连接。原实现默认连接寿命 7 分钟、随机 jitter 为"只加 50%"（即 `[base, 1.5×base]`），存在两个问题：

- 平均寿命偏高，连接不够"新鲜"，轮换不够及时；
- 加法 jitter 让部分连接活到 1.5×base，尾部偏长。

## 改动

1. **默认连接寿命**：`DefaultConnLifetimeSec` 从 420s（7min）降至 360s（6min）。
2. **jitter 方式**：`rotationLifetime` 由"只加 50%"改为"对称 ±30%"，即 `[0.7×base, 1.3×base]`。
3. 同步更新单元测试（`TestRotationLifetimeJitter` 校验上下界）与 README 文档。

## 效果

- 错开窗口保持 216s（≈43 个健康 tick），同批连接的到期时间依旧充分分散，不会同时进入 expiring；
- 平均寿命从 468s 降至 360s（配置值 6min 现在表示均值），轮换更及时，缓解中间盒限速；
- 最大寿命从 576s 降至 468s，无长尾，TLS 握手簇化风险更低；
- 代价：少数连接会提前到 ~4.2min 轮换，握手频率略增（可接受）。

## 测试

- `go test ./transport/...` 通过
- `make lint` 0 issues
