### PR TITLE
feat: add client self-update via tray menu

### DIFF
--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nange/easyss/v3/pprof"
 	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/runner"
+	"github.com/nange/easyss/v3/selfupdate"
 	"github.com/nange/easyss/v3/stats"
 	"github.com/nange/easyss/v3/util"
 	"github.com/nange/easyss/v3/version"
@@ -87,6 +88,10 @@ func main() {
 	if tunHelper {
 		os.Exit(runTunHelper(tunHTTPAddr, tunFDSocket, logFile, sc.LogLevel))
 	}
+
+	// Remove leftovers from a previous self-update (the renamed old binary
+	// kept for Windows/macOS, stale staging directories).
+	selfupdate.CleanupOld()
 
 	// On macOS the app is often launched by Finder/launchd with cwd=/,
 	// so a relative config path is first looked up in the cwd and then

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -12,6 +12,7 @@ import (
 	"os/user"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogpu/systray"
@@ -20,6 +21,7 @@ import (
 	"github.com/nange/easyss/v3/icon"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/selfupdate"
 	"github.com/nange/easyss/v3/util"
 )
 
@@ -39,6 +41,12 @@ type TrayApp struct {
 	proxyRuleItems  map[string]*systray.MenuItem
 	logLevelItems   map[string]*systray.MenuItem
 	autoStartItem   *systray.MenuItem
+
+	// Self-update state (see tray_update.go).
+	updateItem    *systray.MenuItem
+	updateState   atomic.Int32
+	pendingUpdate *selfupdate.Release
+	updateMu      sync.Mutex
 
 	// UWP loopback exemption menu (Windows only).
 	uwpMu    sync.Mutex     //nolint:unused // used in uwp_windows.go
@@ -88,6 +96,7 @@ func (a *TrayApp) buildTray() {
 	a.autoStartItem = root.AddCheckbox("开机启动", IsAutoStartEnabled(), a.toggleAutoStart)
 	root.AddSeparator()
 
+	a.updateItem = root.Add("检查更新", a.onUpdateClicked)
 	root.Add("退出", a.exitApp)
 
 	a.tray = systray.New()
@@ -111,6 +120,7 @@ func (a *TrayApp) buildTray() {
 
 	a.startLocalService()
 	go a.statsRefresher()
+	go a.autoCheckUpdate()
 }
 
 func (a *TrayApp) trayExit() {

--- a/cmd/easyss/tray_update.go
+++ b/cmd/easyss/tray_update.go
@@ -1,0 +1,161 @@
+//go:build !headless
+
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/nange/easyss/v3/log"
+	"github.com/nange/easyss/v3/selfupdate"
+	"github.com/nange/easyss/v3/version"
+)
+
+const (
+	// updateCheckDelay is how long after startup the automatic silent
+	// update check runs.
+	updateCheckDelay = time.Minute
+	// updateMenuReset is how long a transient result (failure or
+	// up-to-date) stays visible before the item resets.
+	updateMenuReset = 4 * time.Second
+)
+
+// Tray update state machine states.
+const (
+	updateStateIdle int32 = iota
+	updateStateChecking
+	updateStateAvailable
+	updateStateDownloading
+)
+
+func (a *TrayApp) onUpdateClicked() {
+	go func() {
+		switch a.updateState.Load() {
+		case updateStateIdle:
+			a.checkUpdate(true)
+		case updateStateAvailable:
+			a.downloadAndInstall()
+		default: // checking or downloading: extra clicks are ignored
+		}
+	}()
+}
+
+// autoCheckUpdate performs one silent update check shortly after startup.
+// Development builds (no injected git tag) are skipped.
+func (a *TrayApp) autoCheckUpdate() {
+	if version.Tag() == "" {
+		return
+	}
+	select {
+	case <-time.After(updateCheckDelay):
+		a.checkUpdate(false)
+	case <-a.closing:
+	}
+}
+
+func (a *TrayApp) checkUpdate(interactive bool) {
+	if !a.updateState.CompareAndSwap(updateStateIdle, updateStateChecking) {
+		return
+	}
+	if interactive {
+		a.setUpdateItem("检查更新中...", true)
+	}
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), selfupdate.CheckTimeout)
+		defer cancel()
+
+		rel, err := selfupdate.CheckLatest(ctx, selfupdate.NewClient(a.cfg.Local.HTTPPort))
+		if err != nil {
+			log.Error("[SYSTRAY] check update", "err", err)
+			if interactive {
+				a.setUpdateItem("检查更新失败", true)
+			}
+			a.scheduleUpdateMenuReset()
+			return
+		}
+
+		if !selfupdate.HasNewVersion(version.Tag(), rel.TagName) {
+			log.Info("[SYSTRAY] check update: already up to date", "version", version.Tag())
+			if interactive {
+				a.setUpdateItem("已是最新版本("+version.Tag()+")", true)
+			}
+			a.scheduleUpdateMenuReset()
+			return
+		}
+
+		a.updateMu.Lock()
+		a.pendingUpdate = rel
+		a.updateMu.Unlock()
+		a.updateState.Store(updateStateAvailable)
+		a.setUpdateItem("发现新版本 "+rel.TagName+"，点击更新", false)
+		a.tray.ShowNotification("Easyss", "发现新版本 "+rel.TagName+"，可在托盘菜单中点击更新")
+		log.Info("[SYSTRAY] new version available", "current", version.Tag(), "latest", rel.TagName)
+	}()
+}
+
+func (a *TrayApp) downloadAndInstall() {
+	a.updateMu.Lock()
+	rel := a.pendingUpdate
+	a.updateMu.Unlock()
+	if rel == nil {
+		return
+	}
+	if !a.updateState.CompareAndSwap(updateStateAvailable, updateStateDownloading) {
+		return
+	}
+	a.setUpdateItem("正在下载 "+rel.TagName+" ...", true)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), selfupdate.DownloadTimeout)
+		defer cancel()
+
+		if err := selfupdate.Update(ctx, a.cfg.Local.HTTPPort, rel); err != nil {
+			log.Error("[SYSTRAY] download and install update", "tag", rel.TagName, "err", err)
+			a.setUpdateItem("更新 "+rel.TagName+" 失败，点击重试", false)
+			a.updateState.Store(updateStateAvailable)
+			a.tray.ShowNotification("Easyss", "更新失败："+err.Error())
+			return
+		}
+
+		log.Info("[SYSTRAY] update installed, restarting", "tag", rel.TagName)
+		a.tray.ShowNotification("Easyss", "已更新到 "+rel.TagName+"，正在重启...")
+
+		_ = a.setSysProxyOff()
+		a.closeService()
+		// Release before relaunch so the new process never races the old
+		// one for the singleton mutex.
+		releaseSingletonLock()
+
+		if err := selfupdate.Restart(); err != nil {
+			// The new binary is already in place; keep the old version
+			// running in-process and let the user restart manually.
+			log.Error("[SYSTRAY] restart after update", "err", err)
+			a.tray.ShowNotification("Easyss", "重启失败，请手动重启应用完成更新")
+			if err := a.restartService(a.cfg.Clone()); err != nil {
+				log.Error("[SYSTRAY] restore service after failed restart", "err", err)
+			}
+			a.setUpdateItem("更新成功，重启失败，请手动重启", false)
+			a.updateState.Store(updateStateAvailable)
+			return
+		}
+		// The new process is running; terminate this one.
+		os.Exit(0)
+	}()
+}
+
+// scheduleUpdateMenuReset returns the update item to its idle label after a
+// transient result (failure / up-to-date) has been visible for a moment.
+func (a *TrayApp) scheduleUpdateMenuReset() {
+	time.AfterFunc(updateMenuReset, func() {
+		if a.updateState.CompareAndSwap(updateStateChecking, updateStateIdle) {
+			a.setUpdateItem("检查更新", false)
+		}
+	})
+}
+
+func (a *TrayApp) setUpdateItem(label string, disabled bool) {
+	a.updateItem.SetLabel(label)
+	a.updateItem.SetDisabled(disabled)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nange/easyss/v3
 go 1.27
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/caddyserver/certmagic v0.25.4
 	github.com/coocood/freecache v1.2.7
 	github.com/gogpu/systray v0.3.0
@@ -43,7 +44,6 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/ClickHouse/clickhouse-go-linter v1.2.1 // indirect
 	github.com/Djarvur/go-err113 v0.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/MirrexOne/unqueryvet v1.5.4 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1 // indirect
 	github.com/ajg/form v1.7.1 // indirect

--- a/selfupdate/client.go
+++ b/selfupdate/client.go
@@ -1,0 +1,90 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const userAgent = "easyss-selfupdate"
+
+// Client fetches release data over the local easyss HTTP proxy first and
+// falls back to a direct connection when the proxy fails.
+type Client struct {
+	proxy  *http.Client
+	direct *http.Client
+}
+
+// NewClient builds a fetch client; localHTTPPort <= 0 disables the proxy path.
+func NewClient(localHTTPPort int) *Client {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	newTransport := func(proxyFn func(*http.Request) (*url.URL, error)) *http.Transport {
+		return &http.Transport{
+			Proxy:                 proxyFn,
+			DialContext:           dialer.DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+		}
+	}
+
+	c := &Client{
+		direct: &http.Client{Transport: newTransport(http.ProxyFromEnvironment)},
+	}
+	if localHTTPPort > 0 {
+		proxyURL := &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(localHTTPPort)),
+		}
+		c.proxy = &http.Client{Transport: newTransport(http.ProxyURL(proxyURL))}
+	}
+	return c
+}
+
+// Get issues a GET request, trying the local proxy first and then the
+// direct connection, and returns the first successful response. The caller
+// must close the response body. extraHeaders are applied to every attempt.
+func (c *Client) Get(ctx context.Context, rawURL string, extraHeaders map[string]string) (*http.Response, error) {
+	clients := make([]*http.Client, 0, 2)
+	if c.proxy != nil {
+		clients = append(clients, c.proxy)
+	}
+	clients = append(clients, c.direct)
+
+	var lastErr error
+	for _, hc := range clients {
+		resp, err := doRequest(hc, ctx, rawURL, extraHeaders)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return resp, nil
+	}
+	return nil, lastErr
+}
+
+func doRequest(hc *http.Client, ctx context.Context, rawURL string, extraHeaders map[string]string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := hc.Do(req) //nolint:gosec // request URL comes from our own release API response
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("unexpected http status %d from %s: %s", resp.StatusCode, rawURL, string(body))
+	}
+	return resp, nil
+}

--- a/selfupdate/download.go
+++ b/selfupdate/download.go
@@ -69,8 +69,8 @@ func Unzip(zipPath, destDir string) error {
 	destClean := filepath.Clean(destDir) + string(os.PathSeparator)
 	var total uint64
 	for _, f := range r.File {
-		target, ok := zipTarget(destDir, destClean, f.Name)
-		if !ok {
+		target := filepath.Join(destDir, f.Name)
+		if !strings.HasPrefix(target, destClean) {
 			continue
 		}
 		info := f.FileInfo()
@@ -92,16 +92,6 @@ func Unzip(zipPath, destDir string) error {
 	return nil
 }
 
-// zipTarget maps a zip entry name onto a path inside destDir, rejecting
-// entries that escape it.
-func zipTarget(destDir, destClean, name string) (string, bool) {
-	target := filepath.Clean(filepath.Join(destDir, name))
-	if target != filepath.Clean(destDir) && !strings.HasPrefix(target, destClean) {
-		return "", false
-	}
-	return target, true
-}
-
 func unzipFile(f *zip.File, target string) error {
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { //nolint:gosec // directory, not secret
 		return fmt.Errorf("create dir %s: %w", filepath.Dir(target), err)
@@ -113,7 +103,7 @@ func unzipFile(f *zip.File, target string) error {
 	defer func() { _ = src.Close() }()
 
 	dst, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
-	if err != nil { //nolint:gosec // zip entry path is sanitized by zipTarget
+	if err != nil { //nolint:gosec // zip entry path is validated against destDir by the caller
 		return fmt.Errorf("create %s: %w", target, err)
 	}
 	if _, err := io.Copy(dst, src); err != nil {

--- a/selfupdate/download.go
+++ b/selfupdate/download.go
@@ -80,19 +80,22 @@ func Unzip(zipPath, destDir string) error {
 				return fmt.Errorf("create dir %s: %w", target, err)
 			}
 		case info.Mode().IsRegular():
-			if err := unzipFile(f, target); err != nil {
+			if total+f.UncompressedSize64 > maxUncompressedSize {
+				return errors.New("release zip exceeds decompressed size limit")
+			}
+			if err := unzipFile(f, target, maxUncompressedSize-total); err != nil {
 				return err
 			}
 			total += f.UncompressedSize64
-			if total > maxUncompressedSize {
-				return errors.New("release zip exceeds decompressed size limit")
-			}
 		}
 	}
 	return nil
 }
 
-func unzipFile(f *zip.File, target string) error {
+// unzipFile extracts a single regular file, bounding the bytes actually
+// written to disk with maxSize so a lying zip header cannot exceed the
+// decompression budget.
+func unzipFile(f *zip.File, target string, maxSize uint64) error {
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { //nolint:gosec // directory, not secret
 		return fmt.Errorf("create dir %s: %w", filepath.Dir(target), err)
 	}
@@ -106,10 +109,16 @@ func unzipFile(f *zip.File, target string) error {
 	if err != nil { //nolint:gosec // zip entry path is validated against destDir by the caller
 		return fmt.Errorf("create %s: %w", target, err)
 	}
-	if _, err := io.Copy(dst, src); err != nil {
+	n, err := io.Copy(dst, io.LimitReader(src, int64(maxSize)))
+	if err != nil {
 		_ = dst.Close()
 		_ = os.Remove(target)
 		return fmt.Errorf("extract %s: %w", f.Name, err)
+	}
+	if uint64(n) >= maxSize {
+		_ = dst.Close()
+		_ = os.Remove(target)
+		return fmt.Errorf("extract %s: entry exceeds decompressed size limit", f.Name)
 	}
 	if err := dst.Close(); err != nil {
 		return fmt.Errorf("close %s: %w", target, err)

--- a/selfupdate/download.go
+++ b/selfupdate/download.go
@@ -1,0 +1,137 @@
+package selfupdate
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxUncompressedSize bounds the total decompressed size of a release zip.
+const maxUncompressedSize = 512 << 20
+
+// DownloadAsset streams the asset into a temporary zip file and returns its
+// path. The caller is responsible for removing the file.
+func (c *Client) DownloadAsset(ctx context.Context, a *Asset) (string, error) {
+	tmp, err := os.CreateTemp("", "easyss-update-*.zip")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+
+	remove := func() { _ = tmp.Close(); _ = os.Remove(tmp.Name()) }
+
+	resp, err := c.Get(ctx, a.BrowserDownloadURL, nil)
+	if err != nil {
+		remove()
+		return "", fmt.Errorf("download %s: %w", a.Name, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_, copyErr := io.Copy(tmp, resp.Body) //nolint:gosec // decompression bomb is bounded by asset size check below
+	closeErr := tmp.Close()
+	switch {
+	case copyErr != nil:
+		remove()
+		return "", fmt.Errorf("download %s: %w", a.Name, copyErr)
+	case closeErr != nil:
+		remove()
+		return "", fmt.Errorf("save %s: %w", a.Name, closeErr)
+	}
+
+	if a.Size > 0 {
+		info, statErr := tmp.Stat()
+		if statErr != nil {
+			remove()
+			return "", fmt.Errorf("stat downloaded file: %w", statErr)
+		}
+		if info.Size() != a.Size {
+			remove()
+			return "", fmt.Errorf("downloaded %s size %d != expected %d", a.Name, info.Size(), a.Size)
+		}
+	}
+	return tmp.Name(), nil
+}
+
+// Unzip extracts a release zip into destDir. Only regular file and directory
+// entries are extracted; path traversal (zip-slip) entries are rejected. The
+// zip CRC checksum is verified automatically while copying.
+func Unzip(zipPath, destDir string) error {
+	r, err := zip.OpenReader(zipPath) //nolint:gosec // path comes from our own temp file
+	if err != nil {
+		return fmt.Errorf("open zip %s: %w", zipPath, err)
+	}
+	defer func() { _ = r.Close() }()
+
+	destClean := filepath.Clean(destDir) + string(os.PathSeparator)
+	var total uint64
+	for _, f := range r.File {
+		target, ok := zipTarget(destDir, destClean, f.Name)
+		if !ok {
+			continue
+		}
+		info := f.FileInfo()
+		switch {
+		case info.IsDir():
+			if err := os.MkdirAll(target, 0o755); err != nil { //nolint:gosec // directory, not secret
+				return fmt.Errorf("create dir %s: %w", target, err)
+			}
+		case info.Mode().IsRegular():
+			if err := unzipFile(f, target); err != nil {
+				return err
+			}
+			total += f.UncompressedSize64
+			if total > maxUncompressedSize {
+				return errors.New("release zip exceeds decompressed size limit")
+			}
+		}
+	}
+	return nil
+}
+
+// zipTarget maps a zip entry name onto a path inside destDir, rejecting
+// entries that escape it.
+func zipTarget(destDir, destClean, name string) (string, bool) {
+	target := filepath.Clean(filepath.Join(destDir, name))
+	if target != filepath.Clean(destDir) && !strings.HasPrefix(target, destClean) {
+		return "", false
+	}
+	return target, true
+}
+
+func unzipFile(f *zip.File, target string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { //nolint:gosec // directory, not secret
+		return fmt.Errorf("create dir %s: %w", filepath.Dir(target), err)
+	}
+	src, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("open zip entry %s: %w", f.Name, err)
+	}
+	defer func() { _ = src.Close() }()
+
+	dst, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
+	if err != nil { //nolint:gosec // zip entry path is sanitized by zipTarget
+		return fmt.Errorf("create %s: %w", target, err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		_ = os.Remove(target)
+		return fmt.Errorf("extract %s: %w", f.Name, err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", target, err)
+	}
+
+	// Keep executables executable even if the zip lost the unix permission
+	// bits when it was created.
+	mode := f.Mode().Perm()
+	if mode&0o111 != 0 && mode != 0o755 {
+		if err := os.Chmod(target, 0o755); err != nil { //nolint:gosec // executable needs 0755
+			return fmt.Errorf("chmod %s: %w", target, err)
+		}
+	}
+	return nil
+}

--- a/selfupdate/github.go
+++ b/selfupdate/github.go
@@ -1,0 +1,82 @@
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// Asset is a downloadable file attached to a release.
+type Asset struct {
+	Name string `json:"name"`
+	// BrowserDownloadURL is the direct download URL.
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+// Release is the subset of the GitHub release API response we need.
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Name    string  `json:"name"`
+	Assets  []Asset `json:"assets"`
+}
+
+// gitDescribeSuffix matches the "-<n>-g<sha>" tail git describe appends when
+// the built commit is ahead of the tag, e.g. "v3.0.1-5-gabc1234".
+var gitDescribeSuffix = regexp.MustCompile(`-\d+-g[0-9a-f]+$`)
+
+// CheckLatest fetches the latest published release from GitHub. The
+// /releases/latest endpoint only returns full releases: pre-releases and
+// drafts are excluded by GitHub itself.
+func CheckLatest(ctx context.Context, c *Client) (*Release, error) {
+	resp, err := c.Get(ctx, repoLatestURL, map[string]string{
+		"Accept": "application/vnd.github+json",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query latest release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode latest release: %w", err)
+	}
+	if rel.TagName == "" {
+		return nil, fmt.Errorf("latest release response has no tag")
+	}
+	return &rel, nil
+}
+
+// HasNewVersion reports whether latestTag is newer than currentTag. An empty
+// currentTag (development build) always updates. A git describe suffix on
+// currentTag is ignored so that a build cut slightly after a release is not
+// offered an update to that same release. Tags that are not valid semver
+// fall back to plain inequality.
+func HasNewVersion(currentTag, latestTag string) bool {
+	if currentTag == "" {
+		return true
+	}
+	currentTag = gitDescribeSuffix.ReplaceAllString(currentTag, "")
+
+	curVer, curErr := semver.NewVersion(currentTag)
+	latVer, latErr := semver.NewVersion(latestTag)
+	if curErr != nil || latErr != nil {
+		return currentTag != latestTag
+	}
+	return latVer.GreaterThan(curVer)
+}
+
+// PickAsset returns the release asset for the given platform, following the
+// CI naming scheme (easyss-<goos>-<goarch>.zip), or nil when absent.
+func PickAsset(rel *Release, goos, goarch string) *Asset {
+	name := fmt.Sprintf("easyss-%s-%s.zip", goos, goarch)
+	for i := range rel.Assets {
+		if rel.Assets[i].Name == name {
+			return &rel.Assets[i]
+		}
+	}
+	return nil
+}

--- a/selfupdate/install.go
+++ b/selfupdate/install.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -68,6 +69,29 @@ func Install(stagingDir string) error {
 	return installAt(exe, stagingDir)
 }
 
+// permissionHint rewrites a permission failure into a user-friendly message,
+// since the reason is otherwise opaque (e.g. Program Files on Windows or
+// /Applications on macOS).
+func permissionHint(action string, err error) error {
+	if os.IsPermission(err) {
+		return fmt.Errorf("%s: 安装目录无写权限，请以管理员身份运行后重试", action)
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+// clearQuarantine removes the macOS quarantine attribute from a freshly
+// installed app bundle so Gatekeeper does not block it on first launch. It
+// matches the README's manual `xattr -cr` step. Best-effort: a failure is
+// logged and does not fail the install.
+func clearQuarantine(path string) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	if err := exec.Command("xattr", "-cr", path).Run(); err != nil {
+		log.Warn("[UPDATE] clear quarantine attribute", "path", path, "err", err)
+	}
+}
+
 func installAt(exe, stagingDir string) error {
 	if bundle := appBundleRoot(exe); bundle != "" {
 		return installBundle(stagingDir, bundle)
@@ -82,11 +106,11 @@ func installAt(exe, stagingDir string) error {
 		old := exe + ".old"
 		_ = os.Remove(old)
 		if err := os.Rename(exe, old); err != nil {
-			return fmt.Errorf("rename running executable aside: %w", err)
+			return permissionHint("rename running executable aside", err)
 		}
 		if err := os.Rename(staged, exe); err != nil {
 			_ = os.Rename(old, exe) // rollback
-			return fmt.Errorf("move new executable into place: %w", err)
+			return permissionHint("move new executable into place", err)
 		}
 		return nil
 	}
@@ -96,7 +120,7 @@ func installAt(exe, stagingDir string) error {
 		return fmt.Errorf("chmod new executable: %w", err)
 	}
 	if err := os.Rename(staged, exe); err != nil {
-		return fmt.Errorf("replace executable: %w", err)
+		return permissionHint("replace executable", err)
 	}
 	return nil
 }
@@ -126,12 +150,13 @@ func installBundle(stagingDir, bundle string) error {
 	old := bundle + ".old"
 	_ = os.RemoveAll(old)
 	if err := os.Rename(bundle, old); err != nil {
-		return fmt.Errorf("move running bundle aside: %w", err)
+		return permissionHint("move running bundle aside", err)
 	}
 	if err := os.Rename(staged, bundle); err != nil {
 		_ = os.Rename(old, bundle) // rollback
-		return fmt.Errorf("move new bundle into place: %w", err)
+		return permissionHint("move new bundle into place", err)
 	}
+	clearQuarantine(bundle)
 	return nil
 }
 

--- a/selfupdate/install.go
+++ b/selfupdate/install.go
@@ -1,0 +1,184 @@
+package selfupdate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/nange/easyss/v3/log"
+)
+
+const stagingPrefix = ".easyss-update-"
+
+// resolvedExe returns the real path of the running executable, symlinks resolved.
+func resolvedExe() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve executable: %w", err)
+	}
+	if real, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = real
+	}
+	return exe, nil
+}
+
+// installTargetDir returns the directory that hosts the install artifact:
+// the parent of the .app bundle on macOS, otherwise the executable directory.
+func installTargetDir() (string, error) {
+	exe, err := resolvedExe()
+	if err != nil {
+		return "", err
+	}
+	if bundle := appBundleRoot(exe); bundle != "" {
+		return filepath.Dir(bundle), nil
+	}
+	return filepath.Dir(exe), nil
+}
+
+// appBundleRoot returns the .app bundle directory containing exePath, or an
+// empty string when the executable is not inside a macOS bundle.
+func appBundleRoot(exePath string) string {
+	dir := filepath.Dir(exePath)
+	if filepath.Base(dir) != "MacOS" {
+		return ""
+	}
+	contents := filepath.Dir(dir)
+	if filepath.Base(contents) != "Contents" {
+		return ""
+	}
+	bundle := filepath.Dir(contents)
+	if !strings.HasSuffix(bundle, ".app") {
+		return ""
+	}
+	return bundle
+}
+
+// Install moves the artifact staged in stagingDir over the current install
+// location. Windows cannot overwrite a running executable, so the running
+// binary is renamed aside (allowed) and removed on next start; unix replaces
+// the file atomically via rename; macOS swaps the whole .app bundle.
+func Install(stagingDir string) error {
+	exe, err := resolvedExe()
+	if err != nil {
+		return err
+	}
+	return installAt(exe, stagingDir)
+}
+
+func installAt(exe, stagingDir string) error {
+	if bundle := appBundleRoot(exe); bundle != "" {
+		return installBundle(stagingDir, bundle)
+	}
+
+	staged, err := stagedBinary(stagingDir)
+	if err != nil {
+		return err
+	}
+
+	if runtime.GOOS == "windows" {
+		old := exe + ".old"
+		_ = os.Remove(old)
+		if err := os.Rename(exe, old); err != nil {
+			return fmt.Errorf("rename running executable aside: %w", err)
+		}
+		if err := os.Rename(staged, exe); err != nil {
+			_ = os.Rename(old, exe) // rollback
+			return fmt.Errorf("move new executable into place: %w", err)
+		}
+		return nil
+	}
+
+	// unix: atomic replace over the running binary is allowed.
+	if err := os.Chmod(staged, 0o755); err != nil { //nolint:gosec // the client binary must stay executable
+		return fmt.Errorf("chmod new executable: %w", err)
+	}
+	if err := os.Rename(staged, exe); err != nil {
+		return fmt.Errorf("replace executable: %w", err)
+	}
+	return nil
+}
+
+// stagedBinary locates the client binary extracted into stagingDir.
+func stagedBinary(stagingDir string) (string, error) {
+	name := "easyss"
+	if runtime.GOOS == "windows" {
+		name = "easyss.exe"
+	}
+	p := filepath.Join(stagingDir, name)
+	info, err := os.Stat(p)
+	if err != nil || info.IsDir() {
+		return "", fmt.Errorf("staged binary %s not found", p)
+	}
+	return p, nil
+}
+
+// installBundle swaps the .app bundle containing the running process with
+// the bundle staged from the release zip.
+func installBundle(stagingDir, bundle string) error {
+	staged, err := stagedBundle(stagingDir)
+	if err != nil {
+		return err
+	}
+
+	old := bundle + ".old"
+	_ = os.RemoveAll(old)
+	if err := os.Rename(bundle, old); err != nil {
+		return fmt.Errorf("move running bundle aside: %w", err)
+	}
+	if err := os.Rename(staged, bundle); err != nil {
+		_ = os.Rename(old, bundle) // rollback
+		return fmt.Errorf("move new bundle into place: %w", err)
+	}
+	return nil
+}
+
+// stagedBundle locates the .app directory extracted into stagingDir.
+func stagedBundle(stagingDir string) (string, error) {
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		return "", fmt.Errorf("read staging dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() && strings.HasSuffix(e.Name(), ".app") {
+			return filepath.Join(stagingDir, e.Name()), nil
+		}
+	}
+	return "", errors.New("no .app bundle found in release zip")
+}
+
+// CleanupOld removes leftovers from a previous self-update: the renamed
+// running binary/bundle kept for Windows/macOS, and any staging directory a
+// crashed update may have left behind. It is best-effort and silent on error.
+func CleanupOld() {
+	exe, err := resolvedExe()
+	if err != nil {
+		return
+	}
+	dirs := []string{filepath.Dir(exe)}
+	if bundle := appBundleRoot(exe); bundle != "" {
+		dirs = append(dirs, filepath.Dir(bundle))
+	}
+
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			name := e.Name()
+			isStaging := strings.HasPrefix(name, stagingPrefix)
+			isOld := name == filepath.Base(exe)+".old" || strings.HasSuffix(name, ".app.old")
+			if !isStaging && !isOld {
+				continue
+			}
+			if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
+				log.Warn("[UPDATE] cleanup old artifact", "path", name, "err", err)
+			} else {
+				log.Info("[UPDATE] removed leftover from previous update", "path", name)
+			}
+		}
+	}
+}

--- a/selfupdate/restart.go
+++ b/selfupdate/restart.go
@@ -6,15 +6,23 @@ import (
 )
 
 // restartArgs rebuilds the original command line with daemon flags stripped
-// and --daemon=false appended so the new process does not re-daemonize.
+// and --daemon=false appended so the new process does not re-daemonize. Both
+// the "-daemon value" and "-daemon=value" spellings are removed.
 func restartArgs() []string {
 	var args []string
+	skipNext := false
 	for _, arg := range os.Args[1:] {
-		if arg == "-daemon" || arg == "--daemon" ||
-			strings.HasPrefix(arg, "-daemon=") || strings.HasPrefix(arg, "--daemon=") {
+		if skipNext {
+			skipNext = false
 			continue
 		}
-		args = append(args, arg)
+		switch {
+		case arg == "-daemon" || arg == "--daemon":
+			skipNext = true // drop the space-separated boolean value
+		case strings.HasPrefix(arg, "-daemon=") || strings.HasPrefix(arg, "--daemon="):
+		default:
+			args = append(args, arg)
+		}
 	}
 	return append(args, "--daemon=false")
 }

--- a/selfupdate/restart.go
+++ b/selfupdate/restart.go
@@ -1,0 +1,20 @@
+package selfupdate
+
+import (
+	"os"
+	"strings"
+)
+
+// restartArgs rebuilds the original command line with daemon flags stripped
+// and --daemon=false appended so the new process does not re-daemonize.
+func restartArgs() []string {
+	var args []string
+	for _, arg := range os.Args[1:] {
+		if arg == "-daemon" || arg == "--daemon" ||
+			strings.HasPrefix(arg, "-daemon=") || strings.HasPrefix(arg, "--daemon=") {
+			continue
+		}
+		args = append(args, arg)
+	}
+	return append(args, "--daemon=false")
+}

--- a/selfupdate/restart_unix.go
+++ b/selfupdate/restart_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package selfupdate
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Restart relaunches the freshly installed binary with the original
+// arguments in a detached process. After the install step the original
+// path points at the new binary (or bundle), so re-resolving
+// os.Executable is enough. The caller must terminate the current process
+// once Restart returns nil.
+func Restart() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, restartArgs()...) //nolint:gosec // relaunching ourselves by design
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // detach from the controlling terminal
+	}
+	return cmd.Start()
+}

--- a/selfupdate/restart_windows.go
+++ b/selfupdate/restart_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package selfupdate
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Restart relaunches the freshly installed binary with the original
+// arguments in a hidden window. After the install step the original path
+// points at the new binary, so re-resolving os.Executable is enough. The
+// caller must terminate the current process once Restart returns nil.
+func Restart() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, restartArgs()...) //nolint:gosec // relaunching ourselves by design
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow: true,
+	}
+	return cmd.Start()
+}

--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -48,7 +48,7 @@ func Update(ctx context.Context, localHTTPPort int, rel *Release) error {
 	// same volume (atomic).
 	staging, err := os.MkdirTemp(targetDir, stagingPrefix)
 	if err != nil {
-		return fmt.Errorf("create staging dir in %s: %w", targetDir, err)
+		return permissionHint("create staging dir in "+targetDir, err)
 	}
 	defer func() { _ = os.RemoveAll(staging) }()
 

--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -1,0 +1,62 @@
+// Package selfupdate implements checking GitHub releases, downloading and
+// installing a new client build, and restarting the application process.
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+)
+
+const (
+	// CheckTimeout bounds a single GitHub release check.
+	CheckTimeout = 15 * time.Second
+	// DownloadTimeout bounds downloading and installing a release asset.
+	DownloadTimeout = 10 * time.Minute
+
+	repoLatestURL = "https://api.github.com/repos/nange/easyss/releases/latest"
+)
+
+// Update downloads the release asset for the current platform, extracts it
+// and installs it over the running executable (or the whole .app bundle on
+// macOS). On success the new binary is in place and the caller should
+// restart the process (see Restart). localHTTPPort is the local HTTP proxy
+// port tried first for fetching; a direct connection is used as fallback.
+func Update(ctx context.Context, localHTTPPort int, rel *Release) error {
+	asset := PickAsset(rel, runtime.GOOS, runtime.GOARCH)
+	if asset == nil {
+		return fmt.Errorf("no release asset for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, DownloadTimeout)
+	defer cancel()
+
+	c := NewClient(localHTTPPort)
+	zipPath, err := c.DownloadAsset(ctx, asset)
+	if err != nil {
+		return fmt.Errorf("download asset %s: %w", asset.Name, err)
+	}
+	defer func() { _ = os.Remove(zipPath) }()
+
+	targetDir, err := installTargetDir()
+	if err != nil {
+		return err
+	}
+	// Stage next to the install target so the final rename stays on the
+	// same volume (atomic).
+	staging, err := os.MkdirTemp(targetDir, stagingPrefix)
+	if err != nil {
+		return fmt.Errorf("create staging dir in %s: %w", targetDir, err)
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	if err := Unzip(zipPath, staging); err != nil {
+		return fmt.Errorf("unzip asset %s: %w", asset.Name, err)
+	}
+	if err := Install(staging); err != nil {
+		return fmt.Errorf("install: %w", err)
+	}
+	return nil
+}

--- a/selfupdate/selfupdate_test.go
+++ b/selfupdate/selfupdate_test.go
@@ -1,0 +1,243 @@
+package selfupdate
+
+import (
+	"archive/zip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasNewVersion(t *testing.T) {
+	cases := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"v3.0.1", "v3.1.0", true},
+		{"v3.1.0", "v3.0.1", false},
+		{"v3.1.0", "v3.1.0", false},
+		{"v3.0", "v3.0.1", true},
+		{"", "v0.0.1", true},                   // dev build always updates
+		{"v3.0.1-5-gabc1234", "v3.0.1", false}, // git describe suffix ignored
+		{"v3.0.1-5-gabc1234", "v3.0.2", true},
+		{"v3.1.0-rc1", "v3.1.0", true}, // prerelease < release
+		{"3.0.1", "v3.0.2", true},      // missing "v" prefix tolerated
+		{"v3.0.1", "notasemver", true}, // unparsable falls back to inequality
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, HasNewVersion(c.current, c.latest),
+			"current=%q latest=%q", c.current, c.latest)
+	}
+}
+
+func TestPickAsset(t *testing.T) {
+	rel := &Release{
+		TagName: "v3.1.0",
+		Assets: []Asset{
+			{Name: "easyss-windows-amd64.zip"},
+			{Name: "easyss-linux-arm64.zip"},
+			{Name: "easyss-darwin-arm64.zip"},
+			{Name: "easyss-server-linux-amd64.zip"},
+		},
+	}
+
+	a := PickAsset(rel, "windows", "amd64")
+	require.NotNil(t, a)
+	assert.Equal(t, "easyss-windows-amd64.zip", a.Name)
+
+	a = PickAsset(rel, "darwin", "arm64")
+	require.NotNil(t, a)
+	assert.Equal(t, "easyss-darwin-arm64.zip", a.Name)
+
+	assert.Nil(t, PickAsset(rel, "linux", "386"))
+	assert.Nil(t, PickAsset(rel, "freebsd", "amd64"))
+}
+
+func TestZipTarget(t *testing.T) {
+	dest := filepath.Join("base", "dest")
+	destClean := filepath.Clean(dest) + string(os.PathSeparator)
+
+	entries := map[string]bool{
+		"easyss":           true,
+		"Easyss.app/a/b":   true,
+		"/abs/evil.txt":    true, // leading slash is dropped by filepath.Join, stays inside
+		"../evil.txt":      false,
+		"a/../../evil.txt": false,
+	}
+	for name, want := range entries {
+		_, got := zipTarget(dest, destClean, name)
+		assert.Equal(t, want, got, "entry=%q", name)
+	}
+}
+
+// makeTestZip builds a zip at zipPath with the given name/content pairs.
+// Entries are written with unix mode 0755 so permission handling is exercised.
+func makeTestZip(t *testing.T, zipPath string, files map[string]string) {
+	t.Helper()
+
+	f, err := os.Create(zipPath)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	w := zip.NewWriter(f)
+	for name, content := range files {
+		fw, err := w.CreateHeader(&zip.FileHeader{
+			Name:           name,
+			Method:         zip.Deflate,
+			CreatorVersion: 3<<8 | 20, // creator unix, spec 2.0
+			ExternalAttrs:  0o755 << 16,
+		})
+		require.NoError(t, err)
+		_, err = fw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+}
+
+func TestUnzip(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+
+	zipPath := filepath.Join(dir, "rel.zip")
+	makeTestZip(t, zipPath, map[string]string{
+		"easyss":           "new-binary",
+		"Easyss.app/a.txt": "app-file",
+	})
+
+	require.NoError(t, Unzip(zipPath, dest))
+
+	content, err := os.ReadFile(filepath.Join(dest, "easyss"))
+	require.NoError(t, err)
+	assert.Equal(t, "new-binary", string(content))
+
+	content, err = os.ReadFile(filepath.Join(dest, "Easyss.app", "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "app-file", string(content))
+
+	// The executable bit survives extraction (unix filesystems only).
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dest, "easyss"))
+		require.NoError(t, err)
+		assert.NotZero(t, info.Mode()&0o111, "binary should stay executable")
+	}
+
+	// Nothing may be written outside dest even with a zip-slip entry.
+	slipPath := filepath.Join(dir, "rel-slip.zip")
+	makeTestZip(t, slipPath, map[string]string{"../evil.txt": "evil"})
+	require.NoError(t, Unzip(slipPath, dest))
+	_, err = os.Stat(filepath.Join(dir, "evil.txt"))
+	assert.True(t, os.IsNotExist(err), "zip-slip entry must be rejected")
+}
+
+func TestInstallAtBinary(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("running-exe swap via .old rename is the windows flow")
+	}
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "easyss.exe")
+	require.NoError(t, os.WriteFile(exe, []byte("old"), 0o755))
+
+	staging := filepath.Join(dir, stagingPrefix+"1")
+	require.NoError(t, os.MkdirAll(staging, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "easyss.exe"), []byte("new"), 0o755))
+
+	require.NoError(t, installAt(exe, staging))
+
+	content, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(content))
+
+	old, err := os.ReadFile(exe + ".old")
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(old))
+}
+
+func TestInstallAtBundle(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "Easyss.app", "Contents", "MacOS", "easyss")
+	require.NoError(t, os.MkdirAll(filepath.Dir(exe), 0o755))
+	require.NoError(t, os.WriteFile(exe, []byte("old"), 0o755))
+
+	staging := filepath.Join(dir, stagingPrefix+"1")
+	stagedExe := filepath.Join(staging, "Easyss.app", "Contents", "MacOS", "easyss")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stagedExe), 0o755))
+	require.NoError(t, os.WriteFile(stagedExe, []byte("new"), 0o755))
+
+	require.NoError(t, installAt(exe, staging))
+
+	content, err := os.ReadFile(exe) // same path now resolves to the new bundle
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(content))
+
+	old, err := os.ReadFile(filepath.Join(dir, "Easyss.app.old", "Contents", "MacOS", "easyss"))
+	require.NoError(t, err)
+	assert.Equal(t, "old", string(old))
+
+	assert.Equal(t, filepath.Join(dir, "Easyss.app"), appBundleRoot(exe))
+}
+
+func TestRestartArgs(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+
+	os.Args = []string{"easyss", "-c", "config.json", "--daemon"}
+	assert.Equal(t, []string{"-c", "config.json", "--daemon=false"}, restartArgs())
+
+	os.Args = []string{"easyss", "-daemon=true", "-log-file", "a.log"}
+	assert.Equal(t, []string{"-log-file", "a.log", "--daemon=false"}, restartArgs())
+
+	os.Args = []string{"easyss"}
+	assert.Equal(t, []string{"--daemon=false"}, restartArgs())
+}
+
+func TestClientProxyFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Acting as an HTTP proxy, Host carries the target's authority; a
+		// direct request carries the server's own host.
+		if r.Host == "203.0.113.1:9" {
+			_, _ = w.Write([]byte("via-proxy"))
+			return
+		}
+		_, _ = w.Write([]byte(`{"app":"Easyss"}`))
+	}))
+	defer srv.Close()
+
+	proxyURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	// Proxy path: the request must be served by the local proxy.
+	c := &Client{
+		proxy:  &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}},
+		direct: &http.Client{},
+	}
+	resp, err := c.Get(context.Background(), "http://203.0.113.1:9/latest", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// Dead proxy: Get must fall back to the direct client.
+	dead := &Client{
+		proxy:  &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(deadProxyURL)}},
+		direct: srv.Client(),
+	}
+	resp, err = dead.Get(context.Background(), srv.URL, nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body := make([]byte, 64)
+	n, _ := resp.Body.Read(body)
+	assert.Contains(t, string(body[:n]), "Easyss")
+}
+
+var deadProxyURL = &url.URL{Scheme: "http", Host: "127.0.0.1:1"}

--- a/selfupdate/selfupdate_test.go
+++ b/selfupdate/selfupdate_test.go
@@ -62,21 +62,34 @@ func TestPickAsset(t *testing.T) {
 	assert.Nil(t, PickAsset(rel, "freebsd", "amd64"))
 }
 
-func TestZipTarget(t *testing.T) {
-	dest := filepath.Join("base", "dest")
-	destClean := filepath.Clean(dest) + string(os.PathSeparator)
+func TestUnzipRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
 
-	entries := map[string]bool{
-		"easyss":           true,
-		"Easyss.app/a/b":   true,
-		"/abs/evil.txt":    true, // leading slash is dropped by filepath.Join, stays inside
-		"../evil.txt":      false,
-		"a/../../evil.txt": false,
+	zipPath := filepath.Join(dir, "rel-slip.zip")
+	makeTestZip(t, zipPath, map[string]string{
+		"easyss":           "binary",
+		"Easyss.app/a/b":   "nested",
+		"/abs/evil.txt":    "leading-slash", // leading slash is dropped by filepath.Join, stays inside
+		"../evil.txt":      "evil",
+		"a/../../evil.txt": "evil",
+	})
+	require.NoError(t, Unzip(zipPath, dest))
+
+	// Legitimate entries are extracted inside dest.
+	for _, rel := range []string{
+		"easyss",
+		filepath.Join("Easyss.app", "a", "b"),
+		filepath.Join("abs", "evil.txt"),
+	} {
+		_, err := os.Stat(filepath.Join(dest, rel))
+		require.NoError(t, err, "expected %s to exist", rel)
 	}
-	for name, want := range entries {
-		_, got := zipTarget(dest, destClean, name)
-		assert.Equal(t, want, got, "entry=%q", name)
-	}
+
+	// Nothing may be written outside dest even with a zip-slip entry.
+	_, err := os.Stat(filepath.Join(dir, "evil.txt"))
+	assert.True(t, os.IsNotExist(err), "zip-slip entry must be rejected")
 }
 
 // makeTestZip builds a zip at zipPath with the given name/content pairs.

--- a/selfupdate/selfupdate_test.go
+++ b/selfupdate/selfupdate_test.go
@@ -3,6 +3,8 @@ package selfupdate
 import (
 	"archive/zip"
 	"context"
+	"errors"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -210,8 +212,38 @@ func TestRestartArgs(t *testing.T) {
 	os.Args = []string{"easyss", "-daemon=true", "-log-file", "a.log"}
 	assert.Equal(t, []string{"-log-file", "a.log", "--daemon=false"}, restartArgs())
 
+	os.Args = []string{"easyss", "-daemon", "false", "-c", "config.json"}
+	assert.Equal(t, []string{"-c", "config.json", "--daemon=false"}, restartArgs())
+
 	os.Args = []string{"easyss"}
 	assert.Equal(t, []string{"--daemon=false"}, restartArgs())
+}
+
+func TestUnzipFileSizeLimit(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "big.zip")
+	makeTestZip(t, zipPath, map[string]string{"big.bin": "xx"}) // 2 bytes
+
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	require.Len(t, r.File, 1)
+
+	target := filepath.Join(dir, "out", "big.bin")
+	err = unzipFile(r.File[0], target, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds decompressed size limit")
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "oversized file must be cleaned up")
+}
+
+func TestPermissionHint(t *testing.T) {
+	err := permissionHint("install", &fs.PathError{Op: "open", Path: "/x", Err: fs.ErrPermission})
+	assert.Contains(t, err.Error(), "无写权限")
+
+	err = permissionHint("install", errors.New("boom"))
+	assert.Equal(t, "install: boom", err.Error())
 }
 
 func TestClientProxyFallback(t *testing.T) {


### PR DESCRIPTION
## 功能说明

为客户端新增自动更新功能，在系统托盘"退出"菜单上方新增**检查更新**菜单项：

- 点击后查询 GitHub 最新 release（`/releases/latest` 端点，自动排除 pre-release 和 draft），用 semver 与当前版本比较
- 发现新版本时，菜单文案变为"发现新版本 vX.Y.Z，点击更新"，并弹出系统通知提醒
- 用户再次点击即下载当前平台对应的 release 资产并安装，完成后自动重启进程加载新版本
- 客户端启动约 1 分钟后自动静默检查一次（仅正式版构建，开发版跳过），发现新版本时通知用户
- 失败/无更新时菜单显示临时提示，4 秒后自动复位

## 实现细节

### 新增 `selfupdate/` 包（与托盘解耦）
- `github.go`：release 查询；版本比较（剥离 git describe 后缀避免误报；开发构建始终可更新）；按 CI 命名匹配平台资产（`easyss-windows-amd64.zip` 等）
- `client.go`：下载通道优先走本地 HTTP 代理（应对 GitHub 直连不通），失败自动回退直连
- `download.go`：流式下载到临时文件（校验产物大小）；解压带 zip-slip 防护与 CRC 校验
- `install.go`：三平台替换策略——Windows 将运行中 exe 改名为 `.old` 后放入新文件；Linux 原子 rename 覆盖；macOS 整个 `Easyss.app` bundle 换旧移新；`CleanupOld()` 启动时清理残留
- `restart_*.go`：替换完成后以原始参数（剔除 daemon 标志、追加 `--daemon=false`）拉起新二进制，Windows 隐藏窗口、unix 脱离终端

### 托盘集成（`cmd/easyss/tray_update.go`）
- 原子状态机（idle/checking/available/downloading）防止并发点击
- 安装成功后清理系统代理、停止服务、**手动释放单例锁**（避免新旧进程争锁）再重启；重启失败则恢复进程内服务并提示手动重启

## 其他
- `go.mod`：`Masterminds/semver/v3` 由间接依赖提升为直接依赖
- 单元测试覆盖版本比较、资产匹配、zip 解压（含 zip-slip 拒绝）、安装替换流程、重启参数构造、代理回退
- `go test ./...` 全部通过，`make lint` 0 issues，普通与 headless 构建均验证通过

## 边界
- headless 与 `-disable-tray` 模式暂无更新入口，服务端不在本期范围