### PR TITLE
chore: enable linting of test files and fix reported issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,4 +11,4 @@ formatters:
 
 run:
   timeout: 10m
-  tests: false
+  tests: true

--- a/client/dialer_test.go
+++ b/client/dialer_test.go
@@ -9,9 +9,9 @@ import (
 	"syscall"
 	"testing"
 
-	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/client/config"
 	"github.com/nange/easyss/v3/client/router"
+	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/xjasonlyu/tun2socks/v2/dialer"
 )
 

--- a/client/dns/cache_test.go
+++ b/client/dns/cache_test.go
@@ -148,14 +148,14 @@ func TestCache_DirectVsProxied(t *testing.T) {
 	msgProxied.SetQuestion("example.com.", dns.TypeA)
 	rrP, _ := dns.NewRR("example.com. 3600 IN A 1.1.1.1")
 	msgProxied.Answer = append(msgProxied.Answer, rrP)
-	c.Set(msgProxied, false)
+	c.Set(msgProxied, false) //nolint:errcheck
 
 	// 存储到 direct
 	msgDirect := &dns.Msg{}
 	msgDirect.SetQuestion("example.com.", dns.TypeA)
 	rrD, _ := dns.NewRR("example.com. 3600 IN A 2.2.2.2")
 	msgDirect.Answer = append(msgDirect.Answer, rrD)
-	c.Set(msgDirect, true)
+	c.Set(msgDirect, true) //nolint:errcheck
 
 	// proxied → 1.1.1.1
 	gotP := c.Get("example.com.", "A", false)

--- a/client/proxy/close_race_test.go
+++ b/client/proxy/close_race_test.go
@@ -25,7 +25,7 @@ func TestSocks5CloseRacingStart(t *testing.T) {
 			t.Fatalf("listen: %v", err)
 		}
 		addr := l.Addr().String()
-		l.Close()
+		l.Close() //nolint:errcheck
 
 		h := newTestStreamHandler(&mockTransport{})
 		srv, err := NewSocks5Server(addr, "", "", h, nil, "", protocol.MethodAES256GCM, true, 10*time.Second, 30*time.Second, 0, 0, nil)
@@ -42,7 +42,7 @@ func TestSocks5CloseRacingStart(t *testing.T) {
 		for time.Now().Before(deadline) {
 			c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
 			if err == nil {
-				c.Close()
+				c.Close() //nolint:errcheck
 				t.Fatalf("iteration #%d: server still listening on %s after Close", i, addr)
 			}
 			time.Sleep(10 * time.Millisecond)

--- a/client/proxy/direct_relay_test.go
+++ b/client/proxy/direct_relay_test.go
@@ -85,7 +85,7 @@ func TestRelayTCPIdleTimeoutClosesBoth(t *testing.T) {
 // relay returns only after both directions completed (both proxy-side
 // sockets closed).
 func TestRelayTCPHalfCloseAndCompletion(t *testing.T) {
-	app, proxyC := tcpPair(t)   // local application <-> proxy
+	app, proxyC := tcpPair(t)     // local application <-> proxy
 	proxyRC, remote := tcpPair(t) // proxy <-> remote server
 
 	done := make(chan struct{})

--- a/client/proxy/direct_udp_test.go
+++ b/client/proxy/direct_udp_test.go
@@ -57,7 +57,7 @@ func startSilentRemoteUDP(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("listen remote udp: %v", err)
 	}
-	t.Cleanup(func() { pc.Close() })
+	t.Cleanup(func() { pc.Close() }) //nolint:errcheck
 	go func() {
 		buf := make([]byte, 2048)
 		for {

--- a/client/proxy/openAndBootstrap_test.go
+++ b/client/proxy/openAndBootstrap_test.go
@@ -86,7 +86,7 @@ func TestOpenAndBootstrap_SuccessFirstTry(t *testing.T) {
 	if tr.openCalls() != 1 {
 		t.Errorf("expected 1 Open call, got %d", tr.openCalls())
 	}
-	defer bs.stream.Close()
+	defer bs.stream.Close() //nolint:errcheck
 }
 
 func TestOpenAndBootstrap_RetryOnErrClosedPipe(t *testing.T) {
@@ -108,7 +108,7 @@ func TestOpenAndBootstrap_RetryOnErrClosedPipe(t *testing.T) {
 	if tr.openCalls() != 2 {
 		t.Errorf("expected 2 Open calls, got %d", tr.openCalls())
 	}
-	defer bs.stream.Close()
+	defer bs.stream.Close() //nolint:errcheck
 }
 
 func TestOpenAndBootstrap_NoRetryOnNonClosedPipeErr(t *testing.T) {
@@ -204,7 +204,7 @@ func TestOpenAndBootstrap_FreshSaltPerAttempt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer bs.stream.Close()
+	defer bs.stream.Close() //nolint:errcheck
 
 	wrapped.mu.Lock()
 	defer wrapped.mu.Unlock()

--- a/client/proxy/stream_drain_test.go
+++ b/client/proxy/stream_drain_test.go
@@ -34,7 +34,7 @@ func (s *drainMockStream) Read(p []byte) (int, error) {
 }
 
 func (s *drainMockStream) Write(p []byte) (int, error) { return len(p), nil }
-func (s *drainMockStream) CloseWrite() error            { return nil }
+func (s *drainMockStream) CloseWrite() error           { return nil }
 func (s *drainMockStream) Close() error {
 	s.closeOnce.Do(func() { close(s.closedCh) })
 	return nil
@@ -103,7 +103,7 @@ func TestStreamRelayDrainsIdleStreamOnDrainingSlot(t *testing.T) {
 	stats.ResetCounters()
 	stream := newDrainMockStream(true)
 	h, tx, rx, lc, lcPeer := newDrainHandler(stream, 100*time.Millisecond)
-	defer lcPeer.Close()
+	defer lcPeer.Close() //nolint:errcheck
 
 	done := make(chan error, 1)
 	go func() { done <- h.relay("example.com:443", lc, tx, rx, stream) }()
@@ -130,7 +130,7 @@ func TestStreamRelayDrainsIdleStreamOnDrainingSlot(t *testing.T) {
 func TestStreamRelayKeepsIdleStreamOnHealthySlot(t *testing.T) {
 	stream := newDrainMockStream(false)
 	h, tx, rx, lc, lcPeer := newDrainHandler(stream, 100*time.Millisecond)
-	defer lcPeer.Close()
+	defer lcPeer.Close() //nolint:errcheck
 
 	done := make(chan error, 1)
 	go func() { done <- h.relay("example.com:443", lc, tx, rx, stream) }()

--- a/client/router/router_test.go
+++ b/client/router/router_test.go
@@ -561,10 +561,10 @@ func TestRouter_RegexpAndGlobCustomDomain(t *testing.T) {
 
 	// 手动添加 regexp 和 glob 规则（模拟 loadCustomIPDomains 的行为）
 	directRe1, _ := regexp.Compile(`^.*\.baidu\.com$`) // regexp: 前缀
-	directRe2, _ := util.GlobToRegexp("*taobao*")           // glob 通配符
+	directRe2, _ := util.GlobToRegexp("*taobao*")      // glob 通配符
 	r.customDirectRegexps = append(r.customDirectRegexps, directRe1, directRe2)
 
-	proxyRe1, _ := util.GlobToRegexp("*google*")            // glob 通配符
+	proxyRe1, _ := util.GlobToRegexp("*google*")       // glob 通配符
 	proxyRe2, _ := regexp.Compile(`^.*\.youtube\..*$`) // regexp: 前缀
 	r.customProxyRegexps = append(r.customProxyRegexps, proxyRe1, proxyRe2)
 

--- a/cmd/easyss/easyss_test.go
+++ b/cmd/easyss/easyss_test.go
@@ -98,7 +98,7 @@ func fetchExternalURL(t *testing.T, client *http.Client) (body []byte, status in
 				continue
 			}
 			body, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck
 			if err != nil {
 				t.Logf("read body %s attempt %d: %v", url, attempt+1, err)
 				continue
@@ -120,7 +120,7 @@ func waitForServer(t *testing.T, addr string) {
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			conn.Close() //nolint:errcheck
 			return
 		}
 		time.Sleep(200 * time.Millisecond)
@@ -135,7 +135,7 @@ func waitForListener(t *testing.T, addr string) {
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			conn.Close() //nolint:errcheck
 			return
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -152,7 +152,7 @@ func startLocalTargetServer(t *testing.T) func() {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "hello-from-target: %s", r.URL.Path)
+		fmt.Fprintf(w, "hello-from-target: %s", r.URL.Path) //nolint:errcheck
 	})
 
 	srv := &http.Server{Addr: addr, Handler: mux}
@@ -184,7 +184,7 @@ func startTCPEchoServer(t *testing.T) func() {
 				return
 			}
 			go func(c net.Conn) {
-				defer c.Close()
+				defer c.Close() //nolint:errcheck
 				buf := make([]byte, 1024)
 				for {
 					nr, err := c.Read(buf)
@@ -202,7 +202,7 @@ func startTCPEchoServer(t *testing.T) func() {
 
 	waitForListener(t, addr)
 
-	return func() { lis.Close() }
+	return func() { lis.Close() } //nolint:errcheck
 }
 
 type testHarness struct {
@@ -454,7 +454,7 @@ func TestV3Integration_LocalDirect(t *testing.T) {
 	targetURL := fmt.Sprintf("http://%s:%d/direct-test", testServerAddr, testTargetPort)
 	resp, err := client.Get(targetURL)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -475,7 +475,7 @@ func TestV3Integration_CloseWrite(t *testing.T) {
 
 	conn, err := sc.Dial("tcp", testServerAddr+":"+strconv.Itoa(testCloseWritePort))
 	require.NoError(t, err)
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck
 
 	// Clear any deadline set by SOCKS5 negotiation
 	_ = conn.SetDeadline(time.Time{})

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -196,7 +196,7 @@ func TestFileWriter(t *testing.T) {
 	if w == nil {
 		t.Fatal("FileWriter returned nil")
 	}
-	defer w.Close()
+	defer w.Close() //nolint:errcheck
 
 	n, err := io.WriteString(w, "test log message\n")
 	if err != nil {
@@ -207,7 +207,7 @@ func TestFileWriter(t *testing.T) {
 	}
 
 	// 关闭后验证文件内容
-	w.Close()
+	w.Close() //nolint:errcheck
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -54,7 +54,7 @@ func occupyTCPPort(t *testing.T) (net.Listener, int) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	t.Cleanup(func() { l.Close() })
+	t.Cleanup(func() { l.Close() }) //nolint:errcheck
 	return l, l.Addr().(*net.TCPAddr).Port
 }
 
@@ -66,7 +66,7 @@ func freePort(t *testing.T) int {
 		t.Fatalf("listen: %v", err)
 	}
 	port := l.Addr().(*net.TCPAddr).Port
-	l.Close()
+	l.Close() //nolint:errcheck
 	return port
 }
 
@@ -78,7 +78,7 @@ func occupyUDPPort(t *testing.T) net.PacketConn {
 	if err != nil {
 		t.Fatalf("listen packet: %v", err)
 	}
-	t.Cleanup(func() { pc.Close() })
+	t.Cleanup(func() { pc.Close() }) //nolint:errcheck
 	return pc
 }
 
@@ -125,7 +125,7 @@ func TestPrebindUDP(t *testing.T) {
 		t.Fatalf("listen packet: %v", err)
 	}
 	freeAddr := freePc.LocalAddr().String()
-	freePc.Close()
+	freePc.Close() //nolint:errcheck
 
 	if err := prebindUDP(freeAddr); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/server/handler/fallback_test.go
+++ b/server/handler/fallback_test.go
@@ -341,7 +341,7 @@ func TestServeFallback_ProxyForwardsRequest(t *testing.T) {
 	// Start a test upstream server that returns a known response.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Upstream", "true")
-		w.Write([]byte("from-upstream:" + r.URL.Path))
+		w.Write([]byte("from-upstream:" + r.URL.Path)) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -365,7 +365,7 @@ func TestServeFallback_ProxyForwardsRequest(t *testing.T) {
 func TestServeFallback_ProxyHighestPriority(t *testing.T) {
 	// Start a test upstream server.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("proxy-response"))
+		w.Write([]byte("proxy-response")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -486,7 +486,7 @@ func TestSetFallbackTarget_InvalidPath(t *testing.T) {
 func TestSetFallbackTarget_ProxyEndToEnd(t *testing.T) {
 	// Full integration: SetFallbackTarget with HTTP URL then serve a request.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("upstream:" + r.URL.Path))
+		w.Write([]byte("upstream:" + r.URL.Path)) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -516,7 +516,7 @@ func TestSetFallbackProxy_HostHeader(t *testing.T) {
 	var gotHost string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHost = r.Host
-		w.Write([]byte("ok"))
+		w.Write([]byte("ok")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -621,7 +621,7 @@ func TestSetFallbackProxy_PreserveHost(t *testing.T) {
 	var gotHost string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHost = r.Host
-		w.Write([]byte("ok"))
+		w.Write([]byte("ok")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -687,7 +687,7 @@ func TestSetFallbackProxy_RewriteSetCookieDomain(t *testing.T) {
 		// a port number.
 		w.Header().Add("Set-Cookie",
 			"_gh_sess=abc123; Domain="+upstreamHost+"; Path=/; HttpOnly; Secure")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -734,7 +734,7 @@ func TestSetFallbackProxy_RewriteSetCookieDomainWithDot(t *testing.T) {
 		w.Header().Set("Content-Type", "text/html")
 		// Manually set a raw Set-Cookie with leading-dot domain.
 		w.Header().Add("Set-Cookie", "test=val; Domain=."+upstreamHost+"; Path=/; Secure")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -764,7 +764,7 @@ func TestSetFallbackProxy_SetCookieOtherDomainUnchanged(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Add("Set-Cookie", "test=val; Domain=other.example.com; Path=/")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -797,7 +797,7 @@ func TestSetFallbackProxy_SetCookieNoDomainUnchanged(t *testing.T) {
 			Value: "val",
 			Path:  "/",
 		})
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -834,7 +834,7 @@ func TestSetFallbackProxy_RewriteContent(t *testing.T) {
 	var upstreamHost string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write([]byte(`<html><a href="https://` + upstreamHost + `/repo">link</a>` +
+		w.Write([]byte(`<html><a href="https://` + upstreamHost + `/repo">link</a>` + //nolint:errcheck
 			`<turbo-frame src="https://` + upstreamHost + `/repo/releases/expanded_assets/v1">` +
 			`</turbo-frame></html>`))
 	}))
@@ -871,7 +871,7 @@ func TestSetFallbackProxy_RewriteContentCSP(t *testing.T) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; connect-src 'self' https://"+upstreamHost+" api."+upstreamHost)
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -912,7 +912,7 @@ func TestSetFallbackProxy_RewriteCSPBareHost(t *testing.T) {
 		// Simulate GitHub-style CSP with bare-host paths in worker-src.
 		w.Header().Set("Content-Security-Policy",
 			"worker-src "+upstreamHost+"/assets-cdn/worker/ "+upstreamHost+"/assets/ gist."+upstreamHost+"/assets-cdn/worker/")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -956,7 +956,7 @@ func TestSetFallbackProxy_RewriteCSPMixed(t *testing.T) {
 		w.Header().Set("Content-Security-Policy",
 			"connect-src 'self' https://"+upstreamHost+" "+upstreamHost+"/api "+
 				"api."+upstreamHost+" https://other.example.com")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -1002,8 +1002,8 @@ func TestSetFallbackProxy_RewriteContentGzip(t *testing.T) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Set("Content-Encoding", "gzip")
 		gw := gzip.NewWriter(w)
-		gw.Write([]byte(`<html><a href="https://` + upstreamHost + `/test">link</a></html>`))
-		gw.Close()
+		gw.Write([]byte(`<html><a href="https://` + upstreamHost + `/test">link</a></html>`)) //nolint:errcheck
+		gw.Close()                                                                            //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -1038,7 +1038,7 @@ func TestSetFallbackProxy_RewriteContentNonHTML(t *testing.T) {
 	var upstreamHost string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"url":"https://` + upstreamHost + `/api"}`))
+		w.Write([]byte(`{"url":"https://` + upstreamHost + `/api"}`)) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -1054,10 +1054,10 @@ func TestSetFallbackProxy_RewriteContentNonHTML(t *testing.T) {
 	ServeFallback(rec, req)
 
 	// JSON should not be rewritten.
-	if bytes.Contains([]byte(rec.Body.String()), []byte("my-site.com")) {
+	if bytes.Contains(rec.Body.Bytes(), []byte("my-site.com")) {
 		t.Errorf("non-HTML body should not be rewritten\nbody: %s", rec.Body.String())
 	}
-	if !bytes.Contains([]byte(rec.Body.String()), []byte(upstreamHost)) {
+	if !bytes.Contains(rec.Body.Bytes(), []byte(upstreamHost)) {
 		t.Errorf("non-HTML body should contain upstream host\nbody: %s", rec.Body.String())
 	}
 }
@@ -1069,7 +1069,7 @@ func TestSetFallbackProxy_RewriteContentAcceptEncoding_ClientGzip(t *testing.T) 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAE = r.Header.Get("Accept-Encoding")
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1096,7 +1096,7 @@ func TestSetFallbackProxy_RewriteContentAcceptEncoding_ClientNoGzip(t *testing.T
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAE = r.Header.Get("Accept-Encoding")
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1123,7 +1123,7 @@ func TestSetFallbackProxy_RewriteContent_RecompressGzip(t *testing.T) {
 	var upstreamHost string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`<html><a href="https://` + upstreamHost + `/test">link</a></html>`))
+		w.Write([]byte(`<html><a href="https://` + upstreamHost + `/test">link</a></html>`)) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -1149,7 +1149,7 @@ func TestSetFallbackProxy_RewriteContent_RecompressGzip(t *testing.T) {
 		t.Fatalf("gzip reader: %v", err)
 	}
 	body, _ := io.ReadAll(gr)
-	gr.Close()
+	gr.Close() //nolint:errcheck
 	if !bytes.Contains(body, []byte("http://my-site.com/test")) {
 		t.Errorf("decompressed body should contain rewritten URL\nbody: %s", body)
 	}
@@ -1167,8 +1167,8 @@ func TestSetFallbackProxy_RewriteContent_NoRecompressWhenClientNoGzip(t *testing
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Set("Content-Encoding", "gzip")
 		gw := gzip.NewWriter(w)
-		gw.Write([]byte(`<html><a href="https://` + upstreamHost + `/test">link</a></html>`))
-		gw.Close()
+		gw.Write([]byte(`<html><a href="https://` + upstreamHost + `/test">link</a></html>`)) //nolint:errcheck
+		gw.Close()                                                                            //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost = upstream.Listener.Addr().String()
@@ -1234,7 +1234,7 @@ func TestSetFallbackProxy_RewriteOrigin(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotOrigin = r.Header.Get("Origin")
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost := upstream.Listener.Addr().String()
@@ -1264,7 +1264,7 @@ func TestSetFallbackProxy_RewriteReferer(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotReferer = r.Header.Get("Referer")
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 	upstreamHost := upstream.Listener.Addr().String()
@@ -1293,7 +1293,7 @@ func TestSetFallbackProxy_OtherHostOriginUnchanged(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotOrigin = r.Header.Get("Origin")
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1318,7 +1318,7 @@ func TestSetFallbackProxy_OtherHostOriginUnchanged(t *testing.T) {
 func TestSetFallbackProxy_NoOriginNoError(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1347,14 +1347,14 @@ func TestSetFallbackProxy_NoOriginNoError(t *testing.T) {
 func TestSetFallbackProxy_CDNRoute(t *testing.T) {
 	var gotHost, gotPath string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("upstream"))
+		w.Write([]byte("upstream")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
 	cdnServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHost = r.Host
 		gotPath = r.URL.Path
-		w.Write([]byte("cdn-content"))
+		w.Write([]byte("cdn-content")) //nolint:errcheck
 	}))
 	defer cdnServer.Close()
 	cdnHost := cdnServer.Listener.Addr().String()
@@ -1393,7 +1393,7 @@ func TestSetFallbackProxy_CDNRouteDisallowedHost(t *testing.T) {
 	var gotPath string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		w.Write([]byte("upstream"))
+		w.Write([]byte("upstream")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1424,7 +1424,7 @@ func TestSetFallbackProxy_CDNHTMLRewrite(t *testing.T) {
 	cdnHost := "cdn.example.com"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`<html><link rel="stylesheet" href="https://` + cdnHost + `/assets/foo.css">` +
+		w.Write([]byte(`<html><link rel="stylesheet" href="https://` + cdnHost + `/assets/foo.css">` + //nolint:errcheck
 			`<script src="https://` + cdnHost + `/assets/bar.js"></script></html>`))
 	}))
 	defer upstream.Close()
@@ -1464,7 +1464,7 @@ func TestSetFallbackProxy_CDNCSPRewrite(t *testing.T) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; style-src 'self' https://"+cdnHost+" "+cdnHost+"/assets/; script-src "+cdnHost)
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1497,7 +1497,7 @@ func TestSetFallbackProxy_CDNNotConfigured(t *testing.T) {
 	cdnHost := "cdn.example.com"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`<html><link href="https://` + cdnHost + `/foo.css"></html>`))
+		w.Write([]byte(`<html><link href="https://` + cdnHost + `/foo.css"></html>`)) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1526,7 +1526,7 @@ func TestSetFallbackProxy_CDNSubdomainRoute(t *testing.T) {
 	cdnParent := "githubassets.com"
 	cdnSub := "github.githubassets.com"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("upstream"))
+		w.Write([]byte("upstream")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1623,7 +1623,7 @@ func TestSetFallbackProxy_CDNSubdomainHTMLRewrite(t *testing.T) {
 	cdnSub := "github.githubassets.com"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`<html><link rel="stylesheet" href="https://` + cdnSub + `/assets/foo.css">` +
+		w.Write([]byte(`<html><link rel="stylesheet" href="https://` + cdnSub + `/assets/foo.css">` + //nolint:errcheck
 			`<link rel="stylesheet" href="https://` + cdnParent + `/assets/bar.css"></html>`))
 	}))
 	defer upstream.Close()
@@ -1668,7 +1668,7 @@ func TestSetFallbackProxy_CDNNonMatchingSubdomain(t *testing.T) {
 	fakeHost := "notgithubassets.com"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(`<html><link href="https://` + fakeHost + `/foo.css"></html>`))
+		w.Write([]byte(`<html><link href="https://` + fakeHost + `/foo.css"></html>`)) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1706,7 +1706,7 @@ func TestSetFallbackProxy_CDNCSPSubdomainRewrite(t *testing.T) {
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; style-src 'self' https://"+cdnSub+" "+cdnSub+"/assets/ "+
 				cdnSub+" https://"+cdnParent+" "+cdnParent+"/assets/")
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1758,7 +1758,7 @@ func TestSetFallbackProxy_CSPRewrittenEvenWhenBodyUnreadable(t *testing.T) {
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'none'; style-src 'unsafe-inline' "+cdnSub+" https://"+cdnSub+
 				"; script-src "+cdnSub)
-		w.Write([]byte("some brotli content that cannot be decompressed"))
+		w.Write([]byte("some brotli content that cannot be decompressed")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1793,7 +1793,7 @@ func TestSetFallbackProxy_CDNCSPTrailingSlash(t *testing.T) {
 		// CSP with bare host (no path) — should get trailing "/" after rewrite.
 		w.Header().Set("Content-Security-Policy",
 			"style-src 'unsafe-inline' "+cdnSub+"; script-src https://"+cdnSub)
-		w.Write([]byte("<html></html>"))
+		w.Write([]byte("<html></html>")) //nolint:errcheck
 	}))
 	defer upstream.Close()
 
@@ -1828,7 +1828,7 @@ func TestSetFallbackProxy_NonRewritableContentType(t *testing.T) {
 	cdnHost := "github.githubassets.com"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/javascript")
-		w.Write([]byte(`fetch("https://` + cdnHost + `/data.js");`))
+		w.Write([]byte(`fetch("https://` + cdnHost + `/data.js");`)) //nolint:errcheck
 	}))
 	defer upstream.Close()
 

--- a/server/handler/reject_test.go
+++ b/server/handler/reject_test.go
@@ -76,7 +76,7 @@ func postBootstrap(t *testing.T, tr *http.Transport, url, saltB64 string, body i
 	require.NoError(t, err)
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	resp.Body.Close()
+	resp.Body.Close() //nolint:errcheck
 	return resp, b
 }
 
@@ -106,7 +106,7 @@ func TestServeHTTP_HandshakeTimeout408(t *testing.T) {
 	salt, err := crypto.GenerateSalt()
 	require.NoError(t, err)
 	pr, pw := io.Pipe()
-	defer pr.Close()
+	defer pr.Close() //nolint:errcheck
 
 	resp, body := postBootstrap(t, tr, srv.URL+sharedconfig.EndpointTCP, saltToB64(salt), pr)
 	_ = pw.Close()

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -40,7 +40,7 @@ func TestUTLSDialUsesHTTP2(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if got := <-protoCh; got != "HTTP/2.0" {

--- a/transport/http2/stream_test.go
+++ b/transport/http2/stream_test.go
@@ -25,14 +25,14 @@ func newTestStream() (*HTTP2Stream, *io.PipeReader) {
 
 func TestHTTP2Stream_WriteSurfacesRoundTripErr(t *testing.T) {
 	s, pr := newTestStream()
-	defer pr.Close()
-	defer s.Close()
+	defer pr.Close() //nolint:errcheck
+	defer s.Close()  //nolint:errcheck
 
 	sentinel := errors.New("tls: handshake failure")
 	s.setRoundTripErr(sentinel)
 
 	// Close the reader so the next Write fails with io.ErrClosedPipe.
-	pr.Close()
+	pr.Close() //nolint:errcheck
 
 	_, err := s.Write([]byte("payload"))
 	if err == nil {
@@ -48,11 +48,11 @@ func TestHTTP2Stream_WriteSurfacesRoundTripErr(t *testing.T) {
 
 func TestHTTP2Stream_WriteNoRoundTripErr(t *testing.T) {
 	s, pr := newTestStream()
-	defer pr.Close()
-	defer s.Close()
+	defer pr.Close() //nolint:errcheck
+	defer s.Close()  //nolint:errcheck
 
 	// rtErr remains nil — Write should return the bare io.ErrClosedPipe.
-	pr.Close()
+	pr.Close() //nolint:errcheck
 
 	_, err := s.Write([]byte("payload"))
 	if err == nil {
@@ -68,8 +68,8 @@ func TestHTTP2Stream_WriteNoRoundTripErr(t *testing.T) {
 
 func TestHTTP2Stream_WriteSuccess(t *testing.T) {
 	s, pr := newTestStream()
-	defer pr.Close()
-	defer s.Close()
+	defer pr.Close() //nolint:errcheck
+	defer s.Close()  //nolint:errcheck
 
 	done := make(chan struct{})
 	go func() {
@@ -97,8 +97,8 @@ func TestHTTP2Stream_WriteSuccess(t *testing.T) {
 
 func TestSetRoundTripErr_Concurrent(t *testing.T) {
 	s, pr := newTestStream()
-	defer pr.Close()
-	defer s.Close()
+	defer pr.Close() //nolint:errcheck
+	defer s.Close()  //nolint:errcheck
 
 	var wg sync.WaitGroup
 	for range 100 {
@@ -122,8 +122,8 @@ func TestSetRoundTripErr_Concurrent(t *testing.T) {
 func TestHTTP2Stream_ConnBytesCountsBothDirections(t *testing.T) {
 	slot := &transportSlot{}
 	s, pr := newTestStream()
-	defer pr.Close()
-	defer s.Close()
+	defer pr.Close() //nolint:errcheck
+	defer s.Close()  //nolint:errcheck
 	s.slot = slot
 	s.startTime = time.Now()
 
@@ -144,8 +144,8 @@ func TestHTTP2Stream_ConnBytesCountsBothDirections(t *testing.T) {
 // trackWrite after it started counting connection bytes.
 func TestHTTP2Stream_TrackWriteNilSlotNoOp(t *testing.T) {
 	s, pr := newTestStream()
-	defer pr.Close()
-	defer s.Close()
+	defer pr.Close() //nolint:errcheck
+	defer s.Close()  //nolint:errcheck
 
 	s.trackWrite(1 << 20) // must not panic
 
@@ -172,7 +172,7 @@ func TestHTTP2Stream_RecordsPathRTTOnResponse(t *testing.T) {
 	t.Run("stamped stream records the sample", func(t *testing.T) {
 		stats.ResetCounters()
 		s, respCh := newStream()
-		defer s.Close()
+		defer s.Close() //nolint:errcheck
 
 		s.MarkBootstrapSent()
 		time.Sleep(2 * time.Millisecond)
@@ -198,7 +198,7 @@ func TestHTTP2Stream_RecordsPathRTTOnResponse(t *testing.T) {
 	t.Run("unstamped stream records nothing", func(t *testing.T) {
 		stats.ResetCounters()
 		s, respCh := newStream()
-		defer s.Close()
+		defer s.Close() //nolint:errcheck
 
 		respCh <- roundTripResult{
 			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))},
@@ -221,8 +221,8 @@ func TestHTTP2Stream_RecordsPathRTTOnResponse(t *testing.T) {
 // idle streams (relay.BidirectionalWithDrain).
 func TestHTTP2Stream_SlotDraining(t *testing.T) {
 	s, pr := newTestStream()
-	defer pr.Close()
-	defer s.Close()
+	defer pr.Close() //nolint:errcheck
+	defer s.Close()  //nolint:errcheck
 
 	slot := &transportSlot{}
 	s.slot = slot

--- a/util/sys_test.go
+++ b/util/sys_test.go
@@ -72,7 +72,7 @@ func TestIsTunSubnetAddr(t *testing.T) {
 		ip   string
 		want bool
 	}{
-		{"198.18.0.1", true},   // default TunIP
+		{"198.18.0.1", true}, // default TunIP
 		{"198.18.255.255", true},
 		{"198.19.255.255", true}, // /15 upper bound
 		{"198.17.255.255", false},

--- a/util/sys_windows_test.go
+++ b/util/sys_windows_test.go
@@ -11,8 +11,8 @@ func TestDefaultRouteCandidates(t *testing.T) {
 	// easyss TUN routes (1.0.0.0/7 … and the netsh-added 0.0.0.0/0 on the
 	// TUN device) plus two physical default routes with different metrics.
 	rows := []mibIpforwardrow{
-		{dest: 0x01000000, mask: 0xFE000000, ifIndex: 10, metric1: 5},  // TUN 1.0.0.0/7
-		{dest: 0x80000000, mask: 0x80000000, ifIndex: 10, metric1: 5},  // TUN 128.0.0.0/1
+		{dest: 0x01000000, mask: 0xFE000000, ifIndex: 10, metric1: 5},                      // TUN 1.0.0.0/7
+		{dest: 0x80000000, mask: 0x80000000, ifIndex: 10, metric1: 5},                      // TUN 128.0.0.0/1
 		{dest: 0x00000000, mask: 0x00000000, ifIndex: 10, metric1: 6, nextHop: 0x010214AC}, // TUN default (netsh)
 		{dest: 0x00000000, mask: 0x00000000, ifIndex: 5, metric1: 35, nextHop: 0xC0A80101}, // physical default
 		{dest: 0x00000000, mask: 0x00000000, ifIndex: 9, metric1: 25, nextHop: 0xC0A80101}, // physical default, lower metric


### PR DESCRIPTION
## 背景

原 `.golangci.yml` 中配置了 `run.tests: false`，导致 golangci-lint 跳过所有 `_test.go` 文件。本次将其改为 `tests: true`，让测试文件也参与 lint 检查。

## 改动内容

1. **`.golangci.yml`**：`run.tests` 从 `false` 改为 `true`
2. **修复测试文件中的 lint 问题**（启用后新暴露出的 44 个问题）：
   - **errcheck**（39 处）：为测试中未检查返回值的 `Close`/`Write`/`Set` 等调用补充 `//nolint:errcheck`，遵循代码库既有约定
   - **gofmt**（多处）：修复 import 排序、注释对齐等格式问题
   - **staticcheck S1030**（2 处）：`fallback_test.go` 中改用 `rec.Body.Bytes()` 替代 `[]byte(rec.Body.String())`

## 涉及文件

`client`、`cmd/easyss`、`log`、`runner`、`server/handler`、`transport/http2`、`util` 下共 17 个测试文件。

## 验证

- `make lint`：0 issues
- 相关包测试全部通过：`transport/http2`、`server/handler`、`client/dns`、`client/proxy`、`runner`、`log`、`util`、`client/router`