### PR TITLE
feat: render idle connections as idle in conns_status

### DIFF
--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -432,11 +432,14 @@ func (t *HTTP2Transport) Stats() transport.TransportStats {
 	return ts
 }
 
-// slotStatus derives a live slot's connection status from its health flags.
-// Multiple flags are joined with "+" so no state is hidden (a heavy download
-// crossing the connection lifetime is both heavy and expiring); a slot with
-// no flags is "active".
-func slotStatus(s *transportSlot) string {
+// slotStatus derives a live slot's connection status from its health flags
+// and the number of streams currently hosted on it. Multiple flags are
+// joined with "+" so no state is hidden (a heavy download crossing the
+// connection lifetime is both heavy and expiring). A slot with no flags
+// hosting at least one stream is "active"; one with no flags and no streams
+// is an idle warm connection and renders as "idle", so a pool full of
+// connection slots but few streams is not mistaken for active traffic.
+func slotStatus(s *transportSlot, active int) string {
 	var parts []string
 	if s.heavy.Load() > 0 {
 		parts = append(parts, "heavy")
@@ -448,6 +451,9 @@ func slotStatus(s *transportSlot) string {
 		parts = append(parts, "expiring")
 	}
 	if len(parts) == 0 {
+		if active == 0 {
+			return "idle"
+		}
 		return "active"
 	}
 	return strings.Join(parts, "+")
@@ -455,8 +461,10 @@ func slotStatus(s *transportSlot) string {
 
 // slotStatusString renders the live slots of one pool as
 // "<index>:<active streams>:<status>", wrapped in brackets, e.g.
-// "[0:3:degraded, 1:2:expiring, 2:1:active, 3:1:heavy]". Entries are
-// ordered by the stable slot identity (retire swap-removes scramble the
+// "[0:3:degraded, 1:2:expiring, 2:1:active, 3:1:heavy]". A healthy slot
+// hosting no streams renders as "0:idle" (a warm connection), so a burst
+// that grew the pool is distinguishable from real active traffic. Entries
+// are ordered by the stable slot identity (retire swap-removes scramble the
 // live order) and then renumbered from 0, so the rendered indices are
 // always consecutive with no jumps. An empty live set renders as "[]".
 // live must be the pool's liveCount value the caller snapshot under the
@@ -473,10 +481,11 @@ func slotStatusString(pool *slotPool, live int) string {
 	entries := make([]entry, 0, live)
 	for i := 0; i < live; i++ {
 		s := pool.slots[i]
+		a := int(s.active.Load())
 		entries = append(entries, entry{
 			idx:    s.idx,
-			active: int(s.active.Load()),
-			status: slotStatus(s),
+			active: a,
+			status: slotStatus(s, a),
 		})
 	}
 	if len(entries) == 0 {

--- a/transport/http2/slot_status_test.go
+++ b/transport/http2/slot_status_test.go
@@ -7,26 +7,30 @@ import (
 func TestSlotStatus(t *testing.T) {
 	tests := []struct {
 		name   string
+		active int32
 		heavy  int32
 		deg    bool
 		exp    bool
 		expect string
 	}{
-		{name: "no flags is active", expect: "active"},
-		{name: "heavy", heavy: 1, expect: "heavy"},
-		{name: "degraded", deg: true, expect: "degraded"},
-		{name: "expiring", exp: true, expect: "expiring"},
-		{name: "heavy and expiring", heavy: 1, exp: true, expect: "heavy+expiring"},
-		{name: "degraded and heavy", heavy: 2, deg: true, expect: "heavy+degraded"},
-		{name: "all flags", heavy: 1, deg: true, exp: true, expect: "heavy+degraded+expiring"},
+		{name: "no flags and no streams is idle", active: 0, expect: "idle"},
+		{name: "no flags with streams is active", active: 1, expect: "active"},
+		{name: "idle expiring", exp: true, expect: "expiring"},
+		{name: "heavy", active: 1, heavy: 1, expect: "heavy"},
+		{name: "degraded", active: 1, deg: true, expect: "degraded"},
+		{name: "expiring", active: 1, exp: true, expect: "expiring"},
+		{name: "heavy and expiring", active: 1, heavy: 1, exp: true, expect: "heavy+expiring"},
+		{name: "degraded and heavy", active: 1, heavy: 2, deg: true, expect: "heavy+degraded"},
+		{name: "all flags", active: 1, heavy: 1, deg: true, exp: true, expect: "heavy+degraded+expiring"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &transportSlot{}
+			s.active.Store(tt.active)
 			s.heavy.Store(tt.heavy)
 			s.degraded.Store(tt.deg)
 			s.expiring.Store(tt.exp)
-			if got := slotStatus(s); got != tt.expect {
+			if got := slotStatus(s, int(tt.active)); got != tt.expect {
 				t.Fatalf("slotStatus() = %q, want %q", got, tt.expect)
 			}
 		})
@@ -53,6 +57,17 @@ func TestSlotStatusString(t *testing.T) {
 	t.Run("all active with stream counts", func(t *testing.T) {
 		sch := newTestScheduler([2]int32{1, 0}, [2]int32{2, 0})
 		if got, want := statusString(sch.priority), "[0:1:active, 1:2:active]"; got != want {
+			t.Fatalf("slotStatusString() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("idle slots render as idle", func(t *testing.T) {
+		sch := newTestScheduler([2]int32{0, 0}, [2]int32{2, 0}, [2]int32{0, 0})
+		sch.priority.slots[2].expiring.Store(true)
+		// A healthy slot hosting no streams renders as "idle" (warm
+		// connection); marks still win over the idle label.
+		want := "[0:0:idle, 1:2:active, 2:0:expiring]"
+		if got := statusString(sch.priority); got != want {
 			t.Fatalf("slotStatusString() = %q, want %q", got, want)
 		}
 	})

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -72,8 +72,11 @@ type TransportStats struct {
 	// priority pool, e.g. "[0:3:degraded, 1:2:expiring, 2:1:active]". Each
 	// element is "<index>:<active streams>:<status>" where indices are
 	// consecutive from 0 (ordered by stable connection identity) and status
-	// is one of active/heavy/degraded/expiring, with multiple flags joined
-	// by "+". The bulk pool renders the same way into BulkConnsStatus.
+	// is one of idle/active/heavy/degraded/expiring, with multiple flags
+	// joined by "+". "idle" marks a healthy connection hosting no streams
+	// (a warm connection), so a pool grown by a past burst is
+	// distinguishable from active traffic. The bulk pool renders the same
+	// way into BulkConnsStatus.
 	PriorityConnsStatus string `json:"priority_conns_status,omitempty"`
 	BulkConnsStatus     string `json:"bulk_conns_status,omitempty"`
 	// GrowEvents lists the most recent slot-growth events (new connections


### PR DESCRIPTION
A healthy slot hosting no streams now renders as 0:idle instead of 0:active, so a connection pool grown by a past burst is no longer mistaken for active traffic.