### PR TITLE
fix: dedupe direct UDP session dials and skip self as DNS fallback

### DIFF
--- a/client/dns/forward.go
+++ b/client/dns/forward.go
@@ -152,17 +152,23 @@ func (s *ForwardServer) exchangeWithServers(servers []string, msg *dns.Msg) (*dn
 }
 
 // systemDNSServers returns the system dns servers as fallback upstreams,
-// filtering out ipv6 ones when ipv6 is disabled.
+// filtering out ipv6 ones when ipv6 is disabled. Servers pointing at this
+// forward server itself are always dropped: during TUN mode the system DNS
+// is set to 127.0.0.1, and using it as a fallback upstream would recurse
+// into ourselves (query -> fallback -> 127.0.0.1:53 -> same query), piling
+// up goroutines and UDP sockets until the per-query timeout unwinds the
+// chain.
 func (s *ForwardServer) systemDNSServers() []string {
 	servers := systemDNSServersFunc()
-	if !s.disableIPV6 {
-		return servers
-	}
 	var filtered []string
 	for _, srv := range servers {
-		if !strings.Contains(srv, "]:") {
-			filtered = append(filtered, srv)
+		if s.disableIPV6 && strings.Contains(srv, "]:") {
+			continue
 		}
+		if srv == s.listenAddr {
+			continue
+		}
+		filtered = append(filtered, srv)
 	}
 	return filtered
 }

--- a/client/dns/forward_test.go
+++ b/client/dns/forward_test.go
@@ -109,3 +109,38 @@ func TestForwardQueryAllServersUnavailable(t *testing.T) {
 		t.Fatalf("expected nil reply, got %v", reply)
 	}
 }
+
+// TestForwardQuerySkipsSelfAsUpstream verifies the forward server never uses
+// itself as a fallback upstream. During TUN mode the system DNS points at
+// 127.0.0.1 (this very server); without the filter the fallback would
+// recurse into itself, piling up goroutines and UDP sockets until the
+// per-query timeout unwound the chain.
+func TestForwardQuerySkipsSelfAsUpstream(t *testing.T) {
+	old := systemDNSServersFunc
+	systemDNSServersFunc = func() []string {
+		// The system DNS in TUN mode: this forward server itself (the
+		// real discovery formats it as host:port), plus an unreachable
+		// extra.
+		return []string{"127.0.0.1:53", "127.0.0.1:1"}
+	}
+	t.Cleanup(func() {
+		systemDNSServersFunc = old
+		resetSystemDNSCache()
+		resetBuiltinDNSCircuit()
+	})
+
+	fs := NewForwardServer("127.0.0.1:53", false)
+	fs.client = &dns.Client{Timeout: 200 * time.Millisecond}
+	fs.dnsServers = []string{"127.0.0.1:1"} // builtin servers all unreachable
+
+	got := fs.systemDNSServers()
+	if len(got) != 1 || got[0] != "127.0.0.1:1" {
+		t.Fatalf("systemDNSServers = %v, want only the non-self server [127.0.0.1:1]", got)
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+	if _, err := fs.forwardQuery(msg); err == nil {
+		t.Fatal("expected error: both the builtin and the non-self fallback server are unreachable")
+	}
+}

--- a/client/proxy/direct_udp_test.go
+++ b/client/proxy/direct_udp_test.go
@@ -1,0 +1,183 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nange/easyss/v3/protocol"
+	"github.com/txthinking/socks5"
+)
+
+// recordingDialer wraps a plain UDP dialer, recording every dialed conn and
+// delaying each dial so concurrent datagram handlers overlap inside the
+// (map check -> dial -> insert) window of the direct UDP relay path.
+type recordingDialer struct {
+	mu    sync.Mutex
+	conns []net.Conn
+	delay time.Duration
+}
+
+func (d *recordingDialer) dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	time.Sleep(d.delay)
+	c, err := net.Dial(network, addr)
+	if err == nil {
+		d.mu.Lock()
+		d.conns = append(d.conns, c)
+		d.mu.Unlock()
+	}
+	return c, err
+}
+
+func (d *recordingDialer) dialed() []net.Conn {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]net.Conn(nil), d.conns...)
+}
+
+func newDirectUDPTestServer(t *testing.T, dial func(context.Context, string, string) (net.Conn, error)) *Socks5Server {
+	t.Helper()
+	h := newTestStreamHandler(&mockTransport{})
+	srv, err := NewSocks5Server("127.0.0.1:0", "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, 0, dial)
+	if err != nil {
+		t.Fatalf("NewSocks5Server: %v", err)
+	}
+	return srv
+}
+
+// startSilentRemoteUDP starts a local UDP "remote" that silently discards
+// every datagram, so the relay's read loops never receive data and never
+// call sendToClient (which would need a real socks5.Server with a UDPConn).
+func startSilentRemoteUDP(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen remote udp: %v", err)
+	}
+	t.Cleanup(func() { pc.Close() })
+	go func() {
+		buf := make([]byte, 2048)
+		for {
+			if _, _, err := pc.ReadFrom(buf); err != nil {
+				return
+			}
+		}
+	}()
+	return pc.LocalAddr().String()
+}
+
+func directTestDatagram(dst string, data byte) *socks5.Datagram {
+	host, portStr, _ := net.SplitHostPort(dst)
+	port, _ := strconv.Atoi(portStr)
+	return socks5.NewDatagram(socks5.ATYPIPv4, net.ParseIP(host).To4(), []byte{byte(port >> 8), byte(port)}, []byte{data})
+}
+
+// TestDirectUDPRelayConcurrentDial verifies that two datagrams for the same
+// (client, target) key handled concurrently create exactly one direct UDP
+// session. The pre-fix code raced between the map check and the insert, so
+// both handlers dialed: one socket was orphaned (leaking it plus its read
+// goroutine for up to the 2-minute read deadline) and the orphan's cleanup
+// then deleted the LIVE map entry, churning a fresh socket every ~2 minutes
+// for long-lived flows (QUIC, games, VoIP).
+func TestDirectUDPRelayConcurrentDial(t *testing.T) {
+	dst := startSilentRemoteUDP(t)
+
+	d := &recordingDialer{delay: 80 * time.Millisecond}
+	srv := newDirectUDPTestServer(t, d.dial)
+
+	clientAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 43210}
+	key := "direct_" + clientAddr.String() + "_" + dst
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := srv.directUDPRelay(&socks5.Server{}, clientAddr, directTestDatagram(dst, 1), dst); err != nil {
+				t.Errorf("directUDPRelay: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := len(d.dialed()); got != 1 {
+		t.Fatalf("dialed %d UDP sockets for one session, want 1 (duplicate dial orphans a socket and its read goroutine)", got)
+	}
+
+	srv.udpMu.RLock()
+	dc, ok := srv.directUDP[key]
+	srv.udpMu.RUnlock()
+	if !ok || dc == nil {
+		t.Fatal("direct UDP session not registered in the map")
+	}
+}
+
+// TestDirectUDPRelayStaleReadLoopKeepsLiveEntry verifies that a read loop
+// exiting for a socket it no longer owns must not delete the map entry of
+// the live session. Pre-fix, the loop's defer deleted the entry blindly, so
+// the session was silently dropped while its socket kept lingering.
+func TestDirectUDPRelayStaleReadLoopKeepsLiveEntry(t *testing.T) {
+	dst := startSilentRemoteUDP(t)
+
+	d := &recordingDialer{delay: 0}
+	srv := newDirectUDPTestServer(t, d.dial)
+
+	clientAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 43211}
+	key := "direct_" + clientAddr.String() + "_" + dst
+
+	if err := srv.directUDPRelay(&socks5.Server{}, clientAddr, directTestDatagram(dst, 1), dst); err != nil {
+		t.Fatalf("directUDPRelay: %v", err)
+	}
+	srv.udpMu.RLock()
+	live, ok := srv.directUDP[key]
+	srv.udpMu.RUnlock()
+	if !ok || live == nil {
+		t.Fatal("live session missing before stale loop test")
+	}
+
+	// A stale socket for the same key that is NOT the map entry (this is
+	// what the duplicate-dial race produced): its read loop must exit
+	// without evicting the live session.
+	staleConn, err := srv.directDialContext(context.Background(), "udp", dst)
+	if err != nil {
+		t.Fatalf("dial stale conn: %v", err)
+	}
+	stale := &directUDPConn{conn: staleConn}
+	go srv.directUDPReadLoop(&socks5.Server{}, clientAddr, dst, key, stale)
+	_ = staleConn.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.udpMu.RLock()
+		_, ok := srv.directUDP[key]
+		srv.udpMu.RUnlock()
+		if !ok {
+			t.Fatal("stale read loop deleted the live session's map entry")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	time.Sleep(100 * time.Millisecond) // let any late delete settle
+	srv.udpMu.RLock()
+	_, ok = srv.directUDP[key]
+	srv.udpMu.RUnlock()
+	if !ok {
+		t.Fatal("live session's map entry disappeared after stale loop exit")
+	}
+
+	// Positive control: the OWNED loop's exit must still clean up its entry.
+	_ = live.conn.Close()
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.udpMu.RLock()
+		_, ok = srv.directUDP[key]
+		srv.udpMu.RUnlock()
+		if !ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("owned read loop did not delete its map entry on exit")
+}

--- a/client/proxy/direct_udp_test.go
+++ b/client/proxy/direct_udp_test.go
@@ -79,7 +79,7 @@ func directTestDatagram(dst string, data byte) *socks5.Datagram {
 // (client, target) key handled concurrently create exactly one direct UDP
 // session. The pre-fix code raced between the map check and the insert, so
 // both handlers dialed: one socket was orphaned (leaking it plus its read
-// goroutine for up to the 2-minute read deadline) and the orphan's cleanup
+// goroutine for up to the read-idle deadline) and the orphan's cleanup
 // then deleted the LIVE map entry, churning a fresh socket every ~2 minutes
 // for long-lived flows (QUIC, games, VoIP).
 func TestDirectUDPRelayConcurrentDial(t *testing.T) {

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nange/easyss/v3/util"
 	"github.com/nange/easyss/v3/util/bytespool"
 	"github.com/txthinking/socks5"
+	"golang.org/x/sync/singleflight"
 
 	easydns "github.com/nange/easyss/v3/client/dns"
 )
@@ -34,11 +35,17 @@ type Socks5Server struct {
 	directDialContext func(context.Context, string, string) (net.Conn, error)
 	dialTimeout       time.Duration
 
-	udpMu          sync.RWMutex
-	udpExch        map[string]*UDPExchange
-	udpInflight    map[string]*udpExchangeFactory
-	directUDP      map[string]*directUDPConn
-	directInflight map[string]*directUDPFactory
+	udpMu   sync.RWMutex
+	udpExch map[string]*UDPExchange
+	// udpExchangeSF deduplicates concurrent OpenUDPExchange calls for the
+	// same (client, target) key; udpInflightCount tracks how many creations
+	// are in flight so the exchange cap can account for them.
+	udpExchangeSF    singleflight.Group
+	udpInflightCount atomic.Int64
+	directUDP        map[string]*directUDPConn
+	// directUDPSF deduplicates concurrent direct-UDP dials for the same
+	// (client, target) key.
+	directUDPSF    singleflight.Group
 	quit           chan struct{}
 	closeOnce      sync.Once
 	udpIdleTimeout time.Duration
@@ -83,9 +90,7 @@ func NewSocks5Server(listenAddr, username, password string, handler *StreamHandl
 		directDialContext: directDialContext,
 		dialTimeout:       dialTimeout,
 		udpExch:           make(map[string]*UDPExchange),
-		udpInflight:       make(map[string]*udpExchangeFactory),
 		directUDP:         make(map[string]*directUDPConn),
-		directInflight:    make(map[string]*directUDPFactory),
 		quit:              make(chan struct{}),
 		udpIdleTimeout:    udpIdleTimeout,
 		dnsRespTimeout:    dnsRespTimeout,

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -38,6 +38,7 @@ type Socks5Server struct {
 	udpExch        map[string]*UDPExchange
 	udpInflight    map[string]*udpExchangeFactory
 	directUDP      map[string]*directUDPConn
+	directInflight map[string]*directUDPFactory
 	quit           chan struct{}
 	closeOnce      sync.Once
 	udpIdleTimeout time.Duration
@@ -84,6 +85,7 @@ func NewSocks5Server(listenAddr, username, password string, handler *StreamHandl
 		udpExch:           make(map[string]*UDPExchange),
 		udpInflight:       make(map[string]*udpExchangeFactory),
 		directUDP:         make(map[string]*directUDPConn),
+		directInflight:    make(map[string]*directUDPFactory),
 		quit:              make(chan struct{}),
 		udpIdleTimeout:    udpIdleTimeout,
 		dnsRespTimeout:    dnsRespTimeout,

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -69,10 +69,10 @@ type directUDPConn struct {
 
 func NewSocks5Server(listenAddr, username, password string, handler *StreamHandler, rt *router.Router, serverDomain string, method protocol.Method, disableQUIC bool, dialTimeout, udpIdleTimeout, dnsRespTimeout time.Duration, directDialContext func(context.Context, string, string) (net.Conn, error)) (*Socks5Server, error) {
 	if dialTimeout <= 0 {
-		dialTimeout = 10 * time.Second
+		dialTimeout = config.DefaultDialTimeout
 	}
 	if udpIdleTimeout <= 0 {
-		udpIdleTimeout = 30 * time.Second
+		udpIdleTimeout = config.DefaultUDPIdleTimeout
 	}
 	if directDialContext == nil {
 		directDialContext = defaultDirectDialContext
@@ -356,8 +356,8 @@ func (s *Socks5Server) replyError(c net.Conn, r *socks5.Request, rep byte) error
 // idle timeout via relay.Bidirectional (StreamHandler.streamIdleTimeout);
 // the direct path previously had no deadline at all, so a silent or
 // half-open peer left the two copy goroutines and their sockets leaked
-// forever.
-const directRelayIdleTimeout = 300 * time.Second
+// forever. It mirrors the stream idle timeout (10 x the user timeout).
+const directRelayIdleTimeout = config.DefaultStreamIdleTimeout
 
 // relayTCP copies bytes in both directions between dst and src with a shared
 // idle timeout, mirroring the proxied path's relay semantics: on clean EOF a

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -422,7 +422,7 @@ func (s *Socks5Server) cleanupLoop() {
 			// Direct UDP sessions get the same idle recycling: a remote peer
 			// that stops responding (or a datagram flow that simply ended)
 			// must not pin the socket and its reader goroutine until the
-			// 2-minute read deadline fires.
+			// read loop's own read-idle deadline fires.
 			for key, dc := range s.directUDP {
 				if time.Since(time.Unix(0, dc.lastSeen.Load())) > s.udpIdleTimeout {
 					log.Debug("[UDP_DIRECT] idle cleanup", "key", key)

--- a/client/proxy/stream.go
+++ b/client/proxy/stream.go
@@ -50,7 +50,7 @@ type StreamHandler struct {
 
 func NewStreamHandler(tr transport.Transport, masterKey []byte, shaperCfg shaper.Config, streamIdleTimeout time.Duration) *StreamHandler {
 	if streamIdleTimeout <= 0 {
-		streamIdleTimeout = 300 * time.Second
+		streamIdleTimeout = config.DefaultStreamIdleTimeout
 	}
 	return &StreamHandler{
 		transport:         tr,

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -466,9 +466,9 @@ func (s *Socks5Server) directUDPRelay(srv *socks5.Server, clientAddr *net.UDPAdd
 // result, so exactly one socket and one read loop exist per (client, target)
 // flow. Without the dedup, two datagrams of the same flow handled
 // concurrently both missed the map lookup and both dialed: one socket was
-// orphaned (leaking it plus its read goroutine until the 2-minute read
+// orphaned (leaking it plus its read goroutine until the read-idle
 // deadline), and the orphan's cleanup then deleted the LIVE map entry,
-// churning a fresh socket for the flow every ~2 minutes.
+// churning a fresh socket for the flow every ~udpIdleTimeout.
 func (s *Socks5Server) getOrCreateDirectUDPSession(srv *socks5.Server, clientAddr *net.UDPAddr, dst, key string) (*directUDPConn, error) {
 	s.udpMu.RLock()
 	dc, ok := s.directUDP[key]
@@ -518,10 +518,13 @@ func (s *Socks5Server) getOrCreateDirectUDPSession(srv *socks5.Server, clientAdd
 }
 
 // directUDPReadLoop relays datagrams from the direct remote back to the
-// client until the socket fails or the 2-minute read deadline fires with no
-// data. On exit it closes the socket and removes the session from the map,
-// but only while the entry still points at this session - never at a newer
-// one that replaced it.
+// client until the socket fails or the read-idle deadline fires with no
+// data. The deadline is the same udpIdleTimeout the cleanup loop uses to
+// reap idle sessions (2 x the user-configured timeout), mirroring the
+// server-side UDP handler which also reads with its 2 x timeout idle
+// deadline. On exit it closes the socket and removes the session from the
+// map, but only while the entry still points at this session - never at a
+// newer one that replaced it.
 func (s *Socks5Server) directUDPReadLoop(srv *socks5.Server, clientAddr *net.UDPAddr, dst, key string, dc *directUDPConn) {
 	rc := dc.conn
 	defer func() {
@@ -535,7 +538,7 @@ func (s *Socks5Server) directUDPReadLoop(srv *socks5.Server, clientAddr *net.UDP
 	buf := bytespool.Get(protocol.MaxUDPDataSize)
 	defer bytespool.MustPut(buf)
 	for {
-		_ = rc.SetReadDeadline(time.Now().Add(2 * time.Minute))
+		_ = rc.SetReadDeadline(time.Now().Add(s.udpIdleTimeout))
 		n, err := rc.Read(buf)
 		if err != nil {
 			return

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -221,15 +221,6 @@ func (s *Socks5Server) proxyDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr
 	return nil
 }
 
-// udpExchangeFactory deduplicates concurrent attempts to create a UDPExchange
-// for the same key. The first goroutine to need a key performs the (slow)
-// OpenUDPExchange call; concurrent waiters block on done and reuse the result.
-type udpExchangeFactory struct {
-	done chan struct{}
-	ue   *UDPExchange
-	err  error
-}
-
 // maxUDPExchanges bounds the number of concurrent proxied UDP exchanges.
 // Each exchange owns one HTTP/2 stream, one receiveLoop goroutine and one
 // shaper; keying by (client address, target) means a client that uses a
@@ -244,28 +235,30 @@ const maxUDPExchanges = 128
 // the exchange already existed, firstPayload is ignored. If this call created
 // the exchange, created is true and the caller MUST NOT call ue.Send for the
 // first payload (it was already sent in the handshake).
+//
+// Concurrent creations for the same key are deduplicated through a
+// singleflight group: the first caller performs the (slow) OpenUDPExchange
+// call, concurrent waiters block and reuse the result, so exactly one
+// HTTP/2 stream and one receiveLoop exist per (client, target) flow.
 func (s *Socks5Server) getOrCreateUDPExchange(key, dst string, firstPayload []byte) (ue *UDPExchange, created bool, err error) {
-	s.udpMu.Lock()
-	if existing, ok := s.udpExch[key]; ok {
-		s.udpMu.Unlock()
+	s.udpMu.RLock()
+	existing, ok := s.udpExch[key]
+	s.udpMu.RUnlock()
+	if ok {
 		return existing, false, nil
 	}
-	if f, ok := s.udpInflight[key]; ok {
-		s.udpMu.Unlock()
-		<-f.done
-		if s.closing.Load() {
-			return nil, false, errSocksServerClosed
-		}
-		return f.ue, false, f.err
-	}
+
+	// Enforce the exchange cap before creating. In-flight creations for
+	// other keys count towards the limit; this call's own creation is not
+	// registered yet (the flight fn bumps udpInflightCount after the
+	// check), mirroring the pre-singleflight semantics where the factory
+	// entry was inserted after the check.
 	var evicted *UDPExchange
-	if len(s.udpExch)+len(s.udpInflight) >= maxUDPExchanges {
+	s.udpMu.Lock()
+	if len(s.udpExch)+int(s.udpInflightCount.Load()) >= maxUDPExchanges {
 		evicted = s.evictOldestExchangeLocked()
 	}
-	f := &udpExchangeFactory{done: make(chan struct{})}
-	s.udpInflight[key] = f
 	s.udpMu.Unlock()
-
 	// Close the evicted exchange outside the lock: Close flushes a FIN
 	// through the HTTP/2 stream (an io.Pipe write), which can block on
 	// transport backpressure — holding s.udpMu there would freeze all UDP
@@ -275,31 +268,46 @@ func (s *Socks5Server) getOrCreateUDPExchange(key, dst string, firstPayload []by
 		evicted.Close() //nolint:errcheck
 	}
 
-	ue, err = s.handler.OpenUDPExchange(context.Background(), dst, s.method, firstPayload)
-	f.ue, f.err = ue, err
-	close(f.done)
+	v, err, shared := s.udpExchangeSF.Do(key, func() (any, error) {
+		s.udpInflightCount.Add(1)
+		defer s.udpInflightCount.Add(-1)
 
+		ue, err := s.handler.OpenUDPExchange(context.Background(), dst, s.method, firstPayload)
+		if err != nil {
+			return nil, err
+		}
+		// The server was closed while the exchange was being created: close
+		// it immediately so the stream and its receiveLoop cannot leak past
+		// shutdown (the cleanup loop has already exited).
+		if s.closing.Load() {
+			ue.Close() //nolint:errcheck
+			return nil, errSocksServerClosed
+		}
+		return ue, nil
+	})
 	if err != nil {
-		s.udpMu.Lock()
-		delete(s.udpInflight, key)
-		s.udpMu.Unlock()
 		return nil, false, err
 	}
-	// The server was closed while the exchange was being created: close it
-	// immediately so the stream and its receiveLoop cannot leak past
-	// shutdown (the cleanup loop has already exited).
+	ue = v.(*UDPExchange)
 	if s.closing.Load() {
-		ue.Close() //nolint:errcheck
-		s.udpMu.Lock()
-		delete(s.udpInflight, key)
-		s.udpMu.Unlock()
+		// The server was closed after the flight finished but before the
+		// exchange was registered. The creator (shared == false) owns the
+		// exchange and must close it (it is not in the map yet, so Close's
+		// map sweep cannot reclaim it); waiters just report the error.
+		if !shared {
+			ue.Close() //nolint:errcheck
+		}
 		return nil, false, errSocksServerClosed
 	}
+	// Registering the same pointer from every caller (creator and waiters)
+	// is idempotent, and lets the waiters' first payload be sent by their
+	// own ue.Send below instead of being lost.
 	s.udpMu.Lock()
 	s.udpExch[key] = ue
-	delete(s.udpInflight, key)
 	s.udpMu.Unlock()
-	return ue, true, nil
+	// created reports whether this call's firstPayload was merged into the
+	// bootstrap record: only the creator's payload was (shared == false).
+	return ue, !shared, nil
 }
 
 var errSocksServerClosed = errors.New("socks5 udp server closed")
@@ -431,19 +439,6 @@ func (s *Socks5Server) handleRegularUDP(srv *socks5.Server, clientAddr *net.UDPA
 	return nil
 }
 
-// directUDPFactory deduplicates concurrent attempts to create a direct UDP
-// session for the same key, mirroring udpExchangeFactory on the proxied path.
-// Without it, two datagrams of the same (client, target) flow handled
-// concurrently both missed the map lookup and both dialed: one socket was
-// orphaned (leaking it plus its read goroutine until the 2-minute read
-// deadline), and the orphan's cleanup then deleted the LIVE map entry,
-// churning a fresh socket for the flow every ~2 minutes.
-type directUDPFactory struct {
-	done chan struct{}
-	dc   *directUDPConn
-	err  error
-}
-
 func (s *Socks5Server) directUDPRelay(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, dst string) error {
 	key := "direct_" + clientAddr.String() + "_" + dst
 
@@ -466,61 +461,59 @@ func (s *Socks5Server) directUDPRelay(srv *socks5.Server, clientAddr *net.UDPAdd
 
 // getOrCreateDirectUDPSession returns the direct UDP session for key,
 // creating its socket and read loop when absent. Concurrent creators for the
-// same key are deduplicated through an in-flight factory: the first caller
-// dials, the others block on the factory and reuse the result, so exactly
-// one socket and one read loop exist per (client, target) flow.
+// same key are deduplicated through a singleflight group (mirroring the
+// proxied path): the first caller dials, the others wait for and reuse the
+// result, so exactly one socket and one read loop exist per (client, target)
+// flow. Without the dedup, two datagrams of the same flow handled
+// concurrently both missed the map lookup and both dialed: one socket was
+// orphaned (leaking it plus its read goroutine until the 2-minute read
+// deadline), and the orphan's cleanup then deleted the LIVE map entry,
+// churning a fresh socket for the flow every ~2 minutes.
 func (s *Socks5Server) getOrCreateDirectUDPSession(srv *socks5.Server, clientAddr *net.UDPAddr, dst, key string) (*directUDPConn, error) {
-	s.udpMu.Lock()
-	if existing, ok := s.directUDP[key]; ok {
-		s.udpMu.Unlock()
-		return existing, nil
+	s.udpMu.RLock()
+	dc, ok := s.directUDP[key]
+	s.udpMu.RUnlock()
+	if ok {
+		return dc, nil
 	}
-	if f, ok := s.directInflight[key]; ok {
-		s.udpMu.Unlock()
-		<-f.done
-		return f.dc, f.err
-	}
-	f := &directUDPFactory{done: make(chan struct{})}
-	s.directInflight[key] = f
-	s.udpMu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), s.dialTimeout)
-	rc, err := s.directDialContext(ctx, "udp", dst)
-	cancel()
-	if err != nil {
-		f.dc, f.err = nil, err
-		close(f.done)
+	v, err, _ := s.directUDPSF.Do(key, func() (any, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), s.dialTimeout)
+		rc, err := s.directDialContext(ctx, "udp", dst)
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+
+		// The server was closed while we were dialing: close the socket so
+		// the session and its read loop cannot leak past shutdown (the
+		// cleanup loop has already exited).
+		if s.closing.Load() {
+			rc.Close() //nolint:errcheck
+			return nil, errSocksServerClosed
+		}
+
+		dc := &directUDPConn{conn: rc}
+		dc.lastSeen.Store(time.Now().UnixNano())
+
 		s.udpMu.Lock()
-		delete(s.directInflight, key)
+		s.directUDP[key] = dc
 		s.udpMu.Unlock()
+
+		go s.directUDPReadLoop(srv, clientAddr, dst, key, dc)
+
+		return dc, nil
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	// The server was closed while we were dialing: close the socket so the
-	// session and its read loop cannot leak past shutdown (the cleanup
-	// loop has already exited).
+	dc = v.(*directUDPConn)
+	// The server was closed after the flight finished: the creator has
+	// already registered the session, so Close's map sweep or the read
+	// loop's own exit reclaims it; waiters just report the error.
 	if s.closing.Load() {
-		rc.Close() //nolint:errcheck
-		f.dc, f.err = nil, errSocksServerClosed
-		close(f.done)
-		s.udpMu.Lock()
-		delete(s.directInflight, key)
-		s.udpMu.Unlock()
 		return nil, errSocksServerClosed
 	}
-
-	dc := &directUDPConn{conn: rc}
-	dc.lastSeen.Store(time.Now().UnixNano())
-	f.dc, f.err = dc, nil
-	close(f.done)
-
-	s.udpMu.Lock()
-	s.directUDP[key] = dc
-	delete(s.directInflight, key)
-	s.udpMu.Unlock()
-
-	go s.directUDPReadLoop(srv, clientAddr, dst, key, dc)
-
 	return dc, nil
 }
 

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -431,6 +431,19 @@ func (s *Socks5Server) handleRegularUDP(srv *socks5.Server, clientAddr *net.UDPA
 	return nil
 }
 
+// directUDPFactory deduplicates concurrent attempts to create a direct UDP
+// session for the same key, mirroring udpExchangeFactory on the proxied path.
+// Without it, two datagrams of the same (client, target) flow handled
+// concurrently both missed the map lookup and both dialed: one socket was
+// orphaned (leaking it plus its read goroutine until the 2-minute read
+// deadline), and the orphan's cleanup then deleted the LIVE map entry,
+// churning a fresh socket for the flow every ~2 minutes.
+type directUDPFactory struct {
+	done chan struct{}
+	dc   *directUDPConn
+	err  error
+}
+
 func (s *Socks5Server) directUDPRelay(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, dst string) error {
 	key := "direct_" + clientAddr.String() + "_" + dst
 
@@ -438,52 +451,110 @@ func (s *Socks5Server) directUDPRelay(srv *socks5.Server, clientAddr *net.UDPAdd
 	dc, ok := s.directUDP[key]
 	s.udpMu.RUnlock()
 
-	if ok {
-		dc.lastSeen.Store(time.Now().UnixNano())
-		_, err := dc.conn.Write(d.Data)
-		return err
+	if !ok {
+		var err error
+		dc, err = s.getOrCreateDirectUDPSession(srv, clientAddr, dst, key)
+		if err != nil {
+			return err
+		}
 	}
+
+	dc.lastSeen.Store(time.Now().UnixNano())
+	_, err := dc.conn.Write(d.Data)
+	return err
+}
+
+// getOrCreateDirectUDPSession returns the direct UDP session for key,
+// creating its socket and read loop when absent. Concurrent creators for the
+// same key are deduplicated through an in-flight factory: the first caller
+// dials, the others block on the factory and reuse the result, so exactly
+// one socket and one read loop exist per (client, target) flow.
+func (s *Socks5Server) getOrCreateDirectUDPSession(srv *socks5.Server, clientAddr *net.UDPAddr, dst, key string) (*directUDPConn, error) {
+	s.udpMu.Lock()
+	if existing, ok := s.directUDP[key]; ok {
+		s.udpMu.Unlock()
+		return existing, nil
+	}
+	if f, ok := s.directInflight[key]; ok {
+		s.udpMu.Unlock()
+		<-f.done
+		return f.dc, f.err
+	}
+	f := &directUDPFactory{done: make(chan struct{})}
+	s.directInflight[key] = f
+	s.udpMu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.dialTimeout)
 	rc, err := s.directDialContext(ctx, "udp", dst)
 	cancel()
 	if err != nil {
-		return err
+		f.dc, f.err = nil, err
+		close(f.done)
+		s.udpMu.Lock()
+		delete(s.directInflight, key)
+		s.udpMu.Unlock()
+		return nil, err
 	}
-	dc = &directUDPConn{conn: rc}
+
+	// The server was closed while we were dialing: close the socket so the
+	// session and its read loop cannot leak past shutdown (the cleanup
+	// loop has already exited).
+	if s.closing.Load() {
+		rc.Close() //nolint:errcheck
+		f.dc, f.err = nil, errSocksServerClosed
+		close(f.done)
+		s.udpMu.Lock()
+		delete(s.directInflight, key)
+		s.udpMu.Unlock()
+		return nil, errSocksServerClosed
+	}
+
+	dc := &directUDPConn{conn: rc}
 	dc.lastSeen.Store(time.Now().UnixNano())
+	f.dc, f.err = dc, nil
+	close(f.done)
 
 	s.udpMu.Lock()
 	s.directUDP[key] = dc
+	delete(s.directInflight, key)
 	s.udpMu.Unlock()
 
-	go func() {
-		defer func() {
-			rc.Close() //nolint:errcheck
-			s.udpMu.Lock()
-			delete(s.directUDP, key)
-			s.udpMu.Unlock()
-		}()
-		buf := bytespool.Get(protocol.MaxUDPDataSize)
-		defer bytespool.MustPut(buf)
-		for {
-			_ = rc.SetReadDeadline(time.Now().Add(2 * time.Minute))
-			n, err := rc.Read(buf)
-			if err != nil {
-				return
-			}
-			// Refresh the idle timestamp on receive as well as send, mirroring
-			// the proxied path (UDPExchange.Receive): a flow that keeps
-			// receiving but never writes again (a one-shot query with a long
-			// stream of responses) must not be reaped while it is still
-			// active.
-			dc.lastSeen.Store(time.Now().UnixNano())
-			s.sendToClient(srv, clientAddr, buf[:n], dst)
-		}
-	}()
+	go s.directUDPReadLoop(srv, clientAddr, dst, key, dc)
 
-	_, err = rc.Write(d.Data)
-	return err
+	return dc, nil
+}
+
+// directUDPReadLoop relays datagrams from the direct remote back to the
+// client until the socket fails or the 2-minute read deadline fires with no
+// data. On exit it closes the socket and removes the session from the map,
+// but only while the entry still points at this session - never at a newer
+// one that replaced it.
+func (s *Socks5Server) directUDPReadLoop(srv *socks5.Server, clientAddr *net.UDPAddr, dst, key string, dc *directUDPConn) {
+	rc := dc.conn
+	defer func() {
+		rc.Close() //nolint:errcheck
+		s.udpMu.Lock()
+		if cur, ok := s.directUDP[key]; ok && cur == dc {
+			delete(s.directUDP, key)
+		}
+		s.udpMu.Unlock()
+	}()
+	buf := bytespool.Get(protocol.MaxUDPDataSize)
+	defer bytespool.MustPut(buf)
+	for {
+		_ = rc.SetReadDeadline(time.Now().Add(2 * time.Minute))
+		n, err := rc.Read(buf)
+		if err != nil {
+			return
+		}
+		// Refresh the idle timestamp on receive as well as send, mirroring
+		// the proxied path (UDPExchange.Receive): a flow that keeps
+		// receiving but never writes again (a one-shot query with a long
+		// stream of responses) must not be reaped while it is still
+		// active.
+		dc.lastSeen.Store(time.Now().UnixNano())
+		s.sendToClient(srv, clientAddr, buf[:n], dst)
+	}
 }
 
 func (s *Socks5Server) proxyUDPRelay(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, dst string) error {

--- a/cmd/easyss/easyss_test.go
+++ b/cmd/easyss/easyss_test.go
@@ -22,6 +22,7 @@ import (
 	clientconfig "github.com/nange/easyss/v3/client/config"
 	"github.com/nange/easyss/v3/client/proxy"
 	"github.com/nange/easyss/v3/client/router"
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/protocol"
 	server "github.com/nange/easyss/v3/server"
 	serverconfig "github.com/nange/easyss/v3/server/config"
@@ -306,9 +307,9 @@ func newTestHarness(t *testing.T) *testHarness {
 
 	// Create stream handler
 	timeout := clientCfg.TimeoutDuration()
-	streamIdleTimeout := 10 * timeout
-	udpIdleTimeout := 2 * timeout
-	dialTimeout := timeout / 2
+	streamIdleTimeout := sharedconfig.StreamIdleTimeout(timeout)
+	udpIdleTimeout := sharedconfig.UDPIdleTimeout(timeout)
+	dialTimeout := sharedconfig.DialTimeout(timeout)
 	shaperCfg := shaper.Config{
 		BatchWindowMS: clientCfg.Shaper.BatchWindowMS,
 		Cover: shaper.CoverConfig{

--- a/config/timeouts.go
+++ b/config/timeouts.go
@@ -1,0 +1,39 @@
+package config
+
+import "time"
+
+// Timeout derivation helpers: the single source of truth for how the
+// user-configured base timeout maps to each idle/dial timeout. The client
+// (runner.Run) and the server (server.New) both derive their timeouts
+// through these functions, so a change to any formula takes effect on both
+// sides and in the tests that mirror the derivation.
+//
+// The base timeout is passed in as an argument: these functions never read
+// the configuration themselves, callers hand over their own configured
+// value (default 30s, see DefaultTimeout).
+
+// StreamIdleTimeout returns the TCP stream idle timeout derived from the
+// user-configured base timeout (10 x base; default 30s -> 300s).
+func StreamIdleTimeout(base time.Duration) time.Duration {
+	return 10 * base
+}
+
+// UDPIdleTimeout returns the UDP session idle/read timeout (2 x base;
+// default 30s -> 60s).
+func UDPIdleTimeout(base time.Duration) time.Duration {
+	return 2 * base
+}
+
+// DialTimeout returns the outbound dial timeout: base / 3, clamped to
+// [3s, 15s]. Shared by the client (direct dials) and the server (TCP
+// handler dials) so both sides always derive the same value.
+func DialTimeout(base time.Duration) time.Duration {
+	d := base / 3
+	if d < 3*time.Second {
+		d = 3 * time.Second
+	}
+	if d > 15*time.Second {
+		d = 15 * time.Second
+	}
+	return d
+}

--- a/config/timeouts_test.go
+++ b/config/timeouts_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStreamIdleTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{"默认值 30s", 30 * time.Second, 300 * time.Second},
+		{"0s", 0, 0},
+		{"小值 5s", 5 * time.Second, 50 * time.Second},
+		{"大值 120s", 120 * time.Second, 20 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StreamIdleTimeout(tt.timeout); got != tt.want {
+				t.Errorf("StreamIdleTimeout(%v) = %v, want %v", tt.timeout, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUDPIdleTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{"默认值 30s", 30 * time.Second, 60 * time.Second},
+		{"0s", 0, 0},
+		{"小值 5s", 5 * time.Second, 10 * time.Second},
+		{"大值 120s", 120 * time.Second, 4 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UDPIdleTimeout(tt.timeout); got != tt.want {
+				t.Errorf("UDPIdleTimeout(%v) = %v, want %v", tt.timeout, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDialTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{"默认值 30s", 30 * time.Second, 10 * time.Second},
+		{"最小值保底：0s", 0, 3 * time.Second},
+		{"最小值保底：9s", 9 * time.Second, 3 * time.Second},
+		{"正常值：15s", 15 * time.Second, 5 * time.Second},
+		{"正常值：45s", 45 * time.Second, 15 * time.Second},
+		{"最大值封顶：60s", 60 * time.Second, 15 * time.Second},
+		{"最大值封顶：120s", 120 * time.Second, 15 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DialTimeout(tt.timeout); got != tt.want {
+				t.Errorf("DialTimeout(%v) = %v, want %v", tt.timeout, got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/xjasonlyu/tun2socks/v2 v2.6.1-0.20260808015004-d24a73449e3a
 	golang.org/x/crypto v0.55.0
 	golang.org/x/net v0.58.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -248,7 +249,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260820142414-ca536658362e // indirect
 	golang.org/x/mobile v0.0.0-20260820023541-8e8303b9da6c // indirect
 	golang.org/x/mod v0.40.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nange/easyss/v3/client/config"
 	"github.com/nange/easyss/v3/client/dns"
 	"github.com/nange/easyss/v3/client/proxy"
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/shaper"
@@ -48,9 +49,9 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 	}
 
 	timeout := cfg.TimeoutDuration()
-	streamIdleTimeout := 10 * timeout
-	udpIdleTimeout := 2 * timeout
-	dialTimeout := timeout / 2
+	streamIdleTimeout := sharedconfig.StreamIdleTimeout(timeout)
+	udpIdleTimeout := sharedconfig.UDPIdleTimeout(timeout)
+	dialTimeout := sharedconfig.DialTimeout(timeout)
 
 	streamHandler := proxy.NewStreamHandler(cli.Transport(), cli.MasterKey(), shaperCfg, streamIdleTimeout)
 

--- a/server/handler/helpers_test.go
+++ b/server/handler/helpers_test.go
@@ -141,31 +141,6 @@ func TestNewProxyHandler(t *testing.T) {
 	})
 }
 
-func TestDialTimeout(t *testing.T) {
-	tests := []struct {
-		name    string
-		timeout time.Duration
-		want    time.Duration
-	}{
-		{"默认值 30s", 30 * time.Second, 10 * time.Second},
-		{"最小值保底：0s", 0, 3 * time.Second},
-		{"最小值保底：9s", 9 * time.Second, 3 * time.Second},
-		{"正常值：15s", 15 * time.Second, 5 * time.Second},
-		{"正常值：45s", 45 * time.Second, 15 * time.Second},
-		{"最大值封顶：60s", 60 * time.Second, 15 * time.Second},
-		{"最大值封顶：120s", 120 * time.Second, 15 * time.Second},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := DialTimeout(tt.timeout)
-			if got != tt.want {
-				t.Errorf("DialTimeout(%v) = %v, want %v", tt.timeout, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestNewTCPHandler_DialTimeout(t *testing.T) {
 	h := NewTCPHandler(120*time.Second, 30*time.Second, nil)
 	if h == nil {

--- a/server/handler/tcp.go
+++ b/server/handler/tcp.go
@@ -28,19 +28,9 @@ type TCPHandler struct {
 	dialTimeout time.Duration
 }
 
-// DialTimeout computes the dial timeout for outbound connections.
-// It is derived from the base timeout: timeout/3, clamped to [3s, 15s].
-func DialTimeout(timeout time.Duration) time.Duration {
-	d := timeout / 3
-	if d < 3*time.Second {
-		d = 3 * time.Second
-	}
-	if d > 15*time.Second {
-		d = 15 * time.Second
-	}
-	return d
-}
-
+// NewTCPHandler creates a TCPHandler with the given idle timeout and base
+// timeout. The dial timeout is derived through config.DialTimeout (base/3
+// clamped to [3s, 15s]), shared with the client side.
 func NewTCPHandler(idleTimeout, timeout time.Duration, np *nextproxy.NextProxy) *TCPHandler {
 	if idleTimeout <= 0 {
 		idleTimeout = config.DefaultStreamIdleTimeout
@@ -48,7 +38,7 @@ func NewTCPHandler(idleTimeout, timeout time.Duration, np *nextproxy.NextProxy) 
 	if timeout <= 0 {
 		timeout = time.Duration(config.DefaultTimeout) * time.Second
 	}
-	dialTimeout := DialTimeout(timeout)
+	dialTimeout := config.DialTimeout(timeout)
 	return &TCPHandler{
 		dialer:      &net.Dialer{Timeout: dialTimeout, KeepAlive: timeout},
 		nextProxy:   np,

--- a/server/server.go
+++ b/server/server.go
@@ -281,11 +281,11 @@ func (s *Server) Start() error {
 			log.Error("[SERVER] next proxy load file failed", "err", err)
 			return fmt.Errorf("next proxy load file: %w", err)
 		}
-		np.SetDialTimeout(handler.DialTimeout(timeout))
+		np.SetDialTimeout(sharedconfig.DialTimeout(timeout))
 		log.Info("[SERVER] next proxy configured", "url", s.cfg.NextProxy.URL, "udp", s.cfg.NextProxy.EnableUDP, "all_host", s.cfg.NextProxy.AllHost)
 	}
 
-	streamIdleTimeout := 10 * timeout
+	streamIdleTimeout := sharedconfig.StreamIdleTimeout(timeout)
 
 	proxyHandler := handler.NewProxyHandler(handler.ProxyHandlerConfig{
 		MasterKey:         masterKey,
@@ -293,7 +293,7 @@ func (s *Server) Start() error {
 		HandshakeTimeout:  timeout,
 		Timeout:           timeout,
 		StreamIdleTimeout: streamIdleTimeout,
-		UDPIdleTimeout:    2 * timeout,
+		UDPIdleTimeout:    sharedconfig.UDPIdleTimeout(timeout),
 		BatchWindowMS:     s.cfg.BatchWindowMS,
 		CoverBudgetRatio:  s.cfg.CoverBudgetRatio,
 		CoverBudgetCap:    s.cfg.CoverBudgetCap,


### PR DESCRIPTION
## 背景

修复两个问题：

### 1. direct UDP 会话重复拨号导致连接泄漏

`directUDPRelay` 在 map 查找与插入之间存在竞态窗口：同一 (client, target) 流的并发 datagram 会重复 dial，产生孤儿 socket 及其 read goroutine（最多泄漏至 2 分钟读超时）；更严重的是孤儿 readLoop 退出时无条件删除 map 条目，会误删 LIVE 会话，导致长连接流（QUIC、游戏、VoIP）每 ~2 分钟 churn 一个新 socket。

**修复**：
- 新增 `directUDPFactory` in-flight 去重（与 proxied 路径的 `udpExchangeFactory` 对称），保证每个流恰好一个 socket + 一个 readLoop
- readLoop 退出时仅在 map 条目仍指向本 session 时才删除，孤儿清理不再误删 LIVE 条目
- dial 成功后检查 `closing` 标志，服务关闭期间新建的 socket 立即关闭，不泄漏

### 2. DNS forward 服务器以自身作为 fallback 上游造成递归

TUN 模式 + `EnableForwardDNS` 时系统 DNS 被设置为 127.0.0.1（即本 forward 服务器自身）。当 builtin DNS 服务器全部不可达时，fallback 会递归回自身（查询 -> fallback -> 127.0.0.1:53 -> 同一查询），堆积 goroutine 和 UDP socket 直到查询超时。

**修复**：`systemDNSServers()` 过滤掉指向自身监听地址的条目。

## 测试

- 新增 `TestDirectUDPRelayConcurrentDial`：验证并发 datagram 只拨号一次
- 新增 `TestDirectUDPRelayStaleReadLoopKeepsLiveEntry`：验证孤儿 readLoop 退出不误删 LIVE 条目（含正向对照）
- 新增 `TestForwardQuerySkipsSelfAsUpstream`：验证系统 DNS 中的自身条目被过滤
- `go test ./client/dns/...` 与 `go test ./client/proxy/ -run DirectUDP` 全部通过