### PR TITLE
refactor: restructure server config into nested blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
   },
   "transport": {
     "protocols": ["h2"],
-    "http2_max_frame_size": 0,
-    "http2_recv_buf_conn": 0,
-    "http2_recv_buf_stream": 0,
+    "http2_max_frame_size": 16777215,
+    "http2_recv_buf_conn": 4194304,
+    "http2_recv_buf_stream": 1048576,
     "max_concurrent_streams": 0
   },
   "next_proxy": {
@@ -363,9 +363,9 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
 | `shaper.cover_budget_ratio` | 否 | 0.03 | cover traffic 占真实流量的预算比例，设为 0 或负数使用默认值，范围 (0, 1] |
 | `shaper.cover_budget_cap` | 否 | 16384 | cover traffic 最大累积预算，单位字节，默认 16KB |
 | `transport.protocols` | 否 | h2 | 支持的传输协议列表，目前仅支持 `h2`，配置其他值启动时报错；未来可同时启用多个（如 h2 + h3） |
-| `transport.http2_max_frame_size` | 否 | 16MB-1 | 服务端 HTTP/2 最大帧大小，0 使用默认值 |
-| `transport.http2_recv_buf_conn` | 否 | 4MB | 服务端连接级上行窗口，0 使用默认值 |
-| `transport.http2_recv_buf_stream` | 否 | 1MB | 服务端流级上行窗口，0 使用默认值 |
+| `transport.http2_max_frame_size` | 否 | 16777215 | 服务端 HTTP/2 最大帧大小（16MB-1），0 使用默认值 |
+| `transport.http2_recv_buf_conn` | 否 | 4194304 | 服务端连接级上行窗口（4MB），0 使用默认值 |
+| `transport.http2_recv_buf_stream` | 否 | 1048576 | 服务端流级上行窗口（1MB），0 使用默认值 |
 | `transport.max_concurrent_streams` | 否 | 无限制 | 服务端单连接最大并发流数，0 使用 Go 默认（无限制） |
 | `pprof_enabled` | 否 | false | 是否启用 pprof 调试服务（127.0.0.1:6060） |
 | `timeout` | 否 | 30 | 超时时间，单位秒 |

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
     "cover_budget_cap": 16384
   },
   "transport": {
-    "protocol": "h2",
+    "protocols": ["h2"],
     "http2_max_frame_size": 0,
     "http2_recv_buf_conn": 0,
     "http2_recv_buf_stream": 0,
@@ -362,7 +362,7 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
 | `shaper.batch_window_ms` | 否 | 3 | 流量整形批处理窗口，单位毫秒，范围 1-10 |
 | `shaper.cover_budget_ratio` | 否 | 0.03 | cover traffic 占真实流量的预算比例，设为 0 或负数使用默认值，范围 (0, 1] |
 | `shaper.cover_budget_cap` | 否 | 16384 | cover traffic 最大累积预算，单位字节，默认 16KB |
-| `transport.protocol` | 否 | h2 | 传输协议（目前仅支持 h2，配置其他值启动时报错） |
+| `transport.protocols` | 否 | h2 | 支持的传输协议列表，目前仅支持 `h2`，配置其他值启动时报错；未来可同时启用多个（如 h2 + h3） |
 | `transport.http2_max_frame_size` | 否 | 16MB-1 | 服务端 HTTP/2 最大帧大小，0 使用默认值 |
 | `transport.http2_recv_buf_conn` | 否 | 4MB | 服务端连接级上行窗口，0 使用默认值 |
 | `transport.http2_recv_buf_stream` | 否 | 1MB | 服务端流级上行窗口，0 使用默认值 |

--- a/README.md
+++ b/README.md
@@ -325,8 +325,7 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
     "protocols": ["h2"],
     "http2_max_frame_size": 16777215,
     "http2_recv_buf_conn": 4194304,
-    "http2_recv_buf_stream": 1048576,
-    "max_concurrent_streams": 0
+    "http2_recv_buf_stream": 1048576
   },
   "next_proxy": {
       "url": "",
@@ -366,7 +365,6 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
 | `transport.http2_max_frame_size` | 否 | 16777215 | 服务端 HTTP/2 最大帧大小（16MB-1），0 使用默认值 |
 | `transport.http2_recv_buf_conn` | 否 | 4194304 | 服务端连接级上行窗口（4MB），0 使用默认值 |
 | `transport.http2_recv_buf_stream` | 否 | 1048576 | 服务端流级上行窗口（1MB），0 使用默认值 |
-| `transport.max_concurrent_streams` | 否 | 无限制 | 服务端单连接最大并发流数，0 使用 Go 默认（无限制） |
 | `pprof_enabled` | 否 | false | 是否启用 pprof 调试服务（127.0.0.1:6060） |
 | `timeout` | 否 | 30 | 超时时间，单位秒 |
 

--- a/README.md
+++ b/README.md
@@ -309,21 +309,24 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
     "allowed_methods": ["aes-256-gcm", "chacha20-poly1305"],
     "cert_path": "",
     "key_path": "",
-    "email": "",
-    "fallback_target": "",
-    "fallback_preserve_host": false,
-    "fallback_cdn_domains": [],
+    "email": ""
+  },
+  "fallback": {
+    "target": "",
+    "preserve_host": false,
+    "cdn_domains": []
+  },
+  "shaper": {
     "batch_window_ms": 3,
     "cover_budget_ratio": 0.03,
-    "cover_budget_cap": 16384,
-    "pprof_enabled": false
-  },
-  "log": {
-      "level": "info",
-      "file_path": "easyss.log"
+    "cover_budget_cap": 16384
   },
   "transport": {
-      "protocol": "h2"
+    "protocol": "h2",
+    "http2_max_frame_size": 0,
+    "http2_recv_buf_conn": 0,
+    "http2_recv_buf_stream": 0,
+    "max_concurrent_streams": 0
   },
   "next_proxy": {
       "url": "",
@@ -331,6 +334,11 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
       "enable_udp": false,
       "all_host": false
   },
+  "log": {
+      "level": "info",
+      "file_path": "easyss.log"
+  },
+  "pprof_enabled": false,
   "timeout": 30
 }
 ```
@@ -348,42 +356,50 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
 | `server.cert_path` | 否 | - | 自定义证书文件路径（不为空则使用自定义证书） |
 | `server.key_path` | 否 | - | 自定义证书密钥文件路径 |
 | `server.email` | 否 | 随机生成 | 用于自动获取证书的邮箱地址 |
-| `server.fallback_target` | 否 | - | 回落目标，自动识别类型：<br>**空**: 使用内置主题页面<br>**URL** (`http://`或`https://`开头): 反向代理到上游 HTTP 服务<br>**目录**: 根据 URL path 匹配 HTML 文件（如 `/about` → `about.html`）<br>**文件**: 所有路径返回同一 HTML 页面 |
-| `server.fallback_preserve_host` | 否 | false | 仅对 `fallback_target` 为 URL 生效。<br>**false**: 转发给上游的 Host 头设为上游主机（默认，适合 GitHub 等会校验 Host 的公网站点）<br>**true**: 透传客户端原始 Host 给上游（适合本地 nginx 依赖 `server_name` 做虚拟主机路由的场景） |
-| `server.fallback_cdn_domains` | 否 | [] | 仅对 `fallback_target` 为 URL 生效。<br>配置需要通过代理中转的 CDN 域名列表（如 `["github.githubassets.com"]`）。HTML 和 CSP 中引用这些域名的绝对 URL 会被重写为 `/__cdn__/<host>/...` 路径前缀形式，浏览器请求时走代理转发到对应 CDN，避免直连 CDN 暴露真实 IP 或被 CSP 拦截 |
-| `server.batch_window_ms` | 否 | 3 | 流量整形批处理窗口，单位毫秒，范围 1-10 |
-| `server.cover_budget_ratio` | 否 | 0.03 | cover traffic 占真实流量的预算比例，设为 0 或负数使用默认值，范围 (0, 1] |
-| `server.cover_budget_cap` | 否 | 16384 | cover traffic 最大累积预算，单位字节，默认 16KB |
-| `server.pprof_enabled` | 否 | false | 是否启用 pprof 调试服务（127.0.0.1:6060） |
-| `transport.protocol` | 否 | h2 | 传输协议（目前仅支持 h2） |
+| `fallback.target` | 否 | - | 回落目标，自动识别类型：<br>**空**: 使用内置主题页面<br>**URL** (`http://`或`https://`开头): 反向代理到上游 HTTP 服务<br>**目录**: 根据 URL path 匹配 HTML 文件（如 `/about` → `about.html`）<br>**文件**: 所有路径返回同一 HTML 页面 |
+| `fallback.preserve_host` | 否 | false | 仅对 `fallback.target` 为 URL 生效。<br>**false**: 转发给上游的 Host 头设为上游主机（默认，适合 GitHub 等会校验 Host 的公网站点）<br>**true**: 透传客户端原始 Host 给上游（适合本地 nginx 依赖 `server_name` 做虚拟主机路由的场景） |
+| `fallback.cdn_domains` | 否 | [] | 仅对 `fallback.target` 为 URL 生效。<br>配置需要通过代理中转的 CDN 域名列表（如 `["github.githubassets.com"]`）。HTML 和 CSP 中引用这些域名的绝对 URL 会被重写为 `/__cdn__/<host>/...` 路径前缀形式，浏览器请求时走代理转发到对应 CDN，避免直连 CDN 暴露真实 IP 或被 CSP 拦截 |
+| `shaper.batch_window_ms` | 否 | 3 | 流量整形批处理窗口，单位毫秒，范围 1-10 |
+| `shaper.cover_budget_ratio` | 否 | 0.03 | cover traffic 占真实流量的预算比例，设为 0 或负数使用默认值，范围 (0, 1] |
+| `shaper.cover_budget_cap` | 否 | 16384 | cover traffic 最大累积预算，单位字节，默认 16KB |
+| `transport.protocol` | 否 | h2 | 传输协议（目前仅支持 h2，配置其他值启动时报错） |
+| `transport.http2_max_frame_size` | 否 | 16MB-1 | 服务端 HTTP/2 最大帧大小，0 使用默认值 |
+| `transport.http2_recv_buf_conn` | 否 | 4MB | 服务端连接级上行窗口，0 使用默认值 |
+| `transport.http2_recv_buf_stream` | 否 | 1MB | 服务端流级上行窗口，0 使用默认值 |
+| `transport.max_concurrent_streams` | 否 | 无限制 | 服务端单连接最大并发流数，0 使用 Go 默认（无限制） |
+| `pprof_enabled` | 否 | false | 是否启用 pprof 调试服务（127.0.0.1:6060） |
 | `timeout` | 否 | 30 | 超时时间，单位秒 |
 
-> **fallback_target 使用示例**：
+> **fallback 使用示例**：
 >
 > ```json
 > // 1. 空值 → 内置主题页面（默认）
-> "fallback_target": ""
+> "fallback": { "target": "" }
 >
 > // 2. 反向代理到本地 nginx（透传原始 Host，匹配 server_name 路由）
-> "fallback_target": "http://127.0.0.1:8080",
-> "fallback_preserve_host": true
+> "fallback": {
+>   "target": "http://127.0.0.1:8080",
+>   "preserve_host": true
+> }
 >
 > // 3. 反向代理到公网站点（如 GitHub）
 > //    自动重写 Host 头避免 301，并重写 HTML 中的绝对 URL，
 > //    修复 release assets 等动态加载的 CSP 问题
 > //    配置 CDN 域名让静态资源也走代理
-> "fallback_target": "https://github.com",
-> "fallback_cdn_domains": ["githubassets.com", "githubusercontent.com"]
-> // fallback_preserve_host 默认 false 即可
+> "fallback": {
+>   "target": "https://github.com",
+>   "cdn_domains": ["githubassets.com", "githubusercontent.com"]
+> }
+> // preserve_host 默认 false 即可
 >
 > // 4. 单文件 → 所有路径返回同一页面
-> "fallback_target": "/var/www/fallback.html"
+> "fallback": { "target": "/var/www/fallback.html" }
 >
 > // 5. 目录 → 按 URL path 匹配 HTML 文件
-> "fallback_target": "/var/www/fallback/"
+> "fallback": { "target": "/var/www/fallback/" }
 > ```
 >
-> **URL 模式行为说明**：当 `fallback_target` 为 URL 时，反向代理会自动执行以下处理，无需额外配置：
+> **URL 模式行为说明**：当 `fallback.target` 为 URL 时，反向代理会自动执行以下处理，无需额外配置：
 >
 > * 设置上游 Host 头（避免 GitHub 等站点返回 301 到规范主机）
 > * 重写 3xx `Location` 响应头中指向上游的绝对 URL 为客户端面向地址
@@ -391,7 +407,7 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
 > * 重写 `Set-Cookie` 的 `Domain` 属性，使浏览器接受 cookie（修复 CSRF 422）
 > * 重写请求 `Origin`/`Referer` 头为上游地址（修复 CSRF 422）
 > * 对上游请求 `Accept-Encoding` 与客户端取交集，gzip 响应自动解压后重写、再按客户端能力重新压缩
-> * 配置了 `fallback_cdn_domains` 时，HTML/CSP 中引用这些 CDN 域名的 URL 被重写为 `/__cdn__/<host>/...`，浏览器请求经代理转发到对应 CDN
+> * 配置了 `fallback.cdn_domains` 时，HTML/CSP 中引用这些 CDN 域名的 URL 被重写为 `/__cdn__/<host>/...`，浏览器请求经代理转发到对应 CDN
 >
 > **目录模式**：目录结构如下（优先级: 反向代理 > 目录 > 单文件 > 内置主题）：
 >

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -157,11 +157,10 @@ func exampleV3ServerConfig() string {
 			CoverBudgetCap:   16 * 1024,
 		},
 		Transport: config.TransportConfig{
-			Protocols:           []string{"h2"},
-			HTTP2MaxFrameSize:   sharedconfig.HTTP2ServerMaxReadFrameSize,
-			HTTP2RecvBufConn:    sharedconfig.HTTP2ServerReceiveBufferPerConnection,
-			HTTP2RecvBufStream:  sharedconfig.HTTP2ServerReceiveBufferPerStream,
-			MaxConcurrentStream: 0,
+			Protocols:          []string{"h2"},
+			HTTP2MaxFrameSize:  sharedconfig.HTTP2ServerMaxReadFrameSize,
+			HTTP2RecvBufConn:   sharedconfig.HTTP2ServerReceiveBufferPerConnection,
+			HTTP2RecvBufStream: sharedconfig.HTTP2ServerReceiveBufferPerStream,
 		},
 		NextProxy: config.NextProxyConfig{
 			URL:           "",

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -141,9 +141,9 @@ func exampleV3ServerConfig() string {
 			Domain:         "your-domain.com",
 			Password:       "your-password",
 			AllowedMethods: []string{protocol.MethodAES256GCM.String(), protocol.MethodChaCha20Poly1305.String()},
-			CertPath:             "",
-			KeyPath:              "",
-			Email:                "",
+			CertPath:       "",
+			KeyPath:        "",
+			Email:          "",
 		},
 		Fallback: config.FallbackConfig{
 			Target:       "",

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -156,7 +156,7 @@ func exampleV3ServerConfig() string {
 			CoverBudgetCap:   16 * 1024,
 		},
 		Transport: config.TransportConfig{
-			Protocol: "h2",
+			Protocols: []string{"h2"},
 		},
 		NextProxy: config.NextProxyConfig{
 			URL:           "",

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -68,7 +68,7 @@ func main() {
 	fileCfg.ResolveFilePaths()
 	cfg = fileCfg.EffectiveServerConfig()
 	if pprofEnabled {
-		cfg.PprofEnabled = true
+		fileCfg.PprofEnabled = true
 	}
 	if fileCfg.Log.Level == "" {
 		fileCfg.Log.Level = "info"
@@ -94,7 +94,7 @@ func main() {
 	)
 
 	var pprofSrv *http.Server
-	if cfg.PprofEnabled {
+	if fileCfg.PprofEnabled {
 		pprofSrv = pprof.StartPprof()
 	}
 
@@ -137,20 +137,23 @@ func exampleV3ServerConfig() string {
 	cfg := config.FileConfig{
 		ConfigVersion: 3,
 		Server: config.ServerConfig{
-			Listen:               ":443",
-			Domain:               "your-domain.com",
-			Password:             "your-password",
-			AllowedMethods:       []string{protocol.MethodAES256GCM.String(), protocol.MethodChaCha20Poly1305.String()},
+			Listen:         ":443",
+			Domain:         "your-domain.com",
+			Password:       "your-password",
+			AllowedMethods: []string{protocol.MethodAES256GCM.String(), protocol.MethodChaCha20Poly1305.String()},
 			CertPath:             "",
 			KeyPath:              "",
-			Email:                "your-email@example.com",
-			FallbackTarget:       "",
-			FallbackPreserveHost: false,
-			FallbackCDNDomains:   []string{},
-			BatchWindowMS:        3,
-			CoverBudgetRatio:     0.03,
-			CoverBudgetCap:       16 * 1024,
-			PprofEnabled:         false,
+			Email:                "",
+		},
+		Fallback: config.FallbackConfig{
+			Target:       "",
+			PreserveHost: false,
+			CDNDomains:   []string{},
+		},
+		Shaper: config.ShaperConfig{
+			BatchWindowMS:    3,
+			CoverBudgetRatio: 0.03,
+			CoverBudgetCap:   16 * 1024,
 		},
 		Transport: config.TransportConfig{
 			Protocol: "h2",
@@ -165,7 +168,8 @@ func exampleV3ServerConfig() string {
 			Level:    "info",
 			FilePath: "easyss.log",
 		},
-		Timeout: 30,
+		PprofEnabled: false,
+		Timeout:      30,
 	}
 	b, _ := json.MarshalIndent(cfg, "", "  ")
 	return string(b)

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	_ "time/tzdata"
 
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/pprof"
 	"github.com/nange/easyss/v3/protocol"
@@ -156,7 +157,11 @@ func exampleV3ServerConfig() string {
 			CoverBudgetCap:   16 * 1024,
 		},
 		Transport: config.TransportConfig{
-			Protocols: []string{"h2"},
+			Protocols:           []string{"h2"},
+			HTTP2MaxFrameSize:   sharedconfig.HTTP2ServerMaxReadFrameSize,
+			HTTP2RecvBufConn:    sharedconfig.HTTP2ServerReceiveBufferPerConnection,
+			HTTP2RecvBufStream:  sharedconfig.HTTP2ServerReceiveBufferPerStream,
+			MaxConcurrentStream: 0,
 		},
 		NextProxy: config.NextProxyConfig{
 			URL:           "",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -11,11 +11,11 @@ type LogConfig struct {
 }
 
 type TransportConfig struct {
-	Protocol            string `json:"protocol"`
-	HTTP2MaxFrameSize   int    `json:"http2_max_frame_size"`
-	HTTP2RecvBufConn    int    `json:"http2_recv_buf_conn"`
-	HTTP2RecvBufStream  int    `json:"http2_recv_buf_stream"`
-	MaxConcurrentStream int    `json:"max_concurrent_streams"`
+	Protocols           []string `json:"protocols"`
+	HTTP2MaxFrameSize   int      `json:"http2_max_frame_size"`
+	HTTP2RecvBufConn    int      `json:"http2_recv_buf_conn"`
+	HTTP2RecvBufStream  int      `json:"http2_recv_buf_stream"`
+	MaxConcurrentStream int      `json:"max_concurrent_streams"`
 }
 
 type FallbackConfig struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -11,11 +11,10 @@ type LogConfig struct {
 }
 
 type TransportConfig struct {
-	Protocols           []string `json:"protocols"`
-	HTTP2MaxFrameSize   int      `json:"http2_max_frame_size"`
-	HTTP2RecvBufConn    int      `json:"http2_recv_buf_conn"`
-	HTTP2RecvBufStream  int      `json:"http2_recv_buf_stream"`
-	MaxConcurrentStream int      `json:"max_concurrent_streams"`
+	Protocols          []string `json:"protocols"`
+	HTTP2MaxFrameSize  int      `json:"http2_max_frame_size"`
+	HTTP2RecvBufConn   int      `json:"http2_recv_buf_conn"`
+	HTTP2RecvBufStream int      `json:"http2_recv_buf_stream"`
 }
 
 type FallbackConfig struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -11,7 +11,23 @@ type LogConfig struct {
 }
 
 type TransportConfig struct {
-	Protocol string `json:"protocol"`
+	Protocol            string `json:"protocol"`
+	HTTP2MaxFrameSize   int    `json:"http2_max_frame_size"`
+	HTTP2RecvBufConn    int    `json:"http2_recv_buf_conn"`
+	HTTP2RecvBufStream  int    `json:"http2_recv_buf_stream"`
+	MaxConcurrentStream int    `json:"max_concurrent_streams"`
+}
+
+type FallbackConfig struct {
+	Target       string   `json:"target"`
+	PreserveHost bool     `json:"preserve_host"`
+	CDNDomains   []string `json:"cdn_domains"`
+}
+
+type ShaperConfig struct {
+	BatchWindowMS    int     `json:"batch_window_ms"`
+	CoverBudgetRatio float64 `json:"cover_budget_ratio"`
+	CoverBudgetCap   int     `json:"cover_budget_cap"`
 }
 
 type NextProxyConfig struct {
@@ -22,36 +38,38 @@ type NextProxyConfig struct {
 }
 
 type ServerConfig struct {
-	Listen               string          `json:"listen"`
-	Domain               string          `json:"domain"`
-	Password             string          `json:"password"`
-	AllowedMethods       []string        `json:"allowed_methods"`
-	CertPath             string          `json:"cert_path"`
-	KeyPath              string          `json:"key_path"`
-	Email                string          `json:"email"`
-	FallbackTarget       string          `json:"fallback_target"`
-	FallbackPreserveHost bool            `json:"fallback_preserve_host"`
-	FallbackCDNDomains   []string        `json:"fallback_cdn_domains"`
-	Timeout              int             `json:"-"`
-	BatchWindowMS        int             `json:"batch_window_ms"`
-	CoverBudgetRatio     float64         `json:"cover_budget_ratio"`
-	CoverBudgetCap       int             `json:"cover_budget_cap"`
-	NextProxy            NextProxyConfig `json:"-"`
-	PprofEnabled         bool            `json:"pprof_enabled"`
+	Listen         string          `json:"listen"`
+	Domain         string          `json:"domain"`
+	Password       string          `json:"password"`
+	AllowedMethods []string        `json:"allowed_methods"`
+	CertPath       string          `json:"cert_path"`
+	KeyPath        string          `json:"key_path"`
+	Email          string          `json:"email"`
+	Timeout        int             `json:"-"`
+	Fallback       FallbackConfig  `json:"-"`
+	Shaper         ShaperConfig    `json:"-"`
+	Transport      TransportConfig `json:"-"`
+	NextProxy      NextProxyConfig `json:"-"`
 }
 
 type FileConfig struct {
 	ConfigVersion int             `json:"version"`
 	Server        ServerConfig    `json:"server"`
-	Log           LogConfig       `json:"log"`
+	Fallback      FallbackConfig  `json:"fallback"`
+	Shaper        ShaperConfig    `json:"shaper"`
 	Transport     TransportConfig `json:"transport"`
 	NextProxy     NextProxyConfig `json:"next_proxy"`
+	Log           LogConfig       `json:"log"`
+	PprofEnabled  bool            `json:"pprof_enabled"`
 	Timeout       int             `json:"timeout"`
 }
 
 func (fc *FileConfig) EffectiveServerConfig() ServerConfig {
 	cfg := fc.Server
 	cfg.Timeout = fc.Timeout
+	cfg.Fallback = fc.Fallback
+	cfg.Shaper = fc.Shaper
+	cfg.Transport = fc.Transport
 	cfg.NextProxy = fc.NextProxy
 	return cfg
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -18,11 +18,12 @@ func TestFileConfigEffectiveServerConfig(t *testing.T) {
 			"domain": "example.com",
 			"password": "secret",
 			"allowed_methods": ["aes-256-gcm"],
-				"fallback_target": "fallback.html",
 			"timeout": 99,
 			"next_proxy": {"url": "socks5://127.0.0.1:9999", "enable_udp": false}
 		},
+		"fallback": {"target": "fallback.html"},
 		"next_proxy": {"url": "socks5://127.0.0.1:1080", "enable_udp": true},
+		"pprof_enabled": true,
 		"timeout": 30
 	}`)
 
@@ -31,10 +32,11 @@ func TestFileConfigEffectiveServerConfig(t *testing.T) {
 	cfg := fc.EffectiveServerConfig()
 	require.Equal(t, ":443", cfg.Listen)
 	require.Equal(t, "secret", cfg.Password)
-	require.Equal(t, "fallback.html", cfg.FallbackTarget)
+	require.Equal(t, "fallback.html", cfg.Fallback.Target)
 	require.Equal(t, 30, cfg.Timeout)
 	require.Equal(t, "socks5://127.0.0.1:1080", cfg.NextProxy.URL)
 	require.True(t, cfg.NextProxy.EnableUDP)
+	require.True(t, fc.PprofEnabled)
 }
 
 func TestResolveFilePaths(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -36,10 +36,10 @@ type Server struct {
 }
 
 func New(cfg *config.ServerConfig) (*Server, error) {
-	switch cfg.Transport.Protocol {
-	case "", "h2":
-	default:
-		return nil, fmt.Errorf("unsupported transport protocol %q (only h2 is supported)", cfg.Transport.Protocol)
+	for _, p := range cfg.Transport.Protocols {
+		if p != "h2" {
+			return nil, fmt.Errorf("unsupported transport protocol %q (only h2 is supported)", p)
+		}
 	}
 
 	s := &Server{

--- a/server/server.go
+++ b/server/server.go
@@ -36,6 +36,12 @@ type Server struct {
 }
 
 func New(cfg *config.ServerConfig) (*Server, error) {
+	switch cfg.Transport.Protocol {
+	case "", "h2":
+	default:
+		return nil, fmt.Errorf("unsupported transport protocol %q (only h2 is supported)", cfg.Transport.Protocol)
+	}
+
 	s := &Server{
 		cfg: cfg,
 	}
@@ -259,11 +265,11 @@ func (s *Server) Start() error {
 		timeout = time.Duration(sharedconfig.DefaultTimeout) * time.Second
 	}
 
-	if s.cfg.FallbackTarget != "" {
-		if err := handler.SetFallbackTarget(s.cfg.FallbackTarget, s.cfg.FallbackPreserveHost, s.cfg.FallbackCDNDomains); err != nil {
+	if s.cfg.Fallback.Target != "" {
+		if err := handler.SetFallbackTarget(s.cfg.Fallback.Target, s.cfg.Fallback.PreserveHost, s.cfg.Fallback.CDNDomains); err != nil {
 			return fmt.Errorf("fallback target: %w", err)
 		}
-		log.Info("[SERVER] fallback target configured", "target", s.cfg.FallbackTarget, "preserve_host", s.cfg.FallbackPreserveHost, "cdn_domains", s.cfg.FallbackCDNDomains)
+		log.Info("[SERVER] fallback target configured", "target", s.cfg.Fallback.Target, "preserve_host", s.cfg.Fallback.PreserveHost, "cdn_domains", s.cfg.Fallback.CDNDomains)
 	}
 
 	masterKey, err := crypto.DeriveMasterKey(s.cfg.Password)
@@ -294,9 +300,9 @@ func (s *Server) Start() error {
 		Timeout:           timeout,
 		StreamIdleTimeout: streamIdleTimeout,
 		UDPIdleTimeout:    sharedconfig.UDPIdleTimeout(timeout),
-		BatchWindowMS:     s.cfg.BatchWindowMS,
-		CoverBudgetRatio:  s.cfg.CoverBudgetRatio,
-		CoverBudgetCap:    s.cfg.CoverBudgetCap,
+		BatchWindowMS:     s.cfg.Shaper.BatchWindowMS,
+		CoverBudgetRatio:  s.cfg.Shaper.CoverBudgetRatio,
+		CoverBudgetCap:    s.cfg.Shaper.CoverBudgetCap,
 		NextProxy:         np,
 	})
 
@@ -331,17 +337,31 @@ func (s *Server) Start() error {
 // upload stream's in-flight data (throughput ≈ window/RTT), so both windows
 // must be generous enough for high-RTT links.
 func buildHTTPServer(cfg *config.ServerConfig, tlsConfig *tls.Config, mux *http.ServeMux, timeout time.Duration) *http.Server {
+	http2Cfg := &http.HTTP2Config{
+		MaxReadFrameSize:              sharedconfig.HTTP2ServerMaxReadFrameSize,
+		MaxReceiveBufferPerConnection: sharedconfig.HTTP2ServerReceiveBufferPerConnection,
+		MaxReceiveBufferPerStream:     sharedconfig.HTTP2ServerReceiveBufferPerStream,
+	}
+	if cfg.Transport.HTTP2MaxFrameSize > 0 {
+		http2Cfg.MaxReadFrameSize = cfg.Transport.HTTP2MaxFrameSize
+	}
+	if cfg.Transport.HTTP2RecvBufConn > 0 {
+		http2Cfg.MaxReceiveBufferPerConnection = cfg.Transport.HTTP2RecvBufConn
+	}
+	if cfg.Transport.HTTP2RecvBufStream > 0 {
+		http2Cfg.MaxReceiveBufferPerStream = cfg.Transport.HTTP2RecvBufStream
+	}
+	if cfg.Transport.MaxConcurrentStream > 0 {
+		http2Cfg.MaxConcurrentStreams = cfg.Transport.MaxConcurrentStream
+	}
+
 	srv := &http.Server{
-		Addr:      cfg.Listen,
-		TLSConfig: tlsConfig,
-		Handler:   mux,
-		ErrorLog:  stdErrorLog(),
-		Protocols: &http.Protocols{},
-		HTTP2: &http.HTTP2Config{
-			MaxReadFrameSize:              sharedconfig.HTTP2ServerMaxReadFrameSize,
-			MaxReceiveBufferPerConnection: sharedconfig.HTTP2ServerReceiveBufferPerConnection,
-			MaxReceiveBufferPerStream:     sharedconfig.HTTP2ServerReceiveBufferPerStream,
-		},
+		Addr:              cfg.Listen,
+		TLSConfig:         tlsConfig,
+		Handler:           mux,
+		ErrorLog:          stdErrorLog(),
+		Protocols:         &http.Protocols{},
+		HTTP2:             http2Cfg,
 		IdleTimeout:       8 * timeout,
 		ReadHeaderTimeout: min(timeout/2, 10*time.Second),
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -351,9 +351,6 @@ func buildHTTPServer(cfg *config.ServerConfig, tlsConfig *tls.Config, mux *http.
 	if cfg.Transport.HTTP2RecvBufStream > 0 {
 		http2Cfg.MaxReceiveBufferPerStream = cfg.Transport.HTTP2RecvBufStream
 	}
-	if cfg.Transport.MaxConcurrentStream > 0 {
-		http2Cfg.MaxConcurrentStreams = cfg.Transport.MaxConcurrentStream
-	}
 
 	srv := &http.Server{
 		Addr:              cfg.Listen,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -24,6 +24,21 @@ func TestCertmagicStoragePathForExecutable(t *testing.T) {
 	require.Equal(t, filepath.Join("tmp", "easyss", "certmagic"), certmagicStoragePathForExecutable(exe))
 }
 
+func TestNewTransportProtocolsValidation(t *testing.T) {
+	require.NoError(t, mustNewServer(t, nil))
+	require.NoError(t, mustNewServer(t, []string{"h2"}))
+	require.Error(t, mustNewServer(t, []string{"h3"}))
+	require.Error(t, mustNewServer(t, []string{"h2", "h3"}))
+}
+
+func mustNewServer(t *testing.T, protocols []string) error {
+	t.Helper()
+	_, err := New(&config.ServerConfig{
+		Transport: config.TransportConfig{Protocols: protocols},
+	})
+	return err
+}
+
 func TestShouldRetryFreshCertificate(t *testing.T) {
 	require.True(t, shouldRetryFreshCertificate(errString("Could not validate ARI 'replaces' field")))
 	require.True(t, shouldRetryFreshCertificate(errString("Requested certificate was not found")))


### PR DESCRIPTION
## 概述

重构服务端配置文件结构，将原本平铺在 `server` 下的配置项按功能拆分到独立层级，与客户端配置结构对齐。

## 变更内容

- **fallback**：`server.fallback_target` / `server.fallback_preserve_host` / `server.fallback_cdn_domains` 合并为顶层 `fallback` 块（`target` / `preserve_host` / `cdn_domains`），与顶层 `next_proxy` 保持一致
- **shaper**：`server.batch_window_ms` / `server.cover_budget_ratio` / `server.cover_budget_cap` 提取为顶层 `shaper` 块，与客户端 `shaper` 字段一一对应
- **pprof_enabled**：从 `server` 下移至顶层，与客户端配置一致
- **transport**：扩展 HTTP/2 可调参数（`http2_max_frame_size` / `http2_recv_buf_conn` / `http2_recv_buf_stream` / `max_concurrent_streams`），此前硬编码在 sharedconfig 中；`protocol` 字段真正接入服务端（非 `h2` 启动时报错），为未来 h3 支持预留
- 示例配置 email 统一改为空字符串，避免用户直接拿去申请证书时报错

## 影响

- 服务端配置格式为破坏性变更（v3 仍在 rc），旧配置中的 fallback/shaper/pprof 字段会静默失效，但缺省值均可正常兜底
- README 服务端配置示例、参数表、fallback 使用示例同步更新

## 验证

`go test ./...` 全部通过，`make lint` 0 issues。