### PR TITLE
chore: apply go fix modernizations

### DIFF
--- a/client/dns/cache.go
+++ b/client/dns/cache.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"strings"
 
 	"github.com/coocood/freecache"
@@ -199,20 +200,16 @@ func (c *Cache) PrePopulateWithFallback(domain string, dnsServers []string, requ
 	}
 
 	if BuiltinDNSAvailable() {
-		for _, s := range dnsServers {
-			if try(s) {
-				MarkBuiltinDNSAvailable()
-				return nil
-			}
+		if slices.ContainsFunc(dnsServers, try) {
+			MarkBuiltinDNSAvailable()
+			return nil
 		}
 		MarkBuiltinDNSUnavailable()
 		log.Warn("[DNS] all builtin dns servers failed, fallback to system dns", "domain", domain, "err", lastErr)
 	}
 
-	for _, s := range systemDNSServersFunc() {
-		if try(s) {
-			return nil
-		}
+	if slices.ContainsFunc(systemDNSServersFunc(), try) {
+		return nil
 	}
 
 	if lastErr == nil {

--- a/client/dns/cache_test.go
+++ b/client/dns/cache_test.go
@@ -267,7 +267,7 @@ func TestJitterTTL_NeverExpire(t *testing.T) {
 func TestJitterTTL_Range(t *testing.T) {
 	const base = 1800
 	seen := make(map[int]bool)
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		ttl := jitterTTL(base)
 		// 结果必须在 [base, 2*base) 区间内
 		if ttl < base || ttl >= 2*base {

--- a/client/proxy/close_race_test.go
+++ b/client/proxy/close_race_test.go
@@ -19,7 +19,7 @@ func TestSocks5CloseRacingStart(t *testing.T) {
 	old := runtime.GOMAXPROCS(1)
 	defer runtime.GOMAXPROCS(old)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		l, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatalf("listen: %v", err)

--- a/client/proxy/direct_udp_test.go
+++ b/client/proxy/direct_udp_test.go
@@ -92,14 +92,12 @@ func TestDirectUDPRelayConcurrentDial(t *testing.T) {
 	key := "direct_" + clientAddr.String() + "_" + dst
 
 	var wg sync.WaitGroup
-	for i := 0; i < 2; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 2 {
+		wg.Go(func() {
 			if err := srv.directUDPRelay(&socks5.Server{}, clientAddr, directTestDatagram(dst, 1), dst); err != nil {
 				t.Errorf("directUDPRelay: %v", err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/client/proxy/helpers_test.go
+++ b/client/proxy/helpers_test.go
@@ -152,7 +152,7 @@ func TestIsDNSResponse(t *testing.T) {
 	}{
 		{"Response=true", makeMsg(true), true},
 		{"Response=false", makeMsg(false), false},
-		{"无 Question", &dns.Msg{MsgHdr: dns.MsgHdr{Response: true}}, false},
+		{"无 Question", &dns.Msg{Response: true}, false},
 	}
 
 	for _, tt := range tests {

--- a/client/proxy/http_proxy.go
+++ b/client/proxy/http_proxy.go
@@ -412,10 +412,7 @@ func (s *HTTPProxyServer) directConnect(target string) (net.Conn, error) {
 func (s *HTTPProxyServer) dialSOCKS5(target string) (net.Conn, error) {
 	// Round the timeout up so sub-second timeouts never truncate to 0 (the
 	// socks5 library treats 0 as "no timeout").
-	socksTimeout := int(math.Ceil(s.timeout.Seconds()))
-	if socksTimeout < 1 {
-		socksTimeout = 1
-	}
+	socksTimeout := max(int(math.Ceil(s.timeout.Seconds())), 1)
 	client, err := socks5.NewClient(s.socksAddr, s.username, s.password, socksTimeout, socksTimeout)
 	if err != nil {
 		return nil, err

--- a/client/proxy/stream.go
+++ b/client/proxy/stream.go
@@ -102,7 +102,7 @@ func (h *StreamHandler) openAndBootstrap(ctx context.Context, endpoint string, p
 	plaintext := protocol.EncodeFrames(frames)
 
 	const maxRetries = 2
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	for attempt := range maxRetries {
 		salt, err := crypto.GenerateSalt()
 		if err != nil {
 			return nil, fmt.Errorf("generate salt: %w", err)

--- a/client/router/router.go
+++ b/client/router/router.go
@@ -80,8 +80,8 @@ func NewGeoSite(data []byte) *GeoSite {
 		fullDomain: make(map[string]struct{}),
 	}
 
-	lines := bytes.Split(data, []byte("\n"))
-	for _, line := range lines {
+	lines := bytes.SplitSeq(data, []byte("\n"))
+	for line := range lines {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue

--- a/cmd/easyss/easyss_test.go
+++ b/cmd/easyss/easyss_test.go
@@ -88,7 +88,7 @@ var testExternalURLs = []string{
 func fetchExternalURL(t *testing.T, client *http.Client) (body []byte, status int) {
 	t.Helper()
 	for _, url := range testExternalURLs {
-		for attempt := 0; attempt < 2; attempt++ {
+		for attempt := range 2 {
 			if attempt > 0 {
 				time.Sleep(2 * time.Second)
 			}

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -202,7 +202,7 @@ func (a *App) Start() error {
 			prepopulated := true
 			if serverAddr := a.cfg.DefaultServer().Address; net.ParseIP(serverAddr) == nil {
 				var err error
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					if a.core.SocksServer == nil || len(config.DirectDNSServers) == 0 {
 						prepopulated = false
 						break

--- a/config/timeouts.go
+++ b/config/timeouts.go
@@ -31,10 +31,7 @@ func UDPIdleTimeout(base time.Duration) time.Duration {
 // [3s, 15s]. Shared by the client (direct dials) and the server (TCP
 // handler dials) so both sides always derive the same value.
 func DialTimeout(base time.Duration) time.Duration {
-	d := base / 3
-	if d < 3*time.Second {
-		d = 3 * time.Second
-	}
+	d := max(base/3, 3*time.Second)
 	if d > 15*time.Second {
 		d = 15 * time.Second
 	}

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -73,14 +73,14 @@ func TestCounterNonce(t *testing.T) {
 	require.Equal(t, prefix[1], n1[1])
 
 	var val1 uint64
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		val1 = (val1 << 8) | uint64(n1[4+i])
 	}
 	require.Equal(t, uint64(0), val1)
 
 	n2 := cn.Next()
 	var val2 uint64
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		val2 = (val2 << 8) | uint64(n2[4+i])
 	}
 	require.Equal(t, uint64(1), val2)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -89,10 +89,7 @@ func bidirectional(idleTimeout time.Duration, drainWhen func() bool, drainIdle t
 	// drain fires within ~drainIdle..drainIdle+tick of going idle.
 	var drainC <-chan time.Time
 	if drainWhen != nil && drainIdle > 0 {
-		tick := drainIdle / 6
-		if tick < 10*time.Millisecond {
-			tick = 10 * time.Millisecond
-		}
+		tick := max(drainIdle/6, 10*time.Millisecond)
 		drainTicker := time.NewTicker(tick)
 		defer drainTicker.Stop()
 		drainC = drainTicker.C
@@ -122,7 +119,7 @@ func bidirectional(idleTimeout time.Duration, drainWhen func() bool, drainIdle t
 					onClose()
 				}
 				// Drain both goroutine results so they can exit cleanly.
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					select {
 					case <-errCh:
 					default:
@@ -140,7 +137,7 @@ func bidirectional(idleTimeout time.Duration, drainWhen func() bool, drainIdle t
 				onClose()
 			}
 			// Drain both goroutine results so they can exit cleanly.
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				select {
 				case <-errCh:
 				default:

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -33,7 +33,7 @@ func TestStopImmediatelyAfterRun(t *testing.T) {
 	old := runtime.GOMAXPROCS(1)
 	defer runtime.GOMAXPROCS(old)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		cfg := testConfig()
 		cfg.Local.SocksPort = freePort(t)
 		cfg.Local.HTTPPort = 0

--- a/server/handler/fallback.go
+++ b/server/handler/fallback.go
@@ -735,12 +735,12 @@ func cdnHostFromRequest(req *http.Request, cdnSet map[string]bool) (string, bool
 		return "", false
 	}
 	rest := path[len(cdnPathPrefix):]
-	slashIdx := strings.Index(rest, "/")
+	before, _, ok := strings.Cut(rest, "/")
 	var host string
-	if slashIdx < 0 {
+	if !ok {
 		host = rest
 	} else {
-		host = rest[:slashIdx]
+		host = before
 	}
 	if host == "" || !cdnHostMatches(host, cdnSet) {
 		return "", false
@@ -755,7 +755,7 @@ func clientAcceptsGzip(acceptEncoding string) bool {
 	if acceptEncoding == "" {
 		return false
 	}
-	for _, part := range strings.Split(acceptEncoding, ",") {
+	for part := range strings.SplitSeq(acceptEncoding, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
@@ -971,8 +971,8 @@ func rewriteCDNURLs(body []byte, origOrigin string, cdnHosts map[string]bool) []
 			// Extract the full host (everything between "://" and the
 			// trailing "/" or ":").
 			s := string(match)
-			idx := strings.Index(s, "://")
-			rest := s[idx+3:]
+			_, after, _ := strings.Cut(s, "://")
+			rest := after
 			// Trim trailing "/" or ":" to get the host.
 			fullHost := rest
 			if last := fullHost[len(fullHost)-1]; last == '/' || last == ':' {

--- a/server/handler/probe_test.go
+++ b/server/handler/probe_test.go
@@ -131,7 +131,7 @@ func TestProbeHandlerRateLimit(t *testing.T) {
 	// Drain the per-IP bucket (capacity 100), then the next request is
 	// rejected with 429.
 	ip := "203.0.113.7"
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if !h.limiter.Allow(ip) {
 			t.Fatalf("bucket drained earlier than expected at request %d", i+1)
 		}

--- a/server/handler/replay_test.go
+++ b/server/handler/replay_test.go
@@ -36,7 +36,7 @@ func TestSaltCache_MarkSeen(t *testing.T) {
 func TestSaltCache_DistinctSalts(t *testing.T) {
 	c := newSaltCache()
 	rng := rand.New(rand.NewSource(42))
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		buf := make([]byte, 16)
 		_, _ = rng.Read(buf)
 		salt := base64.RawURLEncoding.EncodeToString(buf)
@@ -56,7 +56,7 @@ func TestSaltCache_ConcurrentMarkSeen(t *testing.T) {
 
 	start := make(chan struct{})
 	results := make(chan bool, goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			<-start
 			results <- c.MarkSeen("/v3/tcp", salt)
@@ -65,7 +65,7 @@ func TestSaltCache_ConcurrentMarkSeen(t *testing.T) {
 	close(start)
 
 	seen := 0
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		if <-results {
 			seen++
 		}
@@ -80,7 +80,7 @@ func TestIPRateLimiter_BurstThenReject(t *testing.T) {
 	l := newIPRateLimiter()
 	l.now = func() time.Time { return now }
 
-	for i := 0; i < handshakeBurst; i++ {
+	for i := range handshakeBurst {
 		if !l.Allow("1.2.3.4") {
 			t.Fatalf("request %d within burst should be allowed", i)
 		}
@@ -95,14 +95,14 @@ func TestIPRateLimiter_Refill(t *testing.T) {
 	l := newIPRateLimiter()
 	l.now = func() time.Time { return now }
 
-	for i := 0; i < handshakeBurst; i++ {
+	for range handshakeBurst {
 		l.Allow("1.2.3.4")
 	}
 
 	// Advance 1s: exactly handshakeRate tokens are replenished.
 	now = now.Add(time.Second)
 	allowed := 0
-	for i := 0; i < int(handshakeRate); i++ {
+	for range int(handshakeRate) {
 		if l.Allow("1.2.3.4") {
 			allowed++
 		}
@@ -120,7 +120,7 @@ func TestIPRateLimiter_PerIPIsolation(t *testing.T) {
 	l := newIPRateLimiter()
 	l.now = func() time.Time { return now }
 
-	for i := 0; i < handshakeBurst; i++ {
+	for range handshakeBurst {
 		l.Allow("1.2.3.4")
 	}
 	if l.Allow("1.2.3.4") {

--- a/server/nextproxy/nextproxy.go
+++ b/server/nextproxy/nextproxy.go
@@ -242,10 +242,7 @@ func (np *NextProxy) dialSOCKS5Context(ctx context.Context, network, addr string
 		dialTimeout = config.DefaultDialTimeout
 	}
 	dialer := &net.Dialer{Timeout: dialTimeout}
-	socksTimeout := int(dialTimeout.Seconds())
-	if socksTimeout < 1 {
-		socksTimeout = 1
-	}
+	socksTimeout := max(int(dialTimeout.Seconds()), 1)
 
 	type result struct {
 		conn net.Conn

--- a/server/nextproxy/nextproxy_test.go
+++ b/server/nextproxy/nextproxy_test.go
@@ -420,14 +420,14 @@ func TestConcurrentAddIP(t *testing.T) {
 	np := &NextProxy{ips: make(map[string]struct{})}
 	done := make(chan struct{})
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			np.AddIP("10.0.0.1")
 			np.ShouldProxy("10.0.0.1")
 		}
 		done <- struct{}{}
 	}()
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			np.AddIP("10.0.0.2")
 			np.ShouldProxy("10.0.0.2")
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -214,7 +214,7 @@ func TestServerUploadFlowControlWindowsOnWire(t *testing.T) {
 		maxFramesToRead = 16
 	)
 	var streamWindow, connWindow = 0, initialConnWin
-	for i := 0; i < maxFramesToRead; i++ {
+	for range maxFramesToRead {
 		var hdr [9]byte
 		_, err := io.ReadFull(conn, hdr[:])
 		require.NoError(t, err)

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -111,13 +111,13 @@ func TestCollectConcurrentWithReset(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			ResetStartTime()
 			ResetCounters()
 			ClearStartTime()
 		}
 	}()
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		Collect()
 	}
 	<-done

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -88,10 +88,7 @@ func New(cfg Config) (*HTTP2Transport, error) {
 	if ratio <= 0 || ratio > 1 {
 		ratio = sharedconfig.DefaultPrioritySlotRatio
 	}
-	prioritySlots := int(float64(maxSlots) * ratio)
-	if prioritySlots < 1 {
-		prioritySlots = 1
-	}
+	prioritySlots := max(int(float64(maxSlots)*ratio), 1)
 	if prioritySlots > maxSlots {
 		prioritySlots = maxSlots
 	}
@@ -408,7 +405,7 @@ func (t *HTTP2Transport) Stats() transport.TransportStats {
 
 	for _, pool := range []*slotPool{t.sched.priority, t.sched.bulk} {
 		live := int(pool.liveCount.Load())
-		for i := 0; i < live; i++ {
+		for i := range live {
 			a := int(pool.slots[i].active.Load())
 			ts.ActiveStreams += a
 			if pool == t.sched.priority {
@@ -425,8 +422,8 @@ func (t *HTTP2Transport) Stats() transport.TransportStats {
 	// mutex (recordGrowEvent holds no scheduler lock), so no lock ordering
 	// issue with the read lock held above.
 	t.growMu.Lock()
-	for i := len(t.growEvents) - 1; i >= 0; i-- {
-		ts.GrowEvents = append(ts.GrowEvents, t.growEvents[i])
+	for _, v := range slices.Backward(t.growEvents) {
+		ts.GrowEvents = append(ts.GrowEvents, v)
 	}
 	t.growMu.Unlock()
 	return ts

--- a/transport/http2/consistency_test.go
+++ b/transport/http2/consistency_test.go
@@ -134,7 +134,7 @@ func TestGrowEventRingOrderAndCap(t *testing.T) {
 	}
 	tr := &HTTP2Transport{sched: newScheduler(4, slots, 4, 2)}
 
-	for i := 0; i < maxGrowEvents+4; i++ {
+	for i := range maxGrowEvents + 4 {
 		tr.recordGrowEvent("bulk", int32(i), transport.OpenRequest{
 			Endpoint: sharedconfig.EndpointUDP,
 			Target:   "8.8.8.8:53",

--- a/transport/http2/lifecycle_test.go
+++ b/transport/http2/lifecycle_test.go
@@ -36,7 +36,7 @@ func TestEvaluateSlotHealth(t *testing.T) {
 		// The first interval after heavy 0->1 only resets the throughput
 		// baseline and is skipped.
 		lowThroughput(s)
-		for i := 0; i < sharedconfig.DegradedPersistCycles-1; i++ {
+		for i := range sharedconfig.DegradedPersistCycles - 1 {
 			lowThroughput(s)
 			if s.degraded.Load() {
 				t.Fatalf("degraded too early at cycle %d", i+1)
@@ -64,7 +64,7 @@ func TestEvaluateSlotHealth(t *testing.T) {
 	t.Run("clears degraded after consecutive healthy intervals", func(t *testing.T) {
 		s := newHeavySlot()
 		lowThroughput(s) // baseline reset
-		for i := 0; i < sharedconfig.DegradedPersistCycles; i++ {
+		for range sharedconfig.DegradedPersistCycles {
 			lowThroughput(s)
 		}
 		if !s.degraded.Load() {
@@ -82,7 +82,7 @@ func TestEvaluateSlotHealth(t *testing.T) {
 
 	t.Run("slots without heavy streams never degrade", func(t *testing.T) {
 		s := &transportSlot{t: &http.Transport{}}
-		for i := 0; i < sharedconfig.DegradedPersistCycles+2; i++ {
+		for range sharedconfig.DegradedPersistCycles + 2 {
 			lowThroughput(s)
 		}
 		if s.degraded.Load() {
@@ -94,7 +94,7 @@ func TestEvaluateSlotHealth(t *testing.T) {
 		s := newHeavySlot()
 		// Baseline reset happens before the congestion gate.
 		lc.evaluateSlotHealth(0, s, interval, false)
-		for i := 0; i < sharedconfig.DegradedPersistCycles+2; i++ {
+		for range sharedconfig.DegradedPersistCycles + 2 {
 			s.bytesRecv.Add(10 * 1024)
 			lc.evaluateSlotHealth(0, s, interval, false)
 		}
@@ -169,7 +169,7 @@ func TestSuspicionInsteadOfDirectMark(t *testing.T) {
 	}
 
 	low() // baseline reset
-	for i := 0; i < sharedconfig.DegradedPersistCycles; i++ {
+	for range sharedconfig.DegradedPersistCycles {
 		low()
 	}
 	if s.degraded.Load() {
@@ -195,7 +195,7 @@ func TestNoProbeFuncFallsBackToPassive(t *testing.T) {
 	s.heavy.Store(1)
 
 	lc.evaluateSlotHealth(0, s, interval, true) // baseline reset
-	for i := 0; i < sharedconfig.DegradedPersistCycles; i++ {
+	for range sharedconfig.DegradedPersistCycles {
 		s.bytesRecv.Add(10 * 1024)
 		lc.evaluateSlotHealth(0, s, interval, true)
 	}
@@ -309,7 +309,7 @@ func TestProbeUnsupportedFallsBackToPassive(t *testing.T) {
 	s.suspected = false
 	s.heavy.Store(1)
 	lc.evaluateSlotHealth(0, s, interval, true) // baseline reset
-	for i := 0; i < sharedconfig.DegradedPersistCycles; i++ {
+	for range sharedconfig.DegradedPersistCycles {
 		s.bytesRecv.Add(10 * 1024)
 		lc.evaluateSlotHealth(0, s, interval, true)
 	}
@@ -361,7 +361,7 @@ func TestProbeMaxPerInterval(t *testing.T) {
 		calls++
 		return 10 * 1024, probeSlow
 	})
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		sch.priority.slots[i].suspected = true
 	}
 
@@ -445,7 +445,7 @@ func TestRotationLifetimeJitter(t *testing.T) {
 	const base = 15 * time.Minute
 	span := base * 3 / 10
 	min, max := base-span, base+span
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		got := rotationLifetime(base)
 		if got < min || got > max {
 			t.Fatalf("rotationLifetime(%v) = %v, want within [%v, %v]", base, got, min, max)

--- a/transport/http2/scheduler.go
+++ b/transport/http2/scheduler.go
@@ -82,10 +82,7 @@ type slotPool struct {
 // Each pool renumbers its slots from 0, so a slot's stable idx is only
 // meaningful within its own pool.
 func newScheduler(maxSlots int, slots []*transportSlot, threshold int32, prioritySlots int) *slotScheduler {
-	pMax := prioritySlots
-	if pMax > maxSlots {
-		pMax = maxSlots
-	}
+	pMax := min(prioritySlots, maxSlots)
 	if pMax < 1 {
 		pMax = 1
 	}
@@ -379,7 +376,7 @@ func (p *slotPool) tieredSelectAt(live int, recordStats bool) (*transportSlot, b
 		best = nil
 		var bestActive int32 = math.MaxInt32
 		var bestNeg int32 = math.MaxInt32
-		for i := 0; i < live; i++ {
+		for i := range live {
 			sl := p.slots[i]
 			if slotTierOf(sl) != tier || draining(sl) {
 				continue
@@ -457,10 +454,7 @@ func (p *slotPool) pressureLevel(live int) int32 {
 		}
 		return 1 + floorLog2(activeMin/p.base)
 	}
-	poolMin := p.minActiveInRange(live)
-	if poolMin < p.base {
-		poolMin = p.base
-	}
+	poolMin := max(p.minActiveInRange(live), p.base)
 	return 1 + floorLog2(poolMin/p.base)
 }
 
@@ -519,7 +513,7 @@ func tierCap(tier slotTier, level, base int32) int32 {
 func (p *slotPool) minActiveInTier(live int, tier slotTier) (int32, bool) {
 	var min int32 = math.MaxInt32
 	found := false
-	for i := 0; i < live; i++ {
+	for i := range live {
 		sl := p.slots[i]
 		if slotTierOf(sl) != tier {
 			continue
@@ -536,7 +530,7 @@ func (p *slotPool) minActiveInTier(live int, tier slotTier) (int32, bool) {
 // `live` slots; 0 when the range holds no slot.
 func (p *slotPool) minActiveInRange(live int) int32 {
 	var min int32 = math.MaxInt32
-	for i := 0; i < live; i++ {
+	for i := range live {
 		if a := p.slots[i].active.Load(); a < min {
 			min = a
 		}
@@ -569,7 +563,7 @@ func (p *slotPool) leastActive(live int, recordStats bool) *transportSlot {
 	var lastResort *transportSlot // least-loaded retiring/draining slot, absolute last resort
 	var resWeighted int32 = math.MaxInt32
 	var resNeg int32 = math.MaxInt32
-	for i := 0; i < live; i++ {
+	for i := range live {
 		sl := p.slots[i]
 		w := weightedActive(sl)
 		neg := negativeScore(sl)
@@ -716,7 +710,7 @@ func (s *slotScheduler) shrinkIdleLocked() {
 // count. Returns false when no idle slot remains. Caller must hold s.mu.
 func (p *slotPool) removeIdleLocked() bool {
 	live := int(p.liveCount.Load())
-	for i := 0; i < live; i++ {
+	for i := range live {
 		if p.slots[i].active.Load() != 0 {
 			continue
 		}
@@ -752,7 +746,7 @@ func (s *slotScheduler) remove(sl *transportSlot) bool {
 	}
 	for _, pool := range []*slotPool{s.priority, s.bulk} {
 		live := int(pool.liveCount.Load())
-		for i := 0; i < live; i++ {
+		for i := range live {
 			if pool.slots[i] != sl {
 				continue
 			}

--- a/transport/http2/scheduler_bench_test.go
+++ b/transport/http2/scheduler_bench_test.go
@@ -40,7 +40,7 @@ func benchScheduler() *slotScheduler {
 
 	// Bulk pool (base 8): three healthy, one heavy, one expiring, one
 	// degraded, three retiring.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		sch.bulk.slots[i].active.Store(7)
 	}
 	sch.bulk.slots[3].active.Store(1)
@@ -70,7 +70,7 @@ func pickSaturation(sch *slotScheduler, mode string) {
 	case "level1":
 		sch.priority.slots[0].active.Store(4)
 		sch.priority.slots[1].active.Store(4)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			sch.bulk.slots[i].active.Store(8)
 		}
 	case "saturated":
@@ -79,7 +79,7 @@ func pickSaturation(sch *slotScheduler, mode string) {
 		sch.priority.slots[2].active.Store(2) // heavy: 2×4 = 8 ≥ base 4
 		sch.priority.slots[3].active.Store(1) // expiring: 1×8 = 8 ≥ base 4
 		sch.priority.slots[4].active.Store(1) // degraded: 1×16 = 16 ≥ base 4
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			sch.bulk.slots[i].active.Store(8)
 		}
 		sch.bulk.slots[3].active.Store(4) // heavy: 4×4 = 16 ≥ base 8

--- a/transport/http2/scheduler_test.go
+++ b/transport/http2/scheduler_test.go
@@ -826,7 +826,7 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 		// connections, so the sibling pool is grown (with first-activation
 		// +2 semantics).
 		sch := newGrowTestScheduler(10, 5, 5, 0)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 		}
 		sch.grow(true)
@@ -843,7 +843,7 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 		// the sibling pool's slots saturated too (8 each): a new
 		// connection is genuinely needed, so the sibling grows.
 		sch := newGrowTestScheduler(10, 5, 5, 2)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 		}
 		sch.bulk.slots[0].active.Store(8)
@@ -879,7 +879,7 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 		// growing it. Cross-pool growth is throttled by the sibling's own
 		// slot thresholds.
 		sch := newGrowTestScheduler(10, 5, 5, 2)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 		}
 		sch.bulk.slots[0].active.Store(1)
@@ -906,7 +906,7 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 		sch.priority.slots[3].heavy.Store(1)
 		sch.priority.slots[4].active.Store(3)
 		sch.priority.slots[4].heavy.Store(1)
-		for i := 0; i < 7; i++ {
+		for i := range 7 {
 			sch.bulk.slots[i].active.Store(1)
 		}
 		sch.grow(true)
@@ -917,7 +917,7 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 
 	t.Run("bulk pool full grows unactivated priority pool", func(t *testing.T) {
 		sch := newGrowTestScheduler(10, 5, 0, 5)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.bulk.slots[i].active.Store(8)
 		}
 		sch.grow(false)
@@ -931,7 +931,7 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 
 	t.Run("both pools full never grows", func(t *testing.T) {
 		sch := newGrowTestScheduler(10, 5, 5, 5)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 			sch.bulk.slots[i].active.Store(8)
 		}
@@ -949,14 +949,14 @@ func TestGrowGrowsSiblingPoolWhenOwnPoolFull(t *testing.T) {
 func TestGrowConcurrent(t *testing.T) {
 	t.Run("concurrent growers activate the sibling once", func(t *testing.T) {
 		sch := newGrowTestScheduler(10, 5, 5, 0)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 		}
 		const n = 64
 		var wg sync.WaitGroup
 		var grown atomic.Int64
 		wg.Add(n)
-		for i := 0; i < n; i++ {
+		for range n {
 			go func() {
 				defer wg.Done()
 				if pool, _ := sch.grow(true); pool != nil {
@@ -975,7 +975,7 @@ func TestGrowConcurrent(t *testing.T) {
 
 	t.Run("concurrent growers add at most one slot", func(t *testing.T) {
 		sch := newGrowTestScheduler(10, 5, 5, 2)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 		}
 		sch.bulk.slots[0].active.Store(8)
@@ -984,7 +984,7 @@ func TestGrowConcurrent(t *testing.T) {
 		var wg sync.WaitGroup
 		var grown atomic.Int64
 		wg.Add(n)
-		for i := 0; i < n; i++ {
+		for range n {
 			go func() {
 				defer wg.Done()
 				if pool, _ := sch.grow(true); pool != nil {
@@ -1043,7 +1043,7 @@ func TestGrowReturnValue(t *testing.T) {
 
 	t.Run("cross-pool growth reports the sibling pool", func(t *testing.T) {
 		sch := newGrowTestScheduler(10, 5, 5, 0)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 		}
 		pool, live := sch.grow(true)
@@ -1057,7 +1057,7 @@ func TestGrowReturnValue(t *testing.T) {
 
 	t.Run("nil when both pools are at their caps", func(t *testing.T) {
 		sch := newGrowTestScheduler(10, 5, 5, 5)
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			sch.priority.slots[i].active.Store(4)
 			sch.bulk.slots[i].active.Store(8)
 		}

--- a/transport/http2/stream_test.go
+++ b/transport/http2/stream_test.go
@@ -101,12 +101,10 @@ func TestSetRoundTripErr_Concurrent(t *testing.T) {
 	defer s.Close()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 100 {
+		wg.Go(func() {
 			s.setRoundTripErr(errors.New("concurrent error"))
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/util/sysdns_parse.go
+++ b/util/sysdns_parse.go
@@ -15,7 +15,7 @@ func parseDNSServersFromIPConfig(output string) []string {
 	seen := make(map[string]struct{})
 	inDNSSection := false
 
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if isIPConfigDNSLabel(trimmed) {
 			inDNSSection = true


### PR DESCRIPTION
## 概述

运行 `go fix ./...` 应用 Go 1.22–1.24 的标准现代化改写，共涉及 29 个文件、+86/-114 行。

## 改动分类

- **整数 range 循环**（Go 1.22）：`for i := 0; i < N; i++` → `for range N` / `for i := range N`
- **内置 `min`/`max`**（Go 1.21）：手工钳制改为 `max(x, 1)` / `min(a, b)`
- **`Split` → `SplitSeq`**（Go 1.24 迭代器，免分配）：`bytes.Split`、`strings.Split`
- **`strings.Index`+切片 → `strings.Cut`**
- **`wg.Add(1)`+`go func(){defer wg.Done()}` → `wg.Go()`**（Go 1.24）
- **循环手写查找 → `slices.ContainsFunc`**
- **倒序遍历 → `slices.Backward`**
- **内嵌字段提升**：`dns.Msg{MsgHdr: dns.MsgHdr{...}}` → `dns.Msg{Response: true}`

## 说明

所有改动均为行为等价改写，已通过 `go build ./...`、`go vet ./...` 和 `make lint` 验证。