### PR TITLE
feat: log and report slot growth triggers

### DIFF
--- a/client/proxy/stream.go
+++ b/client/proxy/stream.go
@@ -113,6 +113,7 @@ func (h *StreamHandler) openAndBootstrap(ctx context.Context, endpoint string, p
 			Endpoint:     endpoint,
 			Salt:         saltB64,
 			HighPriority: isInteractivePort(target),
+			Target:       target,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("transport open: %w", err)

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -324,6 +324,8 @@ func (a *App) statsLoop() {
 				"slot_retired_degraded", snap.SlotRetiredDegraded,
 				"slot_probes", snap.SlotProbes,
 				"slot_probe_slow", snap.SlotProbeSlow,
+				"slot_grown_priority", snap.SlotGrownPriority,
+				"slot_grown_bulk", snap.SlotGrownBulk,
 				"conn_rotated", snap.ConnRotated,
 			)
 		case <-a.statsCloser:

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -59,6 +59,10 @@ type stats struct {
 	slotProbes           atomic.Int64
 	slotProbeSlow        atomic.Int64
 	slotProbeUnsupported atomic.Int64
+	// slotGrownPriority/slotGrownBulk count slot expansions (new live
+	// connections activated by the lazy-expansion scheduler) per pool.
+	slotGrownPriority atomic.Int64
+	slotGrownBulk     atomic.Int64
 	// streamsDrained counts streams closed early by the relay drain
 	// mechanism: idle streams on slots due for eviction (expiring/degraded)
 	// closed before the full idle timeout so rotation/retirement completes
@@ -125,7 +129,9 @@ func RecordSlotProbeSlow()       { g.slotProbeSlow.Add(1) }
 func RecordSlotProbeUnsupported() {
 	g.slotProbeUnsupported.Add(1)
 }
-func RecordStreamDrained() { g.streamsDrained.Add(1) }
+func RecordSlotGrownPriority() { g.slotGrownPriority.Add(1) }
+func RecordSlotGrownBulk()     { g.slotGrownBulk.Add(1) }
+func RecordStreamDrained()     { g.streamsDrained.Add(1) }
 
 const rttAlpha = 0.35
 
@@ -194,6 +200,8 @@ func ResetCounters() {
 	g.slotProbes.Store(0)
 	g.slotProbeSlow.Store(0)
 	g.slotProbeUnsupported.Store(0)
+	g.slotGrownPriority.Store(0)
+	g.slotGrownBulk.Store(0)
 	g.streamsDrained.Store(0)
 
 	g.rttMu.Lock()
@@ -259,6 +267,8 @@ type Snapshot struct {
 	SlotProbes           int64 `json:"slot_probes"`
 	SlotProbeSlow        int64 `json:"slot_probe_slow"`
 	SlotProbeUnsupported int64 `json:"slot_probe_unsupported"`
+	SlotGrownPriority    int64 `json:"slot_grown_priority"`
+	SlotGrownBulk        int64 `json:"slot_grown_bulk"`
 	StreamsDrained       int64 `json:"streams_drained"`
 
 	// Speed
@@ -353,6 +363,8 @@ func Collect() Snapshot {
 		SlotProbes:             g.slotProbes.Load(),
 		SlotProbeSlow:          g.slotProbeSlow.Load(),
 		SlotProbeUnsupported:   g.slotProbeUnsupported.Load(),
+		SlotGrownPriority:      g.slotGrownPriority.Load(),
+		SlotGrownBulk:          g.slotGrownBulk.Load(),
 		StreamsDrained:         g.streamsDrained.Load(),
 		UploadSpeed:            upSpeed,
 		DownloadSpeed:          downSpeed,

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -17,9 +17,15 @@ import (
 	utls "github.com/refraction-networking/utls"
 
 	sharedconfig "github.com/nange/easyss/v3/config"
+	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/stats"
 	"github.com/nange/easyss/v3/transport"
 )
+
+// maxGrowEvents bounds the ring of recent slot-growth events exposed via
+// TransportStats.GrowEvents — enough to attribute a connection-count jump
+// to its triggering requests without unbounded memory growth.
+const maxGrowEvents = 16
 
 // HTTP2Transport is a facade over the HTTP/2 client machinery: streams are
 // mapped onto connections by slotScheduler, and the per-connection state
@@ -30,6 +36,12 @@ type HTTP2Transport struct {
 	lifecycle *slotLifecycle
 
 	serverURL string
+
+	// growEvents is a bounded ring of recent slot-growth events, oldest
+	// first; snapshotted (newest first) into TransportStats.GrowEvents.
+	// Guarded by growMu.
+	growEvents []transport.GrowEvent
+	growMu     sync.Mutex
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -219,7 +231,27 @@ func (t *HTTP2Transport) Open(ctx context.Context, req transport.OpenRequest) (t
 
 	stats.RecordStreamOpened()
 
-	t.sched.grow(req.HighPriority)
+	if pool, live := t.sched.grow(req.HighPriority); pool != nil {
+		// This request actually triggered a slot expansion: attribute the
+		// growth to it. Concurrent growers serialize on the scheduler write
+		// lock and re-evaluate under it, so only the request that performed
+		// the activation reaches this branch.
+		poolName := "bulk"
+		if pool == t.sched.priority {
+			poolName = "priority"
+			stats.RecordSlotGrownPriority()
+		} else {
+			stats.RecordSlotGrownBulk()
+		}
+		log.Info("[TRANSPORT] slot grown",
+			"pool", poolName,
+			"live", live,
+			"endpoint", req.Endpoint,
+			"proto", protoOfEndpoint(req.Endpoint),
+			"target", req.Target,
+			"priority", req.HighPriority)
+		t.recordGrowEvent(poolName, live, req)
+	}
 
 	t.sched.mu.RLock()
 	slot := t.sched.pick(req.HighPriority)
@@ -307,6 +339,39 @@ func (t *HTTP2Transport) Open(ctx context.Context, req transport.OpenRequest) (t
 	return stream, nil
 }
 
+// protoOfEndpoint maps a proxy endpoint path to its short protocol name
+// for growth-event logging; unknown paths are echoed as-is.
+func protoOfEndpoint(endpoint string) string {
+	switch endpoint {
+	case sharedconfig.EndpointTCP:
+		return "tcp"
+	case sharedconfig.EndpointUDP:
+		return "udp"
+	case sharedconfig.EndpointICMP:
+		return "icmp"
+	}
+	return endpoint
+}
+
+// recordGrowEvent appends one slot-growth event to the bounded ring,
+// dropping the oldest beyond maxGrowEvents. The ring is snapshotted
+// newest-first into TransportStats.GrowEvents by Stats.
+func (t *HTTP2Transport) recordGrowEvent(pool string, live int32, req transport.OpenRequest) {
+	ev := transport.GrowEvent{
+		Time:     time.Now(),
+		Pool:     pool,
+		Live:     int(live),
+		Endpoint: req.Endpoint,
+		Target:   req.Target,
+	}
+	t.growMu.Lock()
+	defer t.growMu.Unlock()
+	t.growEvents = append(t.growEvents, ev)
+	if len(t.growEvents) > maxGrowEvents {
+		t.growEvents = append([]transport.GrowEvent(nil), t.growEvents[len(t.growEvents)-maxGrowEvents:]...)
+	}
+}
+
 func (t *HTTP2Transport) CloseIdle() {
 	// Close idle TCP connections on all slots of both pools. The slot array
 	// elements are swap-mutated by shrink/retire under the scheduler write
@@ -355,6 +420,15 @@ func (t *HTTP2Transport) Stats() transport.TransportStats {
 	}
 	ts.PriorityConnsStatus = slotStatusString(t.sched.priority, pLive)
 	ts.BulkConnsStatus = slotStatusString(t.sched.bulk, bLive)
+
+	// Snapshot the recent growth events newest-first. The ring has its own
+	// mutex (recordGrowEvent holds no scheduler lock), so no lock ordering
+	// issue with the read lock held above.
+	t.growMu.Lock()
+	for i := len(t.growEvents) - 1; i >= 0; i-- {
+		ts.GrowEvents = append(ts.GrowEvents, t.growEvents[i])
+	}
+	t.growMu.Unlock()
 	return ts
 }
 

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -141,6 +141,78 @@ func TestHTTP2Transport_200StatusReadsBody(t *testing.T) {
 	}
 }
 
+// TestHTTP2Transport_GrowEventAttribution verifies that a slot expansion is
+// attributed to the request that triggered it: the first Open on a fresh
+// transport activates the priority pool (2 slots on first activation) and
+// records exactly one GrowEvent carrying the request's endpoint and target;
+// a later Open with tier capacity left records nothing.
+func TestHTTP2Transport_GrowEventAttribution(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	srv.EnableHTTP2 = true
+	srv.Config.Protocols = &http.Protocols{}
+	srv.Config.Protocols.SetHTTP2(true)
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	tr, err := New(Config{
+		ServerURL: srv.URL,
+		TLSConfig: &utls.Config{
+			InsecureSkipVerify: true,
+			NextProtos:         sharedconfig.NextProtos,
+		},
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tr.Close() })
+
+	open := func(target string) {
+		t.Helper()
+		stream, err := tr.Open(context.Background(), transport.OpenRequest{
+			Endpoint:     sharedconfig.EndpointTCP,
+			Salt:         "dGVzdHNhbHR0ZXN0c2FsdA",
+			HighPriority: true,
+			Target:       target,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, stream)
+		stream.Close() //nolint:errcheck
+	}
+
+	// First stream: triggers the priority pool's first activation (+2).
+	open("example.com:443")
+	evs := tr.Stats().GrowEvents
+	if len(evs) != 1 {
+		t.Fatalf("GrowEvents = %d, want 1 after the triggering Open", len(evs))
+	}
+	ev := evs[0]
+	if ev.Pool != "priority" {
+		t.Fatalf("event pool = %q, want priority", ev.Pool)
+	}
+	if ev.Live != 2 {
+		t.Fatalf("event live = %d, want 2 (first activation)", ev.Live)
+	}
+	if ev.Endpoint != sharedconfig.EndpointTCP {
+		t.Fatalf("event endpoint = %q, want %q", ev.Endpoint, sharedconfig.EndpointTCP)
+	}
+	if ev.Target != "example.com:443" {
+		t.Fatalf("event target = %q, want example.com:443", ev.Target)
+	}
+
+	// Second stream: the pool has idle capacity, no growth, no new event.
+	open("example.org:443")
+	if got := len(tr.Stats().GrowEvents); got != 1 {
+		t.Fatalf("GrowEvents = %d, want 1 (no growth for the second Open)", got)
+	}
+}
+
 func TestTrackReadMarksSlotHeavy(t *testing.T) {
 	// Fast path: a large transfer is marked as soon as it crosses the
 	// cumulative size threshold.

--- a/transport/http2/consistency_test.go
+++ b/transport/http2/consistency_test.go
@@ -7,6 +7,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	sharedconfig "github.com/nange/easyss/v3/config"
+	"github.com/nange/easyss/v3/transport"
 )
 
 // TestStatsConnsStatusConsistencyUnderShrink stresses the scheduler with a
@@ -119,4 +122,86 @@ func parseIndices(s string) []int {
 		idxs = append(idxs, n)
 	}
 	return idxs
+}
+
+// TestGrowEventRingOrderAndCap verifies the growth-event ring: newest
+// first, bounded at maxGrowEvents, carrying the triggering request's
+// endpoint and target.
+func TestGrowEventRingOrderAndCap(t *testing.T) {
+	slots := make([]*transportSlot, 4)
+	for i := range slots {
+		slots[i] = &transportSlot{idx: i}
+	}
+	tr := &HTTP2Transport{sched: newScheduler(4, slots, 4, 2)}
+
+	for i := 0; i < maxGrowEvents+4; i++ {
+		tr.recordGrowEvent("bulk", int32(i), transport.OpenRequest{
+			Endpoint: sharedconfig.EndpointUDP,
+			Target:   "8.8.8.8:53",
+		})
+	}
+
+	evs := tr.Stats().GrowEvents
+	if len(evs) != maxGrowEvents {
+		t.Fatalf("GrowEvents = %d, want %d (ring bound)", len(evs), maxGrowEvents)
+	}
+	// Newest first: the last recorded event (live = maxGrowEvents+3) heads
+	// the snapshot, the oldest surviving (live = 4) tails it.
+	if evs[0].Live != maxGrowEvents+3 {
+		t.Fatalf("head event live = %d, want %d (newest first)", evs[0].Live, maxGrowEvents+3)
+	}
+	if evs[0].Pool != "bulk" || evs[0].Endpoint != sharedconfig.EndpointUDP || evs[0].Target != "8.8.8.8:53" {
+		t.Fatalf("head event fields wrong: %+v", evs[0])
+	}
+	if evs[len(evs)-1].Live != 4 {
+		t.Fatalf("tail event live = %d, want 4 (oldest surviving)", evs[len(evs)-1].Live)
+	}
+}
+
+// TestGrowEventRingConcurrent stresses the growth-event ring: a producer
+// goroutine recording events while a reader goroutine snapshots Stats() —
+// must stay race-free and never exceed the ring bound.
+func TestGrowEventRingConcurrent(t *testing.T) {
+	slots := make([]*transportSlot, 4)
+	for i := range slots {
+		slots[i] = &transportSlot{idx: i}
+	}
+	tr := &HTTP2Transport{sched: newScheduler(4, slots, 4, 2)}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			tr.recordGrowEvent("bulk", 3, transport.OpenRequest{
+				Endpoint: sharedconfig.EndpointTCP,
+				Target:   "1.2.3.4:53",
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			_ = tr.Stats()
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	if got := len(tr.Stats().GrowEvents); got > maxGrowEvents {
+		t.Fatalf("GrowEvents = %d, want <= %d", got, maxGrowEvents)
+	}
 }

--- a/transport/http2/scheduler.go
+++ b/transport/http2/scheduler.go
@@ -608,6 +608,10 @@ func (p *slotPool) leastActive(live int, recordStats bool) *transportSlot {
 // saturation. Only when both pools are at their caps does pick fall back
 // to the tiered selection and finally the least-loaded slot.
 //
+// grow reports the pool that actually grew and its live slot count after
+// the activation; a nil pool means no growth happened (the caller then
+// knows this request did not trigger an expansion).
+//
 // Concurrency: the growth decision and the liveCount update happen inside
 // one critical section (s.mu write lock) — the unlocked fast path only
 // filters out the common no-growth case, and growTarget is re-evaluated
@@ -620,11 +624,11 @@ func (p *slotPool) leastActive(live int, recordStats bool) *transportSlot {
 // activated at once for better initial throughput, since typical web
 // browsing generates more than 8 concurrent streams; falls back to 1 when
 // maxSlots is 1.
-func (s *slotScheduler) grow(highPriority bool) {
+func (s *slotScheduler) grow(highPriority bool) (*slotPool, int32) {
 	pool := s.poolOf(highPriority)
 	target, _ := s.growTarget(pool)
 	if target == nil {
-		return
+		return nil, 0
 	}
 
 	// A new connection is needed — grow under lock.
@@ -635,7 +639,7 @@ func (s *slotScheduler) grow(highPriority bool) {
 	// activated the slot (or changed the tiers) while we waited.
 	target, live := s.growTarget(pool)
 	if target == nil {
-		return
+		return nil, 0
 	}
 	// A revived slot must not inherit the previous connection's rotation
 	// state: shrink/retire swap-remove slots out of the live set without
@@ -647,10 +651,11 @@ func (s *slotScheduler) grow(highPriority bool) {
 		target.slots[live].resetRotation()
 		target.slots[live+1].resetRotation()
 		target.liveCount.Add(2)
-	} else {
-		target.slots[live].resetRotation()
-		target.liveCount.Add(1)
+		return target, 2
 	}
+	target.slots[live].resetRotation()
+	target.liveCount.Add(1)
+	return target, live + 1
 }
 
 // growTarget decides whether a new connection is needed and which pool it

--- a/transport/http2/scheduler_test.go
+++ b/transport/http2/scheduler_test.go
@@ -3,6 +3,7 @@ package http2
 import (
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -943,7 +944,8 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 
 // TestGrowConcurrent stresses grow's double-checked locking: concurrent
 // growers must serialize on the write lock and re-evaluate under it, so a
-// burst of streams can never over-grow a pool.
+// burst of streams can never over-grow a pool — and exactly one grower
+// reports the growth (the request that actually activated the slot).
 func TestGrowConcurrent(t *testing.T) {
 	t.Run("concurrent growers activate the sibling once", func(t *testing.T) {
 		sch := newGrowTestScheduler(10, 5, 5, 0)
@@ -952,16 +954,22 @@ func TestGrowConcurrent(t *testing.T) {
 		}
 		const n = 64
 		var wg sync.WaitGroup
+		var grown atomic.Int64
 		wg.Add(n)
 		for i := 0; i < n; i++ {
 			go func() {
 				defer wg.Done()
-				sch.grow(true)
+				if pool, _ := sch.grow(true); pool != nil {
+					grown.Add(1)
+				}
 			}()
 		}
 		wg.Wait()
 		if got := sch.bulk.liveCount.Load(); got != 2 {
 			t.Fatalf("bulk liveCount = %d, want 2 (single first activation under concurrency)", got)
+		}
+		if got := grown.Load(); got != 1 {
+			t.Fatalf("grow reported growth %d times, want 1 (only the activating request)", got)
 		}
 	})
 
@@ -974,16 +982,87 @@ func TestGrowConcurrent(t *testing.T) {
 		sch.bulk.slots[1].active.Store(8)
 		const n = 64
 		var wg sync.WaitGroup
+		var grown atomic.Int64
 		wg.Add(n)
 		for i := 0; i < n; i++ {
 			go func() {
 				defer wg.Done()
-				sch.grow(true)
+				if pool, _ := sch.grow(true); pool != nil {
+					grown.Add(1)
+				}
 			}()
 		}
 		wg.Wait()
 		if got := sch.bulk.liveCount.Load(); got != 3 {
 			t.Fatalf("bulk liveCount = %d, want 3 (at most one slot added under concurrency)", got)
+		}
+		if got := grown.Load(); got != 1 {
+			t.Fatalf("grow reported growth %d times, want 1 (only the activating request)", got)
+		}
+	})
+}
+
+// TestGrowReturnValue verifies grow's reporting contract: nil when no
+// growth happened, otherwise the grown pool with its post-growth live
+// count — Open uses this to attribute a slot expansion to the request
+// that triggered it.
+func TestGrowReturnValue(t *testing.T) {
+	t.Run("nil while the pool has tier capacity", func(t *testing.T) {
+		sch := newGrowTestScheduler(10, 5, 1, 1)
+		sch.priority.slots[0].active.Store(3) // below threshold 4
+		if pool, live := sch.grow(true); pool != nil {
+			t.Fatalf("grow returned pool=%p live=%d with capacity left", pool, live)
+		}
+	})
+
+	t.Run("grows own pool once saturated", func(t *testing.T) {
+		sch := newGrowTestScheduler(10, 5, 1, 1)
+		sch.priority.slots[0].active.Store(4) // at threshold
+		pool, live := sch.grow(true)
+		if pool != sch.priority {
+			t.Fatalf("grow returned %v, want the priority pool", pool)
+		}
+		if live != 2 {
+			t.Fatalf("live = %d, want 2", live)
+		}
+		if got := sch.priority.liveCount.Load(); got != 2 {
+			t.Fatalf("priority liveCount = %d, want 2", got)
+		}
+	})
+
+	t.Run("first activation reports 2 slots", func(t *testing.T) {
+		sch := newGrowTestScheduler(10, 5, 0, 0)
+		pool, live := sch.grow(false)
+		if pool != sch.bulk {
+			t.Fatalf("grow returned %v, want the bulk pool", pool)
+		}
+		if live != 2 {
+			t.Fatalf("live = %d, want 2 on first activation", live)
+		}
+	})
+
+	t.Run("cross-pool growth reports the sibling pool", func(t *testing.T) {
+		sch := newGrowTestScheduler(10, 5, 5, 0)
+		for i := 0; i < 5; i++ {
+			sch.priority.slots[i].active.Store(4)
+		}
+		pool, live := sch.grow(true)
+		if pool != sch.bulk {
+			t.Fatalf("grow returned %v, want the bulk (sibling) pool", pool)
+		}
+		if live != 2 {
+			t.Fatalf("live = %d, want 2 (first bulk activation)", live)
+		}
+	})
+
+	t.Run("nil when both pools are at their caps", func(t *testing.T) {
+		sch := newGrowTestScheduler(10, 5, 5, 5)
+		for i := 0; i < 5; i++ {
+			sch.priority.slots[i].active.Store(4)
+			sch.bulk.slots[i].active.Store(8)
+		}
+		if pool, live := sch.grow(true); pool != nil {
+			t.Fatalf("grow returned pool=%p live=%d with both pools at their caps", pool, live)
 		}
 	})
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 )
 
 // HandshakeRejectedError reports that the server answered the bootstrap
@@ -53,6 +54,11 @@ type OpenRequest struct {
 	Endpoint     string
 	Salt         string
 	HighPriority bool
+	// Target is the stream's original destination as "host:port" (domain
+	// or IP). It never participates in scheduling — it is carried so the
+	// transport can attribute a slot-growth event to the request that
+	// triggered it (see TransportStats.GrowEvents).
+	Target string
 }
 
 type TransportStats struct {
@@ -70,6 +76,25 @@ type TransportStats struct {
 	// by "+". The bulk pool renders the same way into BulkConnsStatus.
 	PriorityConnsStatus string `json:"priority_conns_status,omitempty"`
 	BulkConnsStatus     string `json:"bulk_conns_status,omitempty"`
+	// GrowEvents lists the most recent slot-growth events (new connections
+	// activated by the lazy-expansion scheduler), newest first, bounded to
+	// a small ring (see HTTP2Transport.recordGrowEvent). Each event records
+	// the pool that grew, the live slot count after growth, and the
+	// endpoint/target of the request that triggered the growth, so a
+	// sudden connection-count jump can be attributed to the traffic that
+	// caused it.
+	GrowEvents []GrowEvent `json:"recent_grow_events,omitempty"`
+}
+
+// GrowEvent is one slot-growth (new live connection) occurrence: which
+// pool grew, the live slot count after growth, and the request that
+// triggered it (its protocol endpoint and target host:port).
+type GrowEvent struct {
+	Time     time.Time `json:"time"`
+	Pool     string    `json:"pool"` // "priority" or "bulk"
+	Live     int       `json:"live"` // live slot count after growth
+	Endpoint string    `json:"endpoint"`
+	Target   string    `json:"target"`
 }
 
 type Transport interface {


### PR DESCRIPTION
## 背景

传输层懒加载扩容（grow）此前无任何观测手段：`OpenRequest` 不带目标信息，`grow()` 无日志，导致无法回答"是哪类请求（协议、目标 IP:端口）触发了槽位扩容"。用户曾在统计页面观察到 bulk 池槽数在两次刷新间从 2 涨到 9（默认配置下 bulk 池上限恰为 9），需要定位触发请求。

## 改动

- `transport.OpenRequest` 新增 `Target` 字段（仅用于观测，不参与调度），由 proxy 层 `openAndBootstrap` 全量传入（TCP/UDP/ICMP）；
- `grow()` 返回实际扩容的池子与扩容后 live 槽数（nil 表示未扩容），并发写锁串行化保证归因精确到真正触发扩容的请求；
- `Open` 在触发扩容时打印 `[TRANSPORT] slot grown` 日志（pool/live/endpoint/proto/target）；
- `TransportStats` 新增 `recent_grow_events`（最近 16 条扩容事件环形缓冲，新→旧，含时间/池子/槽数/endpoint/目标）；
- `stats` 新增 `slot_grown_priority` / `slot_grown_bulk` 累计计数，并加入 30s 周期的 `[STATS]` 日志。

## 验证

- 新增测试：grow 返回值契约、64 并发下仅一次归因、环形缓冲顺序/上限、并发读写无竞态（-race）、端到端归因（首个 Open 触发首激活 +2 并记录 target）；
- `go test -race ./transport/... ./client/...` 通过；`make lint` 0 issues；
- `go test ./...` 仅 `util` 包 `TestIsTunIface` 失败，属环境既有问题（本机存在 easyss TUN 接口 utun9，已在干净树上复现，与本次改动无关）。

## 使用方式

复现扩容场景后查看客户端日志中的 `[TRANSPORT] slot grown` 行，或刷新统计页面查看 `recent_grow_events` 与 `slot_grown_*` 计数。