### PR TITLE
fix: unify stream idle timeout derivation and apply it to direct TCP relays

### DIFF
--- a/client/proxy/close_race_test.go
+++ b/client/proxy/close_race_test.go
@@ -28,7 +28,7 @@ func TestSocks5CloseRacingStart(t *testing.T) {
 		l.Close()
 
 		h := newTestStreamHandler(&mockTransport{})
-		srv, err := NewSocks5Server(addr, "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, 0, nil)
+		srv, err := NewSocks5Server(addr, "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, 0, 0, nil)
 		if err != nil {
 			t.Fatalf("NewSocks5Server #%d: %v", i, err)
 		}

--- a/client/proxy/direct_relay_test.go
+++ b/client/proxy/direct_relay_test.go
@@ -1,0 +1,151 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// tcpPair dials a fresh local TCP pair (client side + accepted server side)
+// and returns both ends.
+func tcpPair(t *testing.T) (client, server net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aErr := ln.Accept()
+		if aErr != nil {
+			return
+		}
+		accepted <- c
+	}()
+
+	client, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { client.Close() }) //nolint:errcheck
+
+	select {
+	case server = <-accepted:
+	case <-time.After(2 * time.Second):
+		client.Close() //nolint:errcheck
+		t.Fatal("accept timed out")
+	}
+	t.Cleanup(func() { server.Close() }) //nolint:errcheck
+	return client, server
+}
+
+// connClosed reports whether the connection has been closed: a read on a
+// closed TCP connection returns an error (possibly after the FIN/EOF of a
+// half-close, which also proves no data keeps flowing).
+func connClosed(t *testing.T, conn net.Conn) bool {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := conn.Read(buf)
+	return err != nil
+}
+
+// TestRelayTCPIdleTimeoutClosesBoth verifies that relayTCP honors its idle
+// timeout argument: a silent pair must be torn down (both connections closed)
+// after the given idle, so the copy goroutines cannot linger forever.
+func TestRelayTCPIdleTimeoutClosesBoth(t *testing.T) {
+	client, server := tcpPair(t)
+
+	const idle = 100 * time.Millisecond
+	start := time.Now()
+	relayTCP(client, server, idle)
+	if elapsed := time.Since(start); elapsed < idle {
+		t.Fatalf("relay returned after %v, want >= %v idle", elapsed, idle)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("relay took %v, want ~%v", elapsed, idle)
+	}
+	if !connClosed(t, client) {
+		t.Error("client connection still open after idle timeout")
+	}
+	if !connClosed(t, server) {
+		t.Error("server connection still open after idle timeout")
+	}
+}
+
+// TestRelayTCPHalfCloseAndCompletion verifies the half-close semantics of the
+// direct relay with a faithful topology: two separate TCP pairs simulate the
+// local application <-> proxy leg and the proxy <-> remote leg, with the
+// relay bridging the proxy-side sockets. Each socket has exactly one reader
+// and one writer, like production. A FIN on one leg is propagated to the
+// other via CloseWrite while the reverse direction keeps flowing, and the
+// relay returns only after both directions completed (both proxy-side
+// sockets closed).
+func TestRelayTCPHalfCloseAndCompletion(t *testing.T) {
+	app, proxyC := tcpPair(t)   // local application <-> proxy
+	proxyRC, remote := tcpPair(t) // proxy <-> remote server
+
+	done := make(chan struct{})
+	go func() {
+		relayTCP(proxyRC, proxyC, time.Minute) // same orientation as TCPHandle
+		close(done)
+	}()
+
+	// The application sends its payload and half-closes its write side:
+	// the relay must forward the FIN to the remote (CloseWrite) while the
+	// remote->application direction stays alive.
+	if _, err := app.Write([]byte("hello")); err != nil {
+		t.Fatalf("app write: %v", err)
+	}
+	if err := app.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("app CloseWrite: %v", err)
+	}
+
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(remote, buf); err != nil {
+		t.Fatalf("remote read payload: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Fatalf("remote got %q, want %q", buf, "hello")
+	}
+	// The application FIN must have reached the remote: next read is EOF.
+	if _, err := remote.Read(buf); err != io.EOF {
+		t.Fatalf("remote read after app FIN = %v, want io.EOF", err)
+	}
+
+	// The remote answers and half-closes; the relay must deliver the
+	// payload and the FIN back to the application.
+	if _, err := remote.Write([]byte("world")); err != nil {
+		t.Fatalf("remote write: %v", err)
+	}
+	if err := remote.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("remote CloseWrite: %v", err)
+	}
+	if _, err := io.ReadFull(app, buf); err != nil {
+		t.Fatalf("app read payload: %v", err)
+	}
+	if string(buf) != "world" {
+		t.Fatalf("app got %q, want %q", buf, "world")
+	}
+	// The remote FIN must have reached the application.
+	if _, err := app.Read(buf); err != io.EOF {
+		t.Fatalf("app read after remote FIN = %v, want io.EOF", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relay did not return after both directions completed")
+	}
+	// The relay closed both proxy-side sockets; the app/remote ends saw
+	// their FINs above and are now fully closed too.
+	if !connClosed(t, app) {
+		t.Error("app connection still open after relay completed")
+	}
+	if !connClosed(t, remote) {
+		t.Error("remote connection still open after relay completed")
+	}
+}

--- a/client/proxy/direct_udp_test.go
+++ b/client/proxy/direct_udp_test.go
@@ -41,7 +41,7 @@ func (d *recordingDialer) dialed() []net.Conn {
 func newDirectUDPTestServer(t *testing.T, dial func(context.Context, string, string) (net.Conn, error)) *Socks5Server {
 	t.Helper()
 	h := newTestStreamHandler(&mockTransport{})
-	srv, err := NewSocks5Server("127.0.0.1:0", "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, 0, dial)
+	srv, err := NewSocks5Server("127.0.0.1:0", "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, 0, 0, dial)
 	if err != nil {
 		t.Fatalf("NewSocks5Server: %v", err)
 	}

--- a/client/proxy/http_proxy.go
+++ b/client/proxy/http_proxy.go
@@ -75,7 +75,7 @@ func NewHTTPProxyServer(listenAddr, socksAddr, username, password string, timeou
 		return nil, fmt.Errorf("http proxy requires a local socks5 address")
 	}
 	if timeout <= 0 {
-		timeout = 30 * time.Second
+		timeout = time.Duration(config.DefaultTimeout) * time.Second
 	}
 	if dial == nil {
 		dial = defaultDirectDialContext
@@ -363,7 +363,7 @@ func (s *HTTPProxyServer) handleConnect(w http.ResponseWriter, r *http.Request) 
 		if err := writeConnectEstablished(hijConn, target); err != nil {
 			return
 		}
-		relayTCP(remote, hijConn)
+		relayTCP(remote, hijConn, config.StreamIdleTimeout(s.timeout))
 		return
 	}
 
@@ -378,7 +378,7 @@ func (s *HTTPProxyServer) handleConnect(w http.ResponseWriter, r *http.Request) 
 		if err := writeConnectEstablished(hijConn, target); err != nil {
 			return
 		}
-		relayTCP(remote, hijConn)
+		relayTCP(remote, hijConn, config.StreamIdleTimeout(s.timeout))
 		return
 	}
 

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -34,6 +34,10 @@ type Socks5Server struct {
 	disableQUIC       bool
 	directDialContext func(context.Context, string, string) (net.Conn, error)
 	dialTimeout       time.Duration
+	// streamIdleTimeout bounds idle direct-TCP relays; derived from the
+	// user-configured base timeout via config.StreamIdleTimeout so the
+	// direct path matches the proxied path's stream idle timeout.
+	streamIdleTimeout time.Duration
 
 	udpMu   sync.RWMutex
 	udpExch map[string]*UDPExchange
@@ -67,12 +71,15 @@ type directUDPConn struct {
 	lastSeen atomic.Int64 // UnixNano, refreshed on every datagram written
 }
 
-func NewSocks5Server(listenAddr, username, password string, handler *StreamHandler, rt *router.Router, serverDomain string, method protocol.Method, disableQUIC bool, dialTimeout, udpIdleTimeout, dnsRespTimeout time.Duration, directDialContext func(context.Context, string, string) (net.Conn, error)) (*Socks5Server, error) {
+func NewSocks5Server(listenAddr, username, password string, handler *StreamHandler, rt *router.Router, serverDomain string, method protocol.Method, disableQUIC bool, dialTimeout, udpIdleTimeout, dnsRespTimeout, streamIdleTimeout time.Duration, directDialContext func(context.Context, string, string) (net.Conn, error)) (*Socks5Server, error) {
 	if dialTimeout <= 0 {
 		dialTimeout = config.DefaultDialTimeout
 	}
 	if udpIdleTimeout <= 0 {
 		udpIdleTimeout = config.DefaultUDPIdleTimeout
+	}
+	if streamIdleTimeout <= 0 {
+		streamIdleTimeout = config.DefaultStreamIdleTimeout
 	}
 	if directDialContext == nil {
 		directDialContext = defaultDirectDialContext
@@ -89,6 +96,7 @@ func NewSocks5Server(listenAddr, username, password string, handler *StreamHandl
 		disableQUIC:       disableQUIC,
 		directDialContext: directDialContext,
 		dialTimeout:       dialTimeout,
+		streamIdleTimeout: streamIdleTimeout,
 		udpExch:           make(map[string]*UDPExchange),
 		directUDP:         make(map[string]*directUDPConn),
 		quit:              make(chan struct{}),
@@ -274,7 +282,7 @@ func (s *Socks5Server) TCPHandle(srv *socks5.Server, c *net.TCPConn, r *socks5.R
 			return err
 		}
 		defer rc.Close() //nolint:errcheck
-		relayTCP(rc, c)
+		relayTCP(rc, c, s.streamIdleTimeout)
 		log.Debug("[TCP_DIRECT] relay finished", "target", target)
 		return nil
 	case router.HostRuleProxy:
@@ -351,20 +359,18 @@ func (s *Socks5Server) replyError(c net.Conn, r *socks5.Request, rep byte) error
 	return err
 }
 
-// directRelayIdleTimeout bounds how long a direct TCP relay may sit idle
-// before both connections are torn down. The proxied path enforces its own
-// idle timeout via relay.Bidirectional (StreamHandler.streamIdleTimeout);
-// the direct path previously had no deadline at all, so a silent or
-// half-open peer left the two copy goroutines and their sockets leaked
-// forever. It mirrors the stream idle timeout (10 x the user timeout).
-const directRelayIdleTimeout = config.DefaultStreamIdleTimeout
-
 // relayTCP copies bytes in both directions between dst and src with a shared
 // idle timeout, mirroring the proxied path's relay semantics: on clean EOF a
 // half-close is propagated, and on idle timeout or error both connections
 // are closed exactly once.
-func relayTCP(dst, src net.Conn) {
-	result := relay.Bidirectional(directRelayIdleTimeout, func() {
+//
+// idleTimeout bounds how long the relay may sit idle before both connections
+// are torn down, so a silent or half-open peer cannot leave the two copy
+// goroutines and their sockets alive forever. The caller derives it from the
+// user-configured base timeout (config.StreamIdleTimeout), keeping the direct
+// path consistent with the proxied path's stream idle timeout.
+func relayTCP(dst, src net.Conn, idleTimeout time.Duration) {
+	result := relay.Bidirectional(idleTimeout, func() {
 		_ = dst.Close()
 		_ = src.Close()
 	},

--- a/client/proxy/udp_timeout_test.go
+++ b/client/proxy/udp_timeout_test.go
@@ -58,7 +58,7 @@ const testDNSRespTimeout = 200 * time.Millisecond
 func newTimeoutTestServer(t *testing.T, streams []transport.Stream) *Socks5Server {
 	t.Helper()
 	h := newTestStreamHandler(&mockTransport{streams: streams})
-	srv, err := NewSocks5Server("127.0.0.1:0", "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, testDNSRespTimeout, nil)
+	srv, err := NewSocks5Server("127.0.0.1:0", "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, testDNSRespTimeout, 0, nil)
 	if err != nil {
 		t.Fatalf("NewSocks5Server: %v", err)
 	}

--- a/cmd/easyss/easyss_test.go
+++ b/cmd/easyss/easyss_test.go
@@ -320,7 +320,7 @@ func newTestHarness(t *testing.T) *testHarness {
 
 	// Start SOCKS5 proxy
 	socksAddr := testServerAddr + ":" + strconv.Itoa(testSocks5Port)
-	socksServer, err := proxy.NewSocks5Server(socksAddr, "", "", handler, cli.Router(), "", method, true, dialTimeout, udpIdleTimeout, timeout/3, cli.DialContext)
+	socksServer, err := proxy.NewSocks5Server(socksAddr, "", "", handler, cli.Router(), "", method, true, dialTimeout, udpIdleTimeout, timeout/3, streamIdleTimeout, cli.DialContext)
 	require.NoError(t, err)
 	h.socksServer = socksServer
 

--- a/config/timeouts.go
+++ b/config/timeouts.go
@@ -13,9 +13,12 @@ import "time"
 // value (default 30s, see DefaultTimeout).
 
 // StreamIdleTimeout returns the TCP stream idle timeout derived from the
-// user-configured base timeout (10 x base; default 30s -> 300s).
+// user-configured base timeout (4 x base; default 30s -> 120s). The
+// multiplier bounds how long a stream may sit completely silent before the
+// relay tears it down: generous enough to survive slow, idle connections
+// (SSH, long-polling) while still reaping half-open or dead peers.
 func StreamIdleTimeout(base time.Duration) time.Duration {
-	return 10 * base
+	return 4 * base
 }
 
 // UDPIdleTimeout returns the UDP session idle/read timeout (2 x base;

--- a/config/timeouts_test.go
+++ b/config/timeouts_test.go
@@ -24,10 +24,10 @@ func TestStreamIdleTimeout(t *testing.T) {
 		timeout time.Duration
 		want    time.Duration
 	}{
-		{"默认值 30s", 30 * time.Second, 300 * time.Second},
+		{"默认值 30s", 30 * time.Second, 120 * time.Second},
 		{"0s", 0, 0},
-		{"小值 5s", 5 * time.Second, 50 * time.Second},
-		{"大值 120s", 120 * time.Second, 20 * time.Minute},
+		{"小值 5s", 5 * time.Second, 20 * time.Second},
+		{"大值 120s", 120 * time.Second, 8 * time.Minute},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config/timeouts_test.go
+++ b/config/timeouts_test.go
@@ -5,6 +5,19 @@ import (
 	"time"
 )
 
+// TestDefaultStreamIdleTimeoutDerived guards the single-source-of-truth
+// constraint: the fallback default must always equal the formula evaluated
+// at the default base timeout, never a second magic number.
+func TestDefaultStreamIdleTimeoutDerived(t *testing.T) {
+	want := StreamIdleTimeout(time.Duration(DefaultTimeout) * time.Second)
+	if DefaultStreamIdleTimeout != want {
+		t.Errorf("DefaultStreamIdleTimeout = %v, want StreamIdleTimeout(DefaultTimeout) = %v", DefaultStreamIdleTimeout, want)
+	}
+	if DefaultStreamIdleTimeout <= 0 {
+		t.Fatalf("DefaultStreamIdleTimeout must be positive, got %v", DefaultStreamIdleTimeout)
+	}
+}
+
 func TestStreamIdleTimeout(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/config/types.go
+++ b/config/types.go
@@ -43,7 +43,7 @@ const (
 	// client closes it early (see relay.BidirectionalWithDrain). Lingering
 	// keep-alive and half-closed streams otherwise pin the slot's active
 	// count and postpone rotation/retirement until the full relay idle
-	// timeout (10 x DefaultTimeout = 300s). 30s of total silence means the
+	// timeout (4 x DefaultTimeout = 120s). 30s of total silence means the
 	// stream is effectively dead — normal transfers cannot pause that long,
 	// and cover/padding traffic is not counted as activity by the relay —
 	// so closing it interrupts nothing. Active streams (data flowing) are
@@ -159,8 +159,8 @@ const (
 
 // DefaultStreamIdleTimeout is the fallback TCP stream idle timeout used by
 // constructors when no explicit value is provided (<= 0). It is derived from
-// the default base timeout through config.StreamIdleTimeout (10 x
-// DefaultTimeout = 300s) so the formula in timeouts.go stays the single
+// the default base timeout through config.StreamIdleTimeout (4 x
+// DefaultTimeout = 120s) so the formula in timeouts.go stays the single
 // source of truth: normal paths derive their timeout from the user-configured
 // base and never read this variable.
 var DefaultStreamIdleTimeout = StreamIdleTimeout(time.Duration(DefaultTimeout) * time.Second)

--- a/config/types.go
+++ b/config/types.go
@@ -51,12 +51,10 @@ const (
 	ExpiringStreamDrainIdle = 30 * time.Second
 
 	// Fallback timeouts used by the server-side constructors when no
-	// explicit value is provided. DefaultStreamIdleTimeout mirrors the
-	// server's derivation (10 x DefaultTimeout = 300s); the others are
-	// defensive defaults for the handler/nextproxy entry points.
-	DefaultStreamIdleTimeout = 300 * time.Second // TCP 流空闲超时兜底（= 10 × DefaultTimeout）
-	DefaultUDPIdleTimeout    = 30 * time.Second  // UDP 关联空闲超时兜底
-	DefaultDialTimeout       = 10 * time.Second  // 出口拨号超时兜底（= DefaultTimeout/3）
+	// explicit value is provided. The others are defensive defaults for
+	// the handler/nextproxy entry points.
+	DefaultUDPIdleTimeout = 30 * time.Second // UDP 关联空闲超时兜底
+	DefaultDialTimeout    = 10 * time.Second // 出口拨号超时兜底（= DefaultTimeout/3）
 
 	// Defaults shared by config builders, the example config and runtime
 	// fallbacks. Keep these as the single source of truth: any code that
@@ -158,3 +156,11 @@ const (
 	DefaultTunDeviceName       = "tun-easyss"
 	DefaultTunDeviceNameDarwin = "utun9"
 )
+
+// DefaultStreamIdleTimeout is the fallback TCP stream idle timeout used by
+// constructors when no explicit value is provided (<= 0). It is derived from
+// the default base timeout through config.StreamIdleTimeout (10 x
+// DefaultTimeout = 300s) so the formula in timeouts.go stays the single
+// source of truth: normal paths derive their timeout from the user-configured
+// base and never read this variable.
+var DefaultStreamIdleTimeout = StreamIdleTimeout(time.Duration(DefaultTimeout) * time.Second)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -103,7 +103,7 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 			serverDomain = svr.Address
 		}
 		socksServer, err := proxy.NewSocks5Server(socksAddr, cfg.AuthUsername, cfg.AuthPassword,
-			streamHandler, cli.Router(), serverDomain, method, !cfg.Local.EnableQUIC, dialTimeout, udpIdleTimeout, timeout/3, cli.DialContext)
+			streamHandler, cli.Router(), serverDomain, method, !cfg.Local.EnableQUIC, dialTimeout, udpIdleTimeout, timeout/3, streamIdleTimeout, cli.DialContext)
 		if err != nil {
 			_ = cli.Close()
 			return nil, err


### PR DESCRIPTION
﻿## 背景

此前存在两处不一致：

1. `config.DefaultStreamIdleTimeout`（硬编码 300s）与 `config.StreamIdleTimeout(base)`（10 × base 派生公式）是两份独立定义，仅靠注释维持同步，存在漂移风险。
2. 客户端**直连 TCP** 路径（SOCKS5 CONNECT direct / HTTP CONNECT direct）固定使用 `DefaultStreamIdleTimeout`（300s），不跟随用户配置的 base timeout——当用户配置 `timeout=60s` 时，代理路径与服务端的流空闲超时为 600s，而直连路径仍是 300s，行为不一致。
3. 默认流空闲超时 `StreamIdleTimeout` 采用 10 × base（默认 300s）偏大，半开/死连接需等 5 分钟才被回收。

## 改动

### 统一超时来源 + 直连 TCP 跟随用户配置

- `config/types.go`：`DefaultStreamIdleTimeout` 由常量改为 `var`，从 `StreamIdleTimeout(DefaultTimeout)` 公式导出，`timeouts.go` 成为唯一事实来源。
- `client/proxy/socks5.go`：删除 `directRelayIdleTimeout` 常量；`Socks5Server` 新增 `streamIdleTimeout` 字段；`NewSocks5Server` 新增对应参数（≤0 时兜底 `DefaultStreamIdleTimeout`）；`relayTCP` 新增 `idleTimeout` 参数。
- `client/proxy/http_proxy.go`：CONNECT direct 两处 `relayTCP` 改为 `config.StreamIdleTimeout(s.timeout)` 派生；base 兜底 `30 * time.Second` 统一引用 `config.DefaultTimeout`。
- `runner/runner.go`：`NewSocks5Server` 传入已派生的 `streamIdleTimeout`（与代理路径同源）。

### 默认流空闲超时 10× → 4×

- `config/timeouts.go`：`StreamIdleTimeout(base)` 由 `10 * base` 改为 `4 * base`（默认 30s → 120s），同步更新注释。
- `config/types.go`：相关注释中的数值（300s → 120s）同步更新；`DefaultStreamIdleTimeout` 由公式导出，自动跟随。
- `config/timeouts_test.go`：`TestStreamIdleTimeout` 期望值更新。

## 测试

- `config/timeouts_test.go`：新增 `TestDefaultStreamIdleTimeoutDerived`，守护"默认值恒等于公式在默认 base 下的结果"约束；更新 `TestStreamIdleTimeout` 期望值。
- `client/proxy/direct_relay_test.go`（新增）：
  - `TestRelayTCPIdleTimeoutClosesBoth`：验证 idle 超时后两端连接均被关闭（copy goroutine 不会悬挂）。
  - `TestRelayTCPHalfCloseAndCompletion`：用两对 TCP（应用↔代理、代理↔远端）忠实模拟生产拓扑，验证 FIN 双向传播（CloseWrite half-close）、relay 完成后所有连接关闭。
- 更新 4 处 `NewSocks5Server` 调用（含测试）。

## 行为变化

- 默认配置（30s）下：流空闲超时由 300s 变为 **120s**；直连 TCP 与该值一致。
- 用户配置 timeout ≠ 30s 时：所有路径（代理、直连、服务端）随 base 按 4 × 统一缩放。

## 验证

- `go build ./...`、`go vet`、`go test ./...`（全仓）通过
- 新测试 `-count=5` 重复运行稳定
- `make lint`：0 issues
