### PR TITLE
chore: integrate go fix style checks into lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ version: "2"
 
 linters:
   default: standard
+  enable:
+    - modernize
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,9 @@ test-race:
 
 lint:
 	go tool golangci-lint run --timeout 10m --verbose
+	@diff="$$(go fix -diff ./...)"; \
+	if [ -n "$$diff" ]; then \
+		echo "Error: 'go fix ./...' has pending changes, run 'go fix ./...' until the diff is empty:"; \
+		echo "$$diff"; \
+		exit 1; \
+	fi

--- a/cmd/easyss/autostart_linux.go
+++ b/cmd/easyss/autostart_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 )
 
 const (
@@ -81,13 +82,7 @@ func isAutoStartEnabled() bool {
 	}
 
 	expectedLine := fmt.Sprintf("Exec=%s\n", exe)
-	for _, line := range splitLines(string(data)) {
-		if line == expectedLine {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(splitLines(string(data)), expectedLine)
 }
 
 func splitLines(s string) []string {

--- a/cmd/easyss/tray_tun_helper_unix.go
+++ b/cmd/easyss/tray_tun_helper_unix.go
@@ -73,7 +73,7 @@ func (a *TrayApp) createTun2socksViaHelper() error {
 	// helper sets the system DNS to go through TUN.
 	if serverAddr := a.cfg.DefaultServer().Address; net.ParseIP(serverAddr) == nil {
 		var err error
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			if a.core.SocksServer == nil || len(config.DirectDNSServers) == 0 {
 				err = fmt.Errorf("dns cache not available")
 				break

--- a/cmd/easyss/tun_helper_linux.go
+++ b/cmd/easyss/tun_helper_linux.go
@@ -50,10 +50,7 @@ func openTunDevice(name string) (int, string, error) {
 		return -1, "", fmt.Errorf("set nonblock: %w", err)
 	}
 
-	namelen := len(name)
-	if namelen > len(ifr.name) {
-		namelen = len(ifr.name)
-	}
+	namelen := min(len(name), len(ifr.name))
 	for i, b := range ifr.name[:namelen] {
 		if b == 0 {
 			namelen = i

--- a/cmd/easyss/tun_helper_unix.go
+++ b/cmd/easyss/tun_helper_unix.go
@@ -164,7 +164,7 @@ func fetchTunConfig(httpAddr string) (*proxy.TunConfig, error) {
 	url := fmt.Sprintf("http://%s/tun", httpAddr)
 
 	var lastErr error
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if i > 0 {
 			time.Sleep(time.Duration(i) * 200 * time.Millisecond)
 		}

--- a/config/timeouts.go
+++ b/config/timeouts.go
@@ -31,9 +31,6 @@ func UDPIdleTimeout(base time.Duration) time.Duration {
 // [3s, 15s]. Shared by the client (direct dials) and the server (TCP
 // handler dials) so both sides always derive the same value.
 func DialTimeout(base time.Duration) time.Duration {
-	d := max(base/3, 3*time.Second)
-	if d > 15*time.Second {
-		d = 15 * time.Second
-	}
+	d := min(max(base/3, 3*time.Second), 15*time.Second)
 	return d
 }

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -88,10 +88,7 @@ func New(cfg Config) (*HTTP2Transport, error) {
 	if ratio <= 0 || ratio > 1 {
 		ratio = sharedconfig.DefaultPrioritySlotRatio
 	}
-	prioritySlots := max(int(float64(maxSlots)*ratio), 1)
-	if prioritySlots > maxSlots {
-		prioritySlots = maxSlots
-	}
+	prioritySlots := min(max(int(float64(maxSlots)*ratio), 1), maxSlots)
 
 	timeout := cfg.Timeout
 	if timeout <= 0 {

--- a/transport/http2/scheduler.go
+++ b/transport/http2/scheduler.go
@@ -82,10 +82,7 @@ type slotPool struct {
 // Each pool renumbers its slots from 0, so a slot's stable idx is only
 // meaningful within its own pool.
 func newScheduler(maxSlots int, slots []*transportSlot, threshold int32, prioritySlots int) *slotScheduler {
-	pMax := min(prioritySlots, maxSlots)
-	if pMax < 1 {
-		pMax = 1
-	}
+	pMax := max(min(prioritySlots, maxSlots), 1)
 	bMax := maxSlots - pMax
 	if bMax < 1 {
 		if pMax > 1 {

--- a/util/sysdns_linux.go
+++ b/util/sysdns_linux.go
@@ -71,7 +71,7 @@ func setResolvConf(servers []string) error {
 	}
 
 	var lines []string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "nameserver") {
 			continue
 		}


### PR DESCRIPTION
## 概述

将 `go fix` 的现代化检查整合进 lint 体系，采用 **modernize linter + go fix 检查互补** 的方案。

## 背景

Go 1.27 的 `go fix` 基于 x/tools `modernize` analyzer 实现，而 golangci-lint 的 `modernize` linter 包装了同一个 analyzer——即 golangci-lint 本身就能检测 go fix 的现代化改动，且支持 `--fix` 自动修复、报 issue 即非 0 退出。

## 改动明细

- **`.golangci.yml`**：启用 `modernize` linter，统一纳入 golangci-lint 生态（非测试文件由它检查，可 `golangci-lint run --fix` 一键修复）
- **`Makefile`**：保留 `go fix -diff ./...` 检查兜底。原因：项目配置 `run.tests: false`，modernize 不检查测试文件（开启 tests 会引入 44 个现存 errcheck/gofmt/staticcheck issue，超范围）；`go fix` 还含 modernize 没有的少数规则（buildtag 等）
- **补齐 go fix**：`go fix` 为迭代式，上一轮未收敛的 3 处（`max`+上限钳制 → `min(max(...))`）已补全

## 验证

- `make lint` 通过（0 issues）
- 人为引入需 fix 的代码（minmax）后 `make lint` 正确报错；测试文件退化时由 `go fix -diff` 检查拦截
- `go fix -diff ./...` 输出为空（已收敛）