### PR TITLE
chore: derive remaining fallback timeouts from shared formulas

### DIFF
--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/pprof"
+	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/server"
 	"github.com/nange/easyss/v3/server/config"
 	"github.com/nange/easyss/v3/util"
@@ -139,7 +140,7 @@ func exampleV3ServerConfig() string {
 			Listen:               ":443",
 			Domain:               "your-domain.com",
 			Password:             "your-password",
-			AllowedMethods:       []string{"aes-256-gcm", "chacha20-poly1305"},
+			AllowedMethods:       []string{protocol.MethodAES256GCM.String(), protocol.MethodChaCha20Poly1305.String()},
 			CertPath:             "",
 			KeyPath:              "",
 			Email:                "your-email@example.com",

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -401,17 +401,17 @@ func exampleV3Config() string {
 func exampleSimpleConfig() string {
 	cfg := sharedconfig.SimpleConfig{
 		Server:        "your-domain.com",
-		ServerPort:    443,
+		ServerPort:    sharedconfig.DefaultServerPort,
 		Password:      "your-password",
-		Method:        "aes-256-gcm",
+		Method:        sharedconfig.DefaultMethod,
 		LocalPort:     sharedconfig.DefaultSocksPort,
-		ProxyRule:     "auto",
-		Timeout:       30,
+		ProxyRule:     sharedconfig.DefaultProxyRule,
+		Timeout:       sharedconfig.DefaultTimeout,
 		BindAll:       false,
 		OutboundProto: "native",
 		DirectFile:    "",
 		ProxyFile:     "",
-		LogLevel:      "info",
+		LogLevel:      sharedconfig.DefaultLogLevel,
 		LogFilePath:   "easyss.log",
 	}
 	b, _ := json.MarshalIndent(cfg, "", "  ")

--- a/config/timeouts_test.go
+++ b/config/timeouts_test.go
@@ -18,6 +18,31 @@ func TestDefaultStreamIdleTimeoutDerived(t *testing.T) {
 	}
 }
 
+// TestDefaultUDPIdleTimeoutDerived guards the same constraint for the UDP
+// fallback: it must equal UDPIdleTimeout(DefaultTimeout), so the fallback
+// never diverges from the derived value used on normal paths.
+func TestDefaultUDPIdleTimeoutDerived(t *testing.T) {
+	want := UDPIdleTimeout(time.Duration(DefaultTimeout) * time.Second)
+	if DefaultUDPIdleTimeout != want {
+		t.Errorf("DefaultUDPIdleTimeout = %v, want UDPIdleTimeout(DefaultTimeout) = %v", DefaultUDPIdleTimeout, want)
+	}
+	if DefaultUDPIdleTimeout <= 0 {
+		t.Fatalf("DefaultUDPIdleTimeout must be positive, got %v", DefaultUDPIdleTimeout)
+	}
+}
+
+// TestDefaultDialTimeoutDerived guards the same constraint for the dial
+// fallback: it must equal DialTimeout(DefaultTimeout).
+func TestDefaultDialTimeoutDerived(t *testing.T) {
+	want := DialTimeout(time.Duration(DefaultTimeout) * time.Second)
+	if DefaultDialTimeout != want {
+		t.Errorf("DefaultDialTimeout = %v, want DialTimeout(DefaultTimeout) = %v", DefaultDialTimeout, want)
+	}
+	if DefaultDialTimeout <= 0 {
+		t.Fatalf("DefaultDialTimeout must be positive, got %v", DefaultDialTimeout)
+	}
+}
+
 func TestStreamIdleTimeout(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/config/types.go
+++ b/config/types.go
@@ -50,12 +50,6 @@ const (
 	// never drained.
 	ExpiringStreamDrainIdle = 30 * time.Second
 
-	// Fallback timeouts used by the server-side constructors when no
-	// explicit value is provided. The others are defensive defaults for
-	// the handler/nextproxy entry points.
-	DefaultUDPIdleTimeout = 30 * time.Second // UDP 关联空闲超时兜底
-	DefaultDialTimeout    = 10 * time.Second // 出口拨号超时兜底（= DefaultTimeout/3）
-
 	// Defaults shared by config builders, the example config and runtime
 	// fallbacks. Keep these as the single source of truth: any code that
 	// applies a default must reference the constant, not a literal.
@@ -164,3 +158,16 @@ const (
 // source of truth: normal paths derive their timeout from the user-configured
 // base and never read this variable.
 var DefaultStreamIdleTimeout = StreamIdleTimeout(time.Duration(DefaultTimeout) * time.Second)
+
+// DefaultUDPIdleTimeout is the fallback UDP session idle/read timeout used by
+// constructors when no explicit value is provided (<= 0). Derived through
+// config.UDPIdleTimeout (2 x DefaultTimeout = 60s) so it always matches the
+// value normal paths derive from the user-configured base timeout.
+var DefaultUDPIdleTimeout = UDPIdleTimeout(time.Duration(DefaultTimeout) * time.Second)
+
+// DefaultDialTimeout is the fallback outbound dial timeout used by
+// constructors when no explicit value is provided (<= 0). Derived through
+// config.DialTimeout (DefaultTimeout/3 = 10s, clamped to [3s, 15s]) so it
+// always matches the value normal paths derive from the user-configured base
+// timeout.
+var DefaultDialTimeout = DialTimeout(time.Duration(DefaultTimeout) * time.Second)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "github.com/nange/easyss/v3/util"
+import (
+	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/util"
+)
 
 type LogConfig struct {
 	Level    string `json:"level"`
@@ -68,7 +71,7 @@ func (fc *FileConfig) ResolveFilePaths() {
 
 func (c *ServerConfig) GetAllowedMethods() []string {
 	if len(c.AllowedMethods) == 0 {
-		return []string{"aes-256-gcm", "chacha20-poly1305"}
+		return []string{protocol.MethodAES256GCM.String(), protocol.MethodChaCha20Poly1305.String()}
 	}
 	return c.AllowedMethods
 }

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -103,7 +103,7 @@ func NewProxyHandler(cfg ProxyHandlerConfig) *ProxyHandler {
 		nextProxy:        cfg.NextProxy,
 		tcpHandler:       NewTCPHandler(cfg.StreamIdleTimeout, cfg.Timeout, cfg.NextProxy),
 		udpHandler:       NewUDPHandler(cfg.UDPIdleTimeout, cfg.NextProxy),
-		icmpHandler:      NewICMPHandler(),
+		icmpHandler:      NewICMPHandler(cfg.Timeout),
 		saltCache:        newSaltCache(),
 		ipLimiter:        newIPRateLimiter(),
 	}

--- a/server/handler/helpers_test.go
+++ b/server/handler/helpers_test.go
@@ -172,8 +172,11 @@ func TestNewUDPHandler(t *testing.T) {
 }
 
 func TestNewICMPHandler(t *testing.T) {
-	h := NewICMPHandler()
+	h := NewICMPHandler(30 * time.Second)
 	if h == nil {
 		t.Fatal("NewICMPHandler returned nil")
+	}
+	if h.dialTimeout != 10*time.Second {
+		t.Errorf("dialTimeout = %v, want 10s (DialTimeout(30s))", h.dialTimeout)
 	}
 }

--- a/server/handler/icmp.go
+++ b/server/handler/icmp.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/crypto"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/protocol"
@@ -20,10 +21,18 @@ import (
 )
 
 type ICMPHandler struct {
+	dialTimeout time.Duration
 }
 
-func NewICMPHandler() *ICMPHandler {
-	return &ICMPHandler{}
+// NewICMPHandler creates an ICMPHandler. The outbound ICMP dial timeout is
+// derived through config.DialTimeout (base/3 clamped to [3s, 15s]), shared
+// with the TCP/UDP handlers' dials.
+func NewICMPHandler(timeout time.Duration) *ICMPHandler {
+	dialTimeout := config.DialTimeout(timeout)
+	if timeout <= 0 {
+		dialTimeout = config.DefaultDialTimeout
+	}
+	return &ICMPHandler{dialTimeout: dialTimeout}
 }
 
 func (h *ICMPHandler) Handle(dr *crypto.DecryptedReader, s2c shaper.Shaper, target string) error {
@@ -72,7 +81,7 @@ func (h *ICMPHandler) icmpExchange(target string, payload []byte) ([]byte, error
 		parseProto = 58
 	}
 
-	conn, err := net.DialTimeout(dialNet, target, 5*time.Second)
+	conn, err := net.DialTimeout(dialNet, target, h.dialTimeout)
 	if err != nil {
 		log.Error("[ICMP] dial target failed", "target", target, "err", err)
 		return nil, err

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -98,7 +98,7 @@ func New(cfg Config) (*HTTP2Transport, error) {
 
 	timeout := cfg.Timeout
 	if timeout <= 0 {
-		timeout = 30 * time.Second
+		timeout = time.Duration(sharedconfig.DefaultTimeout) * time.Second
 	}
 
 	dialCtx := cfg.DialContext


### PR DESCRIPTION
﻿## 背景

继 #127 统一 `DefaultStreamIdleTimeout` 与 `StreamIdleTimeout(base)` 公式后，审查发现其余兜底常量与派生公式存在同类问题：

1. **冲突**：`DefaultUDPIdleTimeout = 30s` 与公式 `UDPIdleTimeout(30s) = 60s` 不一致——正常路径（runner/server）走公式得到 60s，而构造兜底路径（`NewSocks5Server`、`NewUDPHandler`）用常量得到 30s。
2. **潜在漂移**：`DefaultDialTimeout = 10s` 当前恰好等于 `DialTimeout(30s) = 10s`，但为独立字面量，公式调整会漂移。
3. **魔法数字**：`transport/http2` 的兜底 `30 * time.Second`、ICMP 出站拨号硬编码 `5 * time.Second`（TCP/UDP 拨号走 `DialTimeout` 默认 10s，同类操作不一致）。
4. **字符串重复**：加密方法名 `"aes-256-gcm"`/`"chacha20-poly1305"` 在 `server/config`、两个 main 中硬编码，而 `protocol` 包已有枚举与 `.String()`。

## 改动

- `config/types.go`：`DefaultUDPIdleTimeout`、`DefaultDialTimeout` 由 const 改为 `var`，分别从 `UDPIdleTimeout`/`DialTimeout` 在默认 base 下导出（60s / 10s），与正常路径对齐。
- `config/timeouts_test.go`：新增 `TestDefaultUDPIdleTimeoutDerived`、`TestDefaultDialTimeoutDerived`，守护"兜底值 == 公式(DefaultTimeout)"约束。
- `transport/http2/client.go`：兜底 `30 * time.Second` 改为 `time.Duration(DefaultTimeout) * time.Second`。
- `server/handler/icmp.go` + `handler.go`：`ICMPHandler` 新增 `dialTimeout` 字段，`NewICMPHandler(timeout)` 通过 `config.DialTimeout(timeout)` 派生（≤0 兜底 `DefaultDialTimeout`），替换硬编码 5s。
- `server/config/config.go`、`cmd/easyss-server/main.go`：方法名改 `protocol.MethodAES256GCM.String()` 等枚举引用。
- `cmd/easyss/main.go`：example 配置字面量改 `sharedconfig.DefaultMethod`/`DefaultTimeout`/`DefaultServerPort`/`DefaultProxyRule`/`DefaultLogLevel`。

## 行为变化

- UDP idle 兜底值 30s → 60s（与正常派生路径一致，仅影响"调用方未传值"场景）。
- ICMP 拨号超时 5s → 10s（跟随 base，与 TCP/UDP 拨号统一）。
- 默认配置下其余数值不变。

## 验证

- `go build ./...`、`go vet ./...` 通过
- `go test ./...`（全仓）通过
- `make lint`：0 issues
