### PR TITLE
fix: use valid domain and underscore in default ACME email

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -215,7 +215,7 @@ func findExistingACMEEmail(storagePath string) string {
 func randomEmail() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
-	return "admin-" + hex.EncodeToString(b) + "@example.com"
+	return "admin_" + hex.EncodeToString(b) + "@gmail.com"
 }
 
 func shouldRetryFreshCertificate(err error) bool {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -72,7 +72,7 @@ func (e errString) Error() string { return string(e) }
 
 func TestRandomEmail(t *testing.T) {
 	email := randomEmail()
-	matched, err := regexp.MatchString(`^admin-[0-9a-f]{16}@example\.com$`, email)
+	matched, err := regexp.MatchString(`^admin_[0-9a-f]{16}@gmail\.com$`, email)
 	require.NoError(t, err)
 	require.True(t, matched, "unexpected email format: %s", email)
 }
@@ -154,7 +154,7 @@ func TestResolveEmail_Generated(t *testing.T) {
 	}
 	s.resolveEmail(t.TempDir())
 
-	matched, err := regexp.MatchString(`^admin-[0-9a-f]{16}@example\.com$`, s.cfg.Email)
+	matched, err := regexp.MatchString(`^admin_[0-9a-f]{16}@gmail\.com$`, s.cfg.Email)
 	require.NoError(t, err)
 	require.True(t, matched, "unexpected generated email format: %s", s.cfg.Email)
 }


### PR DESCRIPTION
## 背景

服务端未配置 `email` 时，`randomEmail()` 生成的默认 ACME 邮箱为 `admin-<16位hex>@example.com`，存在两个问题：

1. `example.com` 是 RFC 2606 保留域，Let's Encrypt 不接受其作为 ACME 账户联系邮箱的域名后缀；
2. 前缀 `admin-` 使用连字符，希望改为下划线 `admin_`。

## 修改内容

- `server/server.go`：`randomEmail()` 生成的默认邮箱改为 `admin_<16位hex>@gmail.com`（真实可用域名 + 下划线分隔）；
- `server/server_test.go`：同步更新 `TestRandomEmail`、`TestResolveEmail_Generated` 两处正则断言。

## 兼容性

`findExistingACMEEmail()` 按 certmagic 存储目录名复用历史邮箱，与格式无关，旧部署中已有的 `admin-xxx@example.com` 目录仍会被正常复用，无需迁移。

## 验证

- `go test ./server/...` 全量通过
- `make lint` 通过（0 issues）
