### PR TITLE
feat: multiplex proxied DNS over a single shared HTTP/2 stream

### DIFF
--- a/client/proxy/dns_shared_exchange_test.go
+++ b/client/proxy/dns_shared_exchange_test.go
@@ -1,0 +1,515 @@
+package proxy
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	easydns "github.com/nange/easyss/v3/client/dns"
+	"github.com/nange/easyss/v3/client/router"
+	"github.com/nange/easyss/v3/config"
+	"github.com/nange/easyss/v3/crypto"
+	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/shaper"
+	"github.com/nange/easyss/v3/transport"
+	"github.com/txthinking/socks5"
+)
+
+// pipeStream adapts one end of a net.Pipe connection to transport.Stream so
+// tests can read/inject encrypted records on the other end.
+type pipeStream struct{ conn net.Conn }
+
+func (s *pipeStream) Read(p []byte) (int, error)  { return s.conn.Read(p) }
+func (s *pipeStream) Write(p []byte) (int, error) { return s.conn.Write(p) }
+func (s *pipeStream) CloseWrite() error {
+	if cw, ok := s.conn.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return nil
+}
+func (s *pipeStream) Close() error { return s.conn.Close() }
+
+var _ transport.Stream = (*pipeStream)(nil)
+
+// newSharedDNSExchange builds a UDPExchange over a net.Pipe pair together
+// with a server-side record writer used to inject DNS responses. The client
+// side (stream) is what the shared receive loop reads from; responses are
+// encrypted on the server side with the same session keys.
+func newSharedDNSExchange(t *testing.T) (*UDPExchange, *crypto.RecordWriter, net.Conn) {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	endpoint := config.EndpointUDP
+	method := protocol.MethodAES256GCM
+	salt, err := crypto.GenerateSalt()
+	if err != nil {
+		t.Fatalf("GenerateSalt: %v", err)
+	}
+	sk, err := crypto.NewStreamKeys(key, salt, endpoint)
+	if err != nil {
+		t.Fatalf("NewStreamKeys: %v", err)
+	}
+
+	aadC2S := crypto.BuildAAD(endpoint, salt, "c2s", "session", method)
+	c2sEnc, c2sCounter, err := sk.Encryptor("c2s", "session", method)
+	if err != nil {
+		t.Fatalf("c2s encryptor: %v", err)
+	}
+	aadS2C := crypto.BuildAAD(endpoint, salt, "s2c", "session", method)
+	s2cEnc, s2cCounter, err := sk.Encryptor("s2c", "session", method)
+	if err != nil {
+		t.Fatalf("s2c encryptor: %v", err)
+	}
+
+	clientSide, serverSide := net.Pipe()
+	clientStream := &pipeStream{conn: clientSide}
+	ue := &UDPExchange{
+		stream: clientStream,
+		tx:     shaper.New(crypto.NewRecordWriter(clientStream, c2sEnc, c2sCounter, aadC2S), shaper.Config{}),
+		reader: crypto.NewDecryptedReader(clientStream, aadS2C, s2cEnc, s2cCounter),
+		target: "8.8.8.8:53",
+	}
+	ue.lastSeen.Store(time.Now().UnixNano())
+
+	// Independent server-side s2c counter: both the client reader and the
+	// server writer start at counter 0, so records written in order decrypt
+	// in order.
+	s2cEnc2, s2cCounter2, err := sk.Encryptor("s2c", "session", method)
+	if err != nil {
+		t.Fatalf("server s2c encryptor: %v", err)
+	}
+	serverTx := crypto.NewRecordWriter(serverSide, s2cEnc2, s2cCounter2, aadS2C)
+	return ue, serverTx, serverSide
+}
+
+// injectDNSResponse writes one DNS response as a DATAGRAM frame record on the
+// server side of the exchange.
+func injectDNSResponse(t *testing.T, serverTx *crypto.RecordWriter, msg *dns.Msg) {
+	t.Helper()
+	packed, err := msg.Pack()
+	if err != nil {
+		t.Fatalf("pack dns response: %v", err)
+	}
+	frame := protocol.NewFrameDATAGRAM(packed)
+	if err := serverTx.WriteRecord(protocol.EncodeFrames([]protocol.Frame{frame})); err != nil {
+		t.Fatalf("write response record: %v", err)
+	}
+}
+
+// newSharedDNSHarness returns a Socks5Server with the shared-DNS state wired
+// up and a fake socks5 server whose UDPConn delivers responses to clients.
+func newSharedDNSHarness(t *testing.T) (*Socks5Server, *socks5.Server) {
+	t.Helper()
+	rt, err := router.New(router.Config{})
+	if err != nil {
+		t.Fatalf("router.New: %v", err)
+	}
+	s := &Socks5Server{
+		router:         rt,
+		dnsCache:       easydns.NewCache(""),
+		dnsRespTimeout: testDNSRespTimeout,
+		dnsPending:     make(map[uint16]dnsPendingEntry),
+		dnsDedup:       make(map[uint64][]uint16),
+		udpExch:        make(map[string]*UDPExchange),
+		udpInflight:    make(map[string]*udpExchangeFactory),
+	}
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("listen server udp: %v", err)
+	}
+	t.Cleanup(func() { pc.Close() })
+	return s, &socks5.Server{UDPConn: pc}
+}
+
+// newFakeDNSClient binds a UDP socket acting as a DNS client.
+func newFakeDNSClient(t *testing.T) *net.UDPConn {
+	t.Helper()
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("listen client udp: %v", err)
+	}
+	t.Cleanup(func() { pc.Close() })
+	return pc
+}
+
+// readDNSResponse reads one SOCKS5 UDP datagram on the fake client socket and
+// returns the parsed DNS message.
+func readDNSResponse(t *testing.T, client *net.UDPConn) *dns.Msg {
+	t.Helper()
+	buf := make([]byte, 65535)
+	if err := client.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	n, _, err := client.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("read client datagram: %v", err)
+	}
+	d, err := socks5.NewDatagramFromBytes(buf[:n])
+	if err != nil {
+		t.Fatalf("parse datagram: %v", err)
+	}
+	msg := new(dns.Msg)
+	if err := msg.Unpack(d.Data); err != nil {
+		t.Fatalf("unpack dns response: %v", err)
+	}
+	return msg
+}
+
+// TestSharedDNSExchangeRoutesResponsesByRewrittenID verifies that responses
+// on the shared stream are routed back to the originating client by the
+// rewritten transaction ID, even when two clients used the same original ID.
+func TestSharedDNSExchangeRoutesResponsesByRewrittenID(t *testing.T) {
+	srv, fakeSocks := newSharedDNSHarness(t)
+	ue, serverTx, serverSide := newSharedDNSExchange(t)
+
+	key := "dns_8.8.8.8:53"
+	srv.udpExch[key] = ue
+
+	clientA := newFakeDNSClient(t)
+	clientB := newFakeDNSClient(t)
+
+	// Two clients with the SAME original ID must not collide on the shared
+	// stream: the rewritten IDs differ, so each response goes to its own
+	// client with its own original ID restored.
+	ridA := srv.allocDNSID()
+	ridB := srv.allocDNSID()
+	if ridA == ridB {
+		t.Fatal("allocated IDs must be distinct")
+	}
+	srv.dnsPendingMu.Lock()
+	srv.dnsPending[ridA] = dnsPendingEntry{origID: 111, client: clientA.LocalAddr().(*net.UDPAddr), hash: 1, deadline: time.Now().Add(time.Minute)}
+	srv.dnsPending[ridB] = dnsPendingEntry{origID: 111, client: clientB.LocalAddr().(*net.UDPAddr), hash: 2, deadline: time.Now().Add(time.Minute)}
+	srv.dnsPendingMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.receiveLoopSharedDNS(ue, fakeSocks, "8.8.8.8:53", key)
+	}()
+
+	respA := &dns.Msg{MsgHdr: dns.MsgHdr{Id: ridA, Response: true}, Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA}}}
+	injectDNSResponse(t, serverTx, respA)
+	respB := &dns.Msg{MsgHdr: dns.MsgHdr{Id: ridB, Response: true}, Question: []dns.Question{{Name: "other.org.", Qtype: dns.TypeA}}}
+	injectDNSResponse(t, serverTx, respB)
+
+	gotA := readDNSResponse(t, clientA)
+	gotB := readDNSResponse(t, clientB)
+	if gotA.Id != 111 || gotB.Id != 111 {
+		t.Fatalf("IDs not restored: A=%d B=%d, want 111/111", gotA.Id, gotB.Id)
+	}
+	if gotA.Question[0].Name != "example.com." || gotB.Question[0].Name != "other.org." {
+		t.Fatalf("responses cross-routed: A=%q B=%q", gotA.Question[0].Name, gotB.Question[0].Name)
+	}
+
+	// Pending entries must be consumed by routing.
+	srv.dnsPendingMu.Lock()
+	_, okA := srv.dnsPending[ridA]
+	_, okB := srv.dnsPending[ridB]
+	srv.dnsPendingMu.Unlock()
+	if okA || okB {
+		t.Fatal("pending entries must be removed after routing")
+	}
+
+	serverSide.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("receive loop did not exit")
+	}
+}
+
+// TestSharedDNSExchangeDedupFanout verifies that concurrent byte-identical
+// queries (differing only in the transaction ID) are answered from a single
+// upstream response: the primary client gets its ID restored and the dedup
+// waiter gets a clone with its own ID.
+func TestSharedDNSExchangeDedupFanout(t *testing.T) {
+	srv, fakeSocks := newSharedDNSHarness(t)
+	ue, serverTx, serverSide := newSharedDNSExchange(t)
+
+	key := "dns_8.8.8.8:53"
+	srv.udpExch[key] = ue
+
+	clientA := newFakeDNSClient(t)
+	clientB := newFakeDNSClient(t)
+
+	hash := uint64(42)
+	ridA := srv.allocDNSID()
+	ridB := srv.allocDNSID()
+	srv.dnsPendingMu.Lock()
+	srv.dnsPending[ridA] = dnsPendingEntry{origID: 111, client: clientA.LocalAddr().(*net.UDPAddr), hash: hash, deadline: time.Now().Add(time.Minute)}
+	srv.dnsPending[ridB] = dnsPendingEntry{origID: 222, client: clientB.LocalAddr().(*net.UDPAddr), hash: hash, deadline: time.Now().Add(time.Minute)}
+	srv.dnsPendingMu.Unlock()
+	srv.dnsDedupMu.Lock()
+	srv.dnsDedup[hash] = []uint16{ridA, ridB}
+	srv.dnsDedupMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.receiveLoopSharedDNS(ue, fakeSocks, "8.8.8.8:53", key)
+	}()
+
+	resp := &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Id: ridA, Response: true},
+		Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA}},
+		Answer: []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.ParseIP("1.2.3.4"),
+		}},
+	}
+	injectDNSResponse(t, serverTx, resp)
+
+	gotA := readDNSResponse(t, clientA)
+	gotB := readDNSResponse(t, clientB)
+	if gotA.Id != 111 || gotB.Id != 222 {
+		t.Fatalf("IDs not restored: A=%d B=%d, want 111/222", gotA.Id, gotB.Id)
+	}
+	if len(gotA.Answer) != 1 || len(gotB.Answer) != 1 {
+		t.Fatalf("cloned response missing answer: A=%d B=%d", len(gotA.Answer), len(gotB.Answer))
+	}
+
+	// Both pending entries and the dedup group must be consumed.
+	srv.dnsPendingMu.Lock()
+	_, okA := srv.dnsPending[ridA]
+	_, okB := srv.dnsPending[ridB]
+	srv.dnsPendingMu.Unlock()
+	if okA || okB {
+		t.Fatal("pending entries must be removed after fan-out")
+	}
+	srv.dnsDedupMu.Lock()
+	_, okG := srv.dnsDedup[hash]
+	srv.dnsDedupMu.Unlock()
+	if okG {
+		t.Fatal("dedup group must be removed after fan-out")
+	}
+
+	serverSide.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("receive loop did not exit")
+	}
+}
+
+// TestSharedDNSExchangeDropsUnknownID verifies that a response whose rewritten
+// ID was never registered (late response, or the query was swept) is dropped
+// instead of being misrouted to a client.
+func TestSharedDNSExchangeDropsUnknownID(t *testing.T) {
+	srv, fakeSocks := newSharedDNSHarness(t)
+	ue, serverTx, serverSide := newSharedDNSExchange(t)
+
+	key := "dns_8.8.8.8:53"
+	srv.udpExch[key] = ue
+	client := newFakeDNSClient(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.receiveLoopSharedDNS(ue, fakeSocks, "8.8.8.8:53", key)
+	}()
+
+	resp := &dns.Msg{MsgHdr: dns.MsgHdr{Id: 9999, Response: true}, Question: []dns.Question{{Name: "example.com.", Qtype: dns.TypeA}}}
+	injectDNSResponse(t, serverTx, resp)
+
+	if err := client.SetReadDeadline(time.Now().Add(300 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 4096)
+	if n, _, err := client.ReadFromUDP(buf); err == nil {
+		t.Fatalf("unknown-ID response was routed: %d bytes", n)
+	}
+
+	serverSide.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("receive loop did not exit")
+	}
+}
+
+// TestSharedDNSExchangeSilentUpstreamSweepsPendingNotStream verifies that an
+// unanswered query (silent upstream DNS) only expires its pending entry and
+// never closes the shared stream — one stuck query cannot kill the other
+// clients' in-flight queries (unlike the old per-client exchange close).
+func TestSharedDNSExchangeSilentUpstreamSweepsPendingNotStream(t *testing.T) {
+	srv, fakeSocks := newSharedDNSHarness(t)
+	ue, _, serverSide := newSharedDNSExchange(t)
+
+	key := "dns_8.8.8.8:53"
+	srv.udpExch[key] = ue
+	client := newFakeDNSClient(t)
+
+	// A pending query whose deadline has already passed (upstream silent).
+	hash := uint64(7)
+	srv.dnsPendingMu.Lock()
+	srv.dnsPending[777] = dnsPendingEntry{origID: 111, client: client.LocalAddr().(*net.UDPAddr), hash: hash, deadline: time.Now().Add(-time.Second)}
+	srv.dnsPendingMu.Unlock()
+	srv.dnsDedupMu.Lock()
+	srv.dnsDedup[hash] = []uint16{777}
+	srv.dnsDedupMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.receiveLoopSharedDNS(ue, fakeSocks, "8.8.8.8:53", key)
+	}()
+
+	// Give the loop a moment to block on the read, then sweep.
+	time.Sleep(50 * time.Millisecond)
+	srv.sweepDNS()
+
+	srv.dnsPendingMu.Lock()
+	_, ok := srv.dnsPending[777]
+	srv.dnsPendingMu.Unlock()
+	if ok {
+		t.Fatal("expired pending entry must be swept")
+	}
+	srv.dnsDedupMu.Lock()
+	_, okG := srv.dnsDedup[hash]
+	srv.dnsDedupMu.Unlock()
+	if okG {
+		t.Fatal("expired dedup group must be swept")
+	}
+
+	// The shared stream must NOT be closed by an unanswered query: the
+	// exchange stays registered and live.
+	if !srv.hasExchange(key) {
+		t.Fatal("shared exchange must stay registered after an unanswered query")
+	}
+
+	serverSide.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("receive loop did not exit")
+	}
+}
+
+// TestProxyDNSQuerySharesOneStreamAndDedups exercises the real proxyDNSQuery
+// path: a burst of queries from different clients (and source ports) opens a
+// single shared stream, concurrent byte-identical queries are merged, and
+// every query is registered with its original ID for response routing.
+func TestProxyDNSQuerySharesOneStreamAndDedups(t *testing.T) {
+	tr := &mockTransport{streams: []transport.Stream{&mockStream{}}}
+	h := newTestStreamHandler(tr)
+	srv, err := NewSocks5Server("127.0.0.1:0", "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, testDNSRespTimeout, nil)
+	if err != nil {
+		t.Fatalf("NewSocks5Server: %v", err)
+	}
+
+	clientA := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 40001}
+	clientB := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 40002}
+
+	q1 := new(dns.Msg)
+	q1.SetQuestion("example.com.", dns.TypeA)
+	q1.Id = 111
+	if err := srv.proxyDNSQuery(nil, clientA, q1, "example.com"); err != nil {
+		t.Fatalf("first query: %v", err)
+	}
+	if got := tr.openCalls(); got != 1 {
+		t.Fatalf("first query opened %d streams, want 1", got)
+	}
+
+	// An identical query (same bytes except the ID) from another client
+	// must neither open a second stream nor trigger a second upstream round
+	// trip: it is merged into the primary's dedup group.
+	q2 := new(dns.Msg)
+	q2.SetQuestion("example.com.", dns.TypeA)
+	q2.Id = 222
+	if err := srv.proxyDNSQuery(nil, clientB, q2, "example.com"); err != nil {
+		t.Fatalf("deduped query: %v", err)
+	}
+	if got := tr.openCalls(); got != 1 {
+		t.Fatalf("deduped query opened %d streams, want 1", got)
+	}
+
+	// A different domain reuses the same shared stream (no new open), but
+	// forms its own dedup group.
+	q3 := new(dns.Msg)
+	q3.SetQuestion("other.org.", dns.TypeA)
+	q3.Id = 333
+	if err := srv.proxyDNSQuery(nil, clientA, q3, "other.org"); err != nil {
+		t.Fatalf("third query: %v", err)
+	}
+	if got := tr.openCalls(); got != 1 {
+		t.Fatalf("different domain opened %d streams, want 1 (shared stream)", got)
+	}
+
+	// Every query must be registered with its original ID for routing.
+	srv.dnsPendingMu.Lock()
+	if len(srv.dnsPending) != 3 {
+		srv.dnsPendingMu.Unlock()
+		t.Fatalf("dnsPending has %d entries, want 3", len(srv.dnsPending))
+	}
+	var foundA, foundDup bool
+	for _, e := range srv.dnsPending {
+		if e.origID == 111 {
+			foundA = true
+		}
+		if e.origID == 222 {
+			foundDup = true
+		}
+	}
+	srv.dnsPendingMu.Unlock()
+	if !foundA || !foundDup {
+		t.Fatal("pending entries missing original IDs")
+	}
+
+	// Two dedup groups: the duplicate query is grouped with the primary.
+	srv.dnsDedupMu.Lock()
+	groups := len(srv.dnsDedup)
+	var groupSizes []int
+	for _, g := range srv.dnsDedup {
+		groupSizes = append(groupSizes, len(g))
+	}
+	srv.dnsDedupMu.Unlock()
+	if groups != 2 {
+		t.Fatalf("dnsDedup has %d groups, want 2", groups)
+	}
+	foundSize2 := false
+	for _, n := range groupSizes {
+		if n == 2 {
+			foundSize2 = true
+		}
+	}
+	if !foundSize2 {
+		t.Fatalf("expected a dedup group of size 2, got %v", groupSizes)
+	}
+}
+
+// TestDNSQueryHashIgnoresTransactionID verifies that byte-identical queries
+// differing only in their transaction ID hash alike, while queries with
+// different questions do not.
+func TestDNSQueryHashIgnoresTransactionID(t *testing.T) {
+	q1 := new(dns.Msg)
+	q1.SetQuestion("example.com.", dns.TypeA)
+	q1.Id = 111
+	p1, err := q1.Pack()
+	if err != nil {
+		t.Fatalf("pack q1: %v", err)
+	}
+
+	q2 := new(dns.Msg)
+	q2.SetQuestion("example.com.", dns.TypeA)
+	q2.Id = 222
+	p2, err := q2.Pack()
+	if err != nil {
+		t.Fatalf("pack q2: %v", err)
+	}
+	if dnsQueryHash(p1) != dnsQueryHash(p2) {
+		t.Fatal("identical queries with different IDs must hash alike")
+	}
+
+	q3 := new(dns.Msg)
+	q3.SetQuestion("other.org.", dns.TypeA)
+	p3, err := q3.Pack()
+	if err != nil {
+		t.Fatalf("pack q3: %v", err)
+	}
+	if dnsQueryHash(p1) == dnsQueryHash(p3) {
+		t.Fatal("different queries must not hash alike")
+	}
+}

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -41,15 +41,28 @@ type Socks5Server struct {
 	quit           chan struct{}
 	closeOnce      sync.Once
 	udpIdleTimeout time.Duration
-	// dnsRespTimeout bounds how long a proxied-DNS exchange may go without
-	// any server response before it is closed (read-idle timeout). Only DNS
-	// exchanges enable it; 0 disables the mechanism. It exists because the
-	// 60s udpIdleTimeout never fires for exchanges whose client keeps
-	// retrying queries (each Send refreshes lastSeen) while the upstream DNS
-	// server stays silent.
+	// dnsRespTimeout bounds how long an unanswered proxied-DNS query may stay
+	// pending on the shared DNS stream before it is dropped (see
+	// proxyDNSQuery and sweepDNS). It exists because the 60s udpIdleTimeout
+	// never fires for a stream whose client keeps retrying queries while the
+	// upstream DNS server stays silent.
 	dnsRespTimeout time.Duration
-	started        atomic.Bool
-	closing        atomic.Bool
+	// Shared proxied-DNS state: every client's DNS queries to the upstream
+	// proxy DNS server share a single HTTP/2 stream (see proxyDNSQuery), so a
+	// burst of concurrent queries cannot inflate the transport's bulk
+	// connection pool. Each forwarded query gets a globally unique rewritten
+	// transaction ID; dnsPending maps that ID back to the originating client
+	// and its original ID so the shared receive loop routes responses
+	// correctly. dnsDedup groups concurrent byte-identical queries
+	// (differing only in the transaction ID) so a burst of duplicate lookups
+	// costs a single upstream round trip.
+	dnsNextID    atomic.Uint32
+	dnsPendingMu sync.Mutex
+	dnsPending   map[uint16]dnsPendingEntry // rewritten ID → pending query
+	dnsDedupMu   sync.Mutex
+	dnsDedup     map[uint64][]uint16 // query hash → rewritten IDs (first = primary)
+	started      atomic.Bool
+	closing      atomic.Bool
 }
 
 // directUDPConn pairs a direct-UDP socket with its last-write timestamp so
@@ -87,6 +100,8 @@ func NewSocks5Server(listenAddr, username, password string, handler *StreamHandl
 		quit:              make(chan struct{}),
 		udpIdleTimeout:    udpIdleTimeout,
 		dnsRespTimeout:    dnsRespTimeout,
+		dnsPending:        make(map[uint16]dnsPendingEntry),
+		dnsDedup:          make(map[uint64][]uint16),
 	}
 	srv, err := socks5.NewClassicServer(listenAddr, "127.0.0.1", username, password, 0, 0)
 	if err != nil {
@@ -403,6 +418,10 @@ func (s *Socks5Server) cleanupLoop() {
 	for {
 		select {
 		case <-ticker.C:
+			// Drop proxied-DNS queries the upstream never answered (see
+			// sweepDNS); the shared DNS stream itself is left alone.
+			s.sweepDNS()
+
 			var stale []*UDPExchange
 			s.udpMu.Lock()
 			for key, ue := range s.udpExch {

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -86,7 +86,7 @@ func (s *Socks5Server) handleDNS(srv *socks5.Server, clientAddr *net.UDPAddr, d 
 
 	log.Info("[DNS_PROXY]", "domain", domain, "qtype", qtype)
 	stats.RecordDNSProxyQuery()
-	return s.proxyDNSQuery(srv, clientAddr, d, msg, domain)
+	return s.proxyDNSQuery(srv, clientAddr, msg, domain)
 }
 
 func (s *Socks5Server) directDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg, domain string) error {
@@ -196,21 +196,91 @@ func (s *Socks5Server) exchangeDirectDNS(ctx context.Context, msg *dns.Msg, addr
 	return dnsConn.ReadMsg()
 }
 
-func (s *Socks5Server) proxyDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg, domain string) error {
-	dst := config.ProxyDNSServer
-	key := clientAddr.String() + "_" + dst
+// dnsPendingEntry records one in-flight DNS query forwarded over the shared
+// proxied-DNS stream: the original transaction ID and client to restore and
+// route the response back to, the dedup group hash it belongs to, and the
+// deadline after which an unanswered query is dropped (see sweepDNS).
+type dnsPendingEntry struct {
+	origID   uint16
+	client   *net.UDPAddr
+	hash     uint64
+	deadline time.Time
+}
 
-	ue, created, err := s.getOrCreateUDPExchange(key, dst, d.Data)
+// defaultDNSRespTimeout bounds how long an unanswered proxied-DNS query may
+// stay pending before it is dropped, applied when dnsRespTimeout is not
+// configured (<= 0).
+const defaultDNSRespTimeout = 10 * time.Second
+
+// proxyDNSQuery forwards one DNS query to the upstream proxy DNS server over
+// a single shared HTTP/2 stream. Every proxied DNS query — from any client
+// and any source port — shares the one stream keyed by the upstream address,
+// so a burst of concurrent queries (which previously opened one stream per
+// (client address, target)) can no longer inflate the transport's bulk
+// connection pool. Because the stream is shared, each query's transaction ID
+// is rewritten to a globally unique ID (allocDNSID) and the response is
+// routed back by the shared receive loop (receiveLoopSharedDNS). Concurrent
+// byte-identical queries (differing only in the transaction ID) are merged
+// into a single upstream round trip via dnsDedup.
+func (s *Socks5Server) proxyDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr, msg *dns.Msg, domain string) error {
+	dst := config.ProxyDNSServer
+	key := "dns_" + dst
+
+	// Rewrite the transaction ID before forwarding: the shared stream
+	// carries queries from every client, so the original per-client IDs may
+	// collide. The rewritten ID is what the shared receive loop uses to
+	// route the response back.
+	origID := msg.Id
+	rid := s.allocDNSID()
+	msg.Id = rid
+	packed, err := msg.Pack()
 	if err != nil {
+		log.Error("[UDP_PROXY] pack dns query", "domain", domain, "err", err)
+		return err
+	}
+
+	// Register the pending response before any receive loop can process it
+	// (on a fresh stream the query rides inside the bootstrap record).
+	respTimeout := s.dnsRespTimeout
+	if respTimeout <= 0 {
+		respTimeout = defaultDNSRespTimeout
+	}
+	hash := dnsQueryHash(packed)
+	s.dnsPendingMu.Lock()
+	s.dnsPending[rid] = dnsPendingEntry{
+		origID:   origID,
+		client:   clientAddr,
+		hash:     hash,
+		deadline: time.Now().Add(respTimeout),
+	}
+	s.dnsPendingMu.Unlock()
+
+	// Merge concurrent identical queries (same bytes except the ID) into
+	// one upstream round trip: receiveLoopSharedDNS clones the primary
+	// response to the waiters.
+	s.dnsDedupMu.Lock()
+	if group, ok := s.dnsDedup[hash]; ok {
+		s.dnsDedup[hash] = append(group, rid)
+		s.dnsDedupMu.Unlock()
+		log.Debug("[DNS_PROXY] deduplicated concurrent query", "domain", domain, "qtype", dns.TypeToString[msg.Question[0].Qtype])
+		return nil
+	}
+	s.dnsDedup[hash] = []uint16{rid}
+	s.dnsDedupMu.Unlock()
+
+	ue, created, err := s.getOrCreateUDPExchange(key, dst, packed)
+	if err != nil {
+		s.dropDNSPending(rid, hash)
 		log.Error("[UDP_PROXY] open exchange", "dst", dst, "err", err)
 		return err
 	}
 	if created {
-		go s.receiveLoop(ue, srv, clientAddr, dst, key, s.dnsRespTimeout)
+		go s.receiveLoopSharedDNS(ue, srv, dst, key)
 		return nil // first payload already sent in handshake
 	}
 
-	if err := ue.Send(d.Data); err != nil {
+	if err := ue.Send(packed); err != nil {
+		s.dropDNSPending(rid, hash)
 		log.Error("[UDP_PROXY] send", "err", err)
 		s.udpMu.Lock()
 		delete(s.udpExch, key)
@@ -219,6 +289,129 @@ func (s *Socks5Server) proxyDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr
 		return err
 	}
 	return nil
+}
+
+// allocDNSID returns a globally unique 16-bit DNS transaction ID for a query
+// on the shared proxied-DNS stream. Pending entries live at most
+// dnsRespTimeout, so the counter effectively never wraps into a live ID; on
+// the theoretical collision the counter is bumped until a free ID is found.
+func (s *Socks5Server) allocDNSID() uint16 {
+	for {
+		rid := uint16(s.dnsNextID.Add(1))
+		if rid == 0 {
+			continue
+		}
+		s.dnsPendingMu.Lock()
+		_, busy := s.dnsPending[rid]
+		s.dnsPendingMu.Unlock()
+		if !busy {
+			return rid
+		}
+	}
+}
+
+// dnsQueryHash hashes a packed DNS query with the transaction ID bytes
+// skipped, so byte-identical queries that differ only in their ID hash alike
+// and can share one upstream round trip. The rest of the packet — flags,
+// question, EDNS options — participates, so queries with different attributes
+// are never merged.
+func dnsQueryHash(packed []byte) uint64 {
+	const (
+		offset64 = 14695981039346656037 // FNV-1a 64-bit offset basis
+		prime64  = 1099511628211
+	)
+	var h uint64 = offset64
+	for i, c := range packed {
+		if i < 2 { // DNS transaction ID
+			continue
+		}
+		h ^= uint64(c)
+		h *= prime64
+	}
+	return h
+}
+
+// dropDNSPending removes a pending query whose upstream round trip failed
+// before any response could arrive, and updates its dedup group: when the
+// primary failed the whole group is dead (no upstream query exists to answer
+// the waiters), otherwise the waiter is just unregistered.
+func (s *Socks5Server) dropDNSPending(rid uint16, hash uint64) {
+	s.dnsPendingMu.Lock()
+	delete(s.dnsPending, rid)
+	s.dnsPendingMu.Unlock()
+
+	s.dnsDedupMu.Lock()
+	defer s.dnsDedupMu.Unlock()
+	group, ok := s.dnsDedup[hash]
+	if !ok {
+		return
+	}
+	if len(group) > 0 && group[0] == rid {
+		delete(s.dnsDedup, hash)
+		return
+	}
+	for i, w := range group {
+		if w == rid {
+			group = append(group[:i], group[i+1:]...)
+			break
+		}
+	}
+	if len(group) == 0 {
+		delete(s.dnsDedup, hash)
+	} else {
+		s.dnsDedup[hash] = group
+	}
+}
+
+// sweepDNS drops pending proxied-DNS responses whose deadline elapsed (the
+// upstream DNS server stayed silent) and cleans up their dedup groups. Unlike
+// the old per-client exchange close, this never tears down the shared stream:
+// only stale pending entries are discarded, so one stuck query cannot affect
+// the other clients' in-flight queries. Run from the cleanup loop.
+func (s *Socks5Server) sweepDNS() {
+	now := time.Now()
+	var expired []uint16
+	s.dnsPendingMu.Lock()
+	for rid, e := range s.dnsPending {
+		if now.After(e.deadline) {
+			expired = append(expired, rid)
+			delete(s.dnsPending, rid)
+		}
+	}
+	s.dnsPendingMu.Unlock()
+	if len(expired) == 0 {
+		return
+	}
+
+	s.dnsDedupMu.Lock()
+	defer s.dnsDedupMu.Unlock()
+	for hash, group := range s.dnsDedup {
+		if containsRID(expired, group[0]) {
+			// The primary expired: no upstream query is in flight for the
+			// group, so the waiters could never be answered — drop the
+			// whole group (their pending entries expire on their own).
+			delete(s.dnsDedup, hash)
+			continue
+		}
+		kept := group[:0]
+		for _, rid := range group {
+			if !containsRID(expired, rid) {
+				kept = append(kept, rid)
+			}
+		}
+		if len(kept) != len(group) {
+			s.dnsDedup[hash] = kept
+		}
+	}
+}
+
+func containsRID(list []uint16, rid uint16) bool {
+	for _, r := range list {
+		if r == rid {
+			return true
+		}
+	}
+	return false
 }
 
 // udpExchangeFactory deduplicates concurrent attempts to create a UDPExchange
@@ -330,22 +523,7 @@ func (s *Socks5Server) evictOldestExchangeLocked() *UDPExchange {
 	return evicted
 }
 
-func (s *Socks5Server) receiveLoop(ue *UDPExchange, srv *socks5.Server, clientAddr *net.UDPAddr, target, key string, respTimeout time.Duration) {
-	// Read-idle timeout for proxied-DNS exchanges: the query was already
-	// sent (Send refreshes lastSeen, so the 60s idle reaper never fires for
-	// a client that keeps retrying while the upstream stays silent), so a
-	// long silence from the server means the upstream DNS is not answering.
-	// Close the exchange so the stream and goroutine cannot pile up; the
-	// next query transparently rebuilds it. Any received datagram resets
-	// the timer. respTimeout <= 0 disables the mechanism (non-DNS UDP).
-	var timer *time.Timer
-	if respTimeout > 0 {
-		timer = time.AfterFunc(respTimeout, func() {
-			log.Debug("[UDP_PROXY] dns response timeout, closing exchange", "key", key, "target", target)
-			ue.Close() //nolint:errcheck // closeOnce makes this safe against concurrent Close
-		})
-		defer timer.Stop()
-	}
+func (s *Socks5Server) receiveLoop(ue *UDPExchange, srv *socks5.Server, clientAddr *net.UDPAddr, target, key string) {
 	defer func() {
 		s.udpMu.Lock()
 		delete(s.udpExch, key)
@@ -361,38 +539,118 @@ func (s *Socks5Server) receiveLoop(ue *UDPExchange, srv *socks5.Server, clientAd
 			}
 			return
 		}
-		if timer != nil {
-			timer.Reset(respTimeout)
+
+		msg := &dns.Msg{}
+		if err := msg.Unpack(data); err == nil && util.IsDNSResponse(msg) && len(msg.Question) > 0 {
+			s.handleDNSResponse(srv, msg, clientAddr, target)
+			continue
+		}
+		s.sendToClient(srv, clientAddr, data, target)
+	}
+}
+
+// handleDNSResponse applies the client-side DNS response handling (AAAA
+// stripping when IPv6 is disabled, cache population, custom-proxy-domain IP
+// learning, logging) and delivers the response to the given client. The
+// message ID must already be restored to the originating client's ID.
+func (s *Socks5Server) handleDNSResponse(srv *socks5.Server, msg *dns.Msg, clientAddr *net.UDPAddr, dst string) {
+	if len(msg.Question) > 0 && s.router.ShouldIPV6Disable() && msg.Question[0].Qtype == dns.TypeAAAA {
+		msg.Answer = nil
+	}
+	packed, err := msg.Pack()
+	if err != nil {
+		log.Debug("[UDP_PROXY] pack dns response", "err", err)
+		return
+	}
+	_ = s.dnsCache.Set(msg, false)
+
+	domain := strings.TrimSuffix(msg.Question[0].Name, ".")
+	qtype := dns.TypeToString[msg.Question[0].Qtype]
+	log.Info("[DNS_PROXY] result", "domain", domain, "qtype", qtype, "answers", util.DNSAnswerStrings(msg))
+
+	if s.router.IsCustomProxyDomain(domain) {
+		for _, ans := range msg.Answer {
+			switch a := ans.(type) {
+			case *dns.A:
+				s.router.AddProxyIP(a.A.String())
+			case *dns.AAAA:
+				s.router.AddProxyIP(a.AAAA.String())
+			case *dns.CNAME:
+				s.router.AddProxyDomain(strings.TrimSuffix(a.Target, "."))
+			}
+		}
+	}
+	s.sendToClient(srv, clientAddr, packed, dst)
+}
+
+// receiveLoopSharedDNS reads responses on the shared proxied-DNS stream and
+// routes each back to the originating client via the rewritten transaction ID
+// (see proxyDNSQuery). Concurrent identical queries (dnsDedup) are answered
+// by cloning the primary response. Unlike the per-client receiveLoop, an
+// unanswered query never closes the shared stream — its pending entry simply
+// expires and is swept (see sweepDNS), so one stuck query cannot kill the
+// other clients' in-flight queries.
+func (s *Socks5Server) receiveLoopSharedDNS(ue *UDPExchange, srv *socks5.Server, dst, key string) {
+	defer func() {
+		s.udpMu.Lock()
+		delete(s.udpExch, key)
+		s.udpMu.Unlock()
+		ue.Close() //nolint:errcheck
+	}()
+
+	for {
+		data, err := ue.Receive()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				log.Debug("[UDP_PROXY] receive", "err", err)
+			}
+			return
 		}
 
 		msg := &dns.Msg{}
-		if err := msg.Unpack(data); err == nil && util.IsDNSResponse(msg) {
-			if s.router.ShouldIPV6Disable() && msg.Question[0].Qtype == dns.TypeAAAA {
-				msg.Answer = nil
-				if packed, packErr := msg.Pack(); packErr == nil {
-					data = packed
-				}
-			}
-			_ = s.dnsCache.Set(msg, false)
-
-			domain := strings.TrimSuffix(msg.Question[0].Name, ".")
-			qtype := dns.TypeToString[msg.Question[0].Qtype]
-			log.Info("[DNS_PROXY] result", "domain", domain, "qtype", qtype, "answers", util.DNSAnswerStrings(msg))
-
-			if s.router.IsCustomProxyDomain(domain) {
-				for _, ans := range msg.Answer {
-					switch a := ans.(type) {
-					case *dns.A:
-						s.router.AddProxyIP(a.A.String())
-					case *dns.AAAA:
-						s.router.AddProxyIP(a.AAAA.String())
-					case *dns.CNAME:
-						s.router.AddProxyDomain(strings.TrimSuffix(a.Target, "."))
-					}
-				}
-			}
+		if err := msg.Unpack(data); err != nil || !util.IsDNSResponse(msg) || len(msg.Question) == 0 {
+			continue
 		}
-		s.sendToClient(srv, clientAddr, data, target)
+
+		rid := msg.Id
+		s.dnsPendingMu.Lock()
+		entry, ok := s.dnsPending[rid]
+		if ok {
+			delete(s.dnsPending, rid)
+		}
+		s.dnsPendingMu.Unlock()
+		if !ok {
+			// Stale or unknown ID (late response, or the query was swept):
+			// drop it rather than misrouting to a client.
+			continue
+		}
+
+		// Restore the primary client's ID and deliver.
+		msg.Id = entry.origID
+		s.handleDNSResponse(srv, msg, entry.client, dst)
+
+		// Fan out to byte-identical waiters from the dedup group.
+		s.dnsDedupMu.Lock()
+		group := s.dnsDedup[entry.hash]
+		delete(s.dnsDedup, entry.hash)
+		s.dnsDedupMu.Unlock()
+		for _, w := range group {
+			if w == rid {
+				continue // the primary itself
+			}
+			s.dnsPendingMu.Lock()
+			wEntry, ok := s.dnsPending[w]
+			if ok {
+				delete(s.dnsPending, w)
+			}
+			s.dnsPendingMu.Unlock()
+			if !ok {
+				continue
+			}
+			clone := *msg
+			clone.Id = wEntry.origID
+			s.handleDNSResponse(srv, &clone, wEntry.client, dst)
+		}
 	}
 }
 
@@ -498,7 +756,7 @@ func (s *Socks5Server) proxyUDPRelay(srv *socks5.Server, clientAddr *net.UDPAddr
 		// Non-DNS UDP must not use the short read-idle timeout: a session
 		// may legitimately stay silent for a long time (e.g. an upload-only
 		// flow), so it keeps the 60s bidirectional idle reaper only.
-		go s.receiveLoop(ue, srv, clientAddr, dst, key, 0)
+		go s.receiveLoop(ue, srv, clientAddr, dst, key)
 		return nil // first payload already sent in handshake
 	}
 

--- a/client/proxy/udp_timeout_test.go
+++ b/client/proxy/udp_timeout_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 // blockingStream is a transport.Stream whose Read blocks until Close is
-// called, simulating a server that never answers (e.g. an upstream DNS
-// server that silently drops queries). Write succeeds so the bootstrap
-// handshake completes.
+// called, simulating a remote peer that never answers. Write succeeds so a
+// bootstrap handshake can complete.
 type blockingStream struct {
 	mu     sync.Mutex
 	closed bool
@@ -53,8 +52,9 @@ var _ transport.Stream = (*blockingStream)(nil)
 
 const testDNSRespTimeout = 200 * time.Millisecond
 
-// newTimeoutTestServer builds a Socks5Server whose proxied-DNS exchanges run
-// with testDNSRespTimeout and whose transport serves the given streams.
+// newTimeoutTestServer builds a Socks5Server whose shared proxied-DNS
+// deadlines run with testDNSRespTimeout and whose transport serves the given
+// streams.
 func newTimeoutTestServer(t *testing.T, streams []transport.Stream) *Socks5Server {
 	t.Helper()
 	h := newTestStreamHandler(&mockTransport{streams: streams})
@@ -73,7 +73,7 @@ func (s *Socks5Server) hasExchange(key string) bool {
 }
 
 // waitExchangeReaped polls until the key disappears from s.udpExch (the
-// receiveLoop defer removes it) or the deadline expires.
+// receive loop defer removes it) or the deadline expires.
 func waitExchangeReaped(t *testing.T, s *Socks5Server, key string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -85,41 +85,11 @@ func waitExchangeReaped(t *testing.T, s *Socks5Server, key string) {
 	}
 }
 
-// TestUDPExchangeDNSResponseTimeout verifies that a proxied-DNS exchange
-// with no server response is closed (stream closed, key removed) once
-// dnsRespTimeout elapses, so silent upstream DNS servers cannot pile up
-// HTTP/2 streams and receiveLoop goroutines.
-func TestUDPExchangeDNSResponseTimeout(t *testing.T) {
-	bs := newBlockingStream()
-	srv := newTimeoutTestServer(t, []transport.Stream{bs})
-
-	key := "127.0.0.1:12345_8.8.8.8:53"
-	ue, created, err := srv.getOrCreateUDPExchange(key, "8.8.8.8:53", []byte("dns query payload"))
-	if err != nil {
-		t.Fatalf("getOrCreateUDPExchange: %v", err)
-	}
-	if !created {
-		t.Fatal("expected exchange to be created")
-	}
-
-	clientAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
-	go srv.receiveLoop(ue, nil, clientAddr, "8.8.8.8:53", key, srv.dnsRespTimeout)
-
-	if !srv.hasExchange(key) {
-		t.Fatal("expected exchange to be registered before the timeout")
-	}
-
-	waitExchangeReaped(t, srv, key)
-
-	if !bs.isClosed() {
-		t.Error("expected exchange stream to be closed after response timeout")
-	}
-}
-
-// TestUDPExchangeNoTimeoutWhenDisabled verifies that respTimeout=0 (the
-// non-DNS UDP path) leaves the exchange untouched even past dnsRespTimeout:
-// a long downlink silence must not kill regular UDP sessions.
-func TestUDPExchangeNoTimeoutWhenDisabled(t *testing.T) {
+// TestUDPExchangeNoTimeoutForRegularUDP verifies that a non-DNS UDP exchange
+// (the per-client path for games etc.) is left untouched even past
+// dnsRespTimeout: a long downlink silence must not kill regular UDP sessions.
+// The per-query DNS deadline only applies to the shared DNS stream.
+func TestUDPExchangeNoTimeoutForRegularUDP(t *testing.T) {
 	bs := newBlockingStream()
 	srv := newTimeoutTestServer(t, []transport.Stream{bs})
 
@@ -133,14 +103,14 @@ func TestUDPExchangeNoTimeoutWhenDisabled(t *testing.T) {
 	}
 
 	clientAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
-	go srv.receiveLoop(ue, nil, clientAddr, "8.8.8.8:443", key, 0)
+	go srv.receiveLoop(ue, nil, clientAddr, "8.8.8.8:443", key)
 
 	time.Sleep(testDNSRespTimeout * 2)
 	if !srv.hasExchange(key) {
-		t.Fatal("exchange must not be reaped when the response timeout is disabled")
+		t.Fatal("exchange must not be reaped for a regular UDP session")
 	}
 	if bs.isClosed() {
-		t.Error("stream must not be closed when the response timeout is disabled")
+		t.Error("stream must not be closed for a regular UDP session")
 	}
 
 	// Tear down: close the exchange so the blocked receiveLoop exits and

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -358,11 +358,14 @@ func (t *HTTP2Transport) Stats() transport.TransportStats {
 	return ts
 }
 
-// slotStatus derives a live slot's connection status from its health flags.
-// Multiple flags are joined with "+" so no state is hidden (a heavy download
-// crossing the connection lifetime is both heavy and expiring); a slot with
-// no flags is "active".
-func slotStatus(s *transportSlot) string {
+// slotStatus derives a live slot's connection status from its health flags
+// and the number of streams currently hosted on it. Multiple flags are
+// joined with "+" so no state is hidden (a heavy download crossing the
+// connection lifetime is both heavy and expiring). A slot with no flags
+// hosting at least one stream is "active"; one with no flags and no streams
+// is an idle warm connection and renders as "idle", so a pool full of
+// connection slots but few streams is not mistaken for active traffic.
+func slotStatus(s *transportSlot, active int) string {
 	var parts []string
 	if s.heavy.Load() > 0 {
 		parts = append(parts, "heavy")
@@ -374,6 +377,9 @@ func slotStatus(s *transportSlot) string {
 		parts = append(parts, "expiring")
 	}
 	if len(parts) == 0 {
+		if active == 0 {
+			return "idle"
+		}
 		return "active"
 	}
 	return strings.Join(parts, "+")
@@ -381,8 +387,10 @@ func slotStatus(s *transportSlot) string {
 
 // slotStatusString renders the live slots of one pool as
 // "<index>:<active streams>:<status>", wrapped in brackets, e.g.
-// "[0:3:degraded, 1:2:expiring, 2:1:active, 3:1:heavy]". Entries are
-// ordered by the stable slot identity (retire swap-removes scramble the
+// "[0:3:degraded, 1:2:expiring, 2:1:active, 3:1:heavy]". A healthy slot
+// hosting no streams renders as "0:idle" (a warm connection), so a burst
+// that grew the pool is distinguishable from real active traffic. Entries
+// are ordered by the stable slot identity (retire swap-removes scramble the
 // live order) and then renumbered from 0, so the rendered indices are
 // always consecutive with no jumps. An empty live set renders as "[]".
 // live must be the pool's liveCount value the caller snapshot under the
@@ -399,10 +407,11 @@ func slotStatusString(pool *slotPool, live int) string {
 	entries := make([]entry, 0, live)
 	for i := 0; i < live; i++ {
 		s := pool.slots[i]
+		a := int(s.active.Load())
 		entries = append(entries, entry{
 			idx:    s.idx,
-			active: int(s.active.Load()),
-			status: slotStatus(s),
+			active: a,
+			status: slotStatus(s, a),
 		})
 	}
 	if len(entries) == 0 {

--- a/transport/http2/slot_status_test.go
+++ b/transport/http2/slot_status_test.go
@@ -7,26 +7,30 @@ import (
 func TestSlotStatus(t *testing.T) {
 	tests := []struct {
 		name   string
+		active int32
 		heavy  int32
 		deg    bool
 		exp    bool
 		expect string
 	}{
-		{name: "no flags is active", expect: "active"},
-		{name: "heavy", heavy: 1, expect: "heavy"},
-		{name: "degraded", deg: true, expect: "degraded"},
-		{name: "expiring", exp: true, expect: "expiring"},
-		{name: "heavy and expiring", heavy: 1, exp: true, expect: "heavy+expiring"},
-		{name: "degraded and heavy", heavy: 2, deg: true, expect: "heavy+degraded"},
-		{name: "all flags", heavy: 1, deg: true, exp: true, expect: "heavy+degraded+expiring"},
+		{name: "no flags and no streams is idle", active: 0, expect: "idle"},
+		{name: "no flags with streams is active", active: 1, expect: "active"},
+		{name: "idle expiring", exp: true, expect: "expiring"},
+		{name: "heavy", active: 1, heavy: 1, expect: "heavy"},
+		{name: "degraded", active: 1, deg: true, expect: "degraded"},
+		{name: "expiring", active: 1, exp: true, expect: "expiring"},
+		{name: "heavy and expiring", active: 1, heavy: 1, exp: true, expect: "heavy+expiring"},
+		{name: "degraded and heavy", active: 1, heavy: 2, deg: true, expect: "heavy+degraded"},
+		{name: "all flags", active: 1, heavy: 1, deg: true, exp: true, expect: "heavy+degraded+expiring"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &transportSlot{}
+			s.active.Store(tt.active)
 			s.heavy.Store(tt.heavy)
 			s.degraded.Store(tt.deg)
 			s.expiring.Store(tt.exp)
-			if got := slotStatus(s); got != tt.expect {
+			if got := slotStatus(s, int(tt.active)); got != tt.expect {
 				t.Fatalf("slotStatus() = %q, want %q", got, tt.expect)
 			}
 		})
@@ -53,6 +57,17 @@ func TestSlotStatusString(t *testing.T) {
 	t.Run("all active with stream counts", func(t *testing.T) {
 		sch := newTestScheduler([2]int32{1, 0}, [2]int32{2, 0})
 		if got, want := statusString(sch.priority), "[0:1:active, 1:2:active]"; got != want {
+			t.Fatalf("slotStatusString() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("idle slots render as idle", func(t *testing.T) {
+		sch := newTestScheduler([2]int32{0, 0}, [2]int32{2, 0}, [2]int32{0, 0})
+		sch.priority.slots[2].expiring.Store(true)
+		// A healthy slot hosting no streams renders as "idle" (warm
+		// connection); marks still win over the idle label.
+		want := "[0:0:idle, 1:2:active, 2:0:expiring]"
+		if got := statusString(sch.priority); got != want {
 			t.Fatalf("slotStatusString() = %q, want %q", got, want)
 		}
 	})

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -66,8 +66,11 @@ type TransportStats struct {
 	// priority pool, e.g. "[0:3:degraded, 1:2:expiring, 2:1:active]". Each
 	// element is "<index>:<active streams>:<status>" where indices are
 	// consecutive from 0 (ordered by stable connection identity) and status
-	// is one of active/heavy/degraded/expiring, with multiple flags joined
-	// by "+". The bulk pool renders the same way into BulkConnsStatus.
+	// is one of idle/active/heavy/degraded/expiring, with multiple flags
+	// joined by "+". "idle" marks a healthy connection hosting no streams
+	// (a warm connection), so a pool grown by a past burst is
+	// distinguishable from active traffic. The bulk pool renders the same
+	// way into BulkConnsStatus.
 	PriorityConnsStatus string `json:"priority_conns_status,omitempty"`
 	BulkConnsStatus     string `json:"bulk_conns_status,omitempty"`
 }


### PR DESCRIPTION
## 背景

代理 DNS 查询原先按 `客户端源地址(含临时端口) + 目标DNS` 各开一条 UDPExchange，即一条 HTTP/2 流。Go 的 `net.Resolver` 等解析器每个查询使用新的临时源端口，冷缓存时的一次并发 DNS 突发（例如打开多域名页面）会产生大量并发 bulk 流，把 transport 的 bulk 连接池一次性打满（默认配置下 bulk 池上限 9 个连接）。本 PR 修复这一根因，并顺带改进 stats 可读性。

## 改动 1：所有代理 DNS 查询共享一条 HTTP/2 流

纯客户端改动，服务端无需变更（`server/handler/udp.go` 本来就是透明的双向数据报管道，天然支持一路多查询）：

- **单流复用**：`proxyDNSQuery` 改为所有客户端共享一条流（key 固定为上游 DNS 地址），突发并发查询从 N 条流降到 1 条，不再打满连接池。
- **ID 重写与分路**：发送前把事务 ID 重写为全局唯一 ID 并登记 `dnsPending`；新增 `receiveLoopSharedDNS` 按重写后的 ID 把响应分路回原客户端并恢复其原始 ID，未知/迟到 ID 的响应直接丢弃，绝不误发。
- **重复查询合并**：字节一致（仅事务 ID 不同）的并发查询并入 `dnsDedup`，主响应克隆给等待者，一个上游往返服务所有重复查询。
- **超时语义改进**：旧的"整条 exchange 静默 10s 即关闭"会误杀共享流上其他客户端的在途查询；新逻辑改为**按查询过期**（10s，由 `cleanupLoop` 的 `sweepDNS` 清扫），只丢该条 pending，共享流永不因此被关闭。

非 DNS UDP（游戏等，走 `proxyUDPRelay` 的每客户端路径）与直连 DNS 路径完全不受影响。

## 改动 2：conns_status 可读性

`slotStatus` 增加 active 感知：无健康标记且 0 流的连接渲染为 `0:idle`（热连接），不再与 `0:active` 混淆，突发过后被误读为"有活跃流"的问题消除。

## 测试

- 新增 `client/proxy/dns_shared_exchange_test.go`：同 ID 碰撞分路、去重克隆扇出、未知 ID 丢弃、静默上游只清 pending 不关流、`proxyDNSQuery` 单流+去重（mock transport 验证 openCalls 恒为 1）、查询哈希忽略事务 ID。
- 重写 `client/proxy/udp_timeout_test.go`：保留非 DNS UDP 不回收的验证，移除已废弃的"整条 exchange 关闭"语义测试。
- 更新 `transport/http2/slot_status_test.go`：新增 `idle` 渲染用例。
- `go test ./...` 全绿，`golangci-lint` 0 issues。
