### PR TITLE
feat: add selfupdate subcommand for server and headless builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,25 @@ docker run -d --name easyss --network host nange/docker-easyss:latest -p yourpor
 可根据自己的需求，使用`openssl`等工具生成自定义证书。也可以参考： `./scripts/self_signed_certs` 目录示例，使用`cfssl`生成自定义证书。
 示例就是使用IP而不是域名生成自定义证书，这样就可以无域名使用Easyss了。
 
+### 自更新
+
+客户端（含 headless 无托盘版）与服务端均支持 `selfupdate` 子命令：从 GitHub 检查最新 release，并**原地替换当前二进制**。替换完成后不会自动重启，需要手动（或由 systemd/supervisor 等）重启进程使新版本生效。
+
+```sh
+# 仅检查是否有新版本
+./easyss selfupdate --check
+./easyss-server selfupdate --check
+
+# 下载并替换二进制（不重启）
+./easyss selfupdate
+./easyss-headless selfupdate
+./easyss-server selfupdate
+```
+
+* `--proxy-port <port>`：若本机同时运行了 easyss 客户端，可指定其 HTTP 代理端口，更新请求优先走本地代理，失败自动回退直连（默认直连）。
+* Windows 下替换时原二进制会保留为 `.old`，下次正常启动时自动清理；Linux/macOS 直接原子替换。
+* Windows 托盘版（`easyss.exe`）因编译时隐藏控制台窗口，CLI 输出不可见，可通过重定向或退出码判断结果；服务端 Windows 版不受影响。
+
 ## 高级用法
 
 ### 服务器部署在反向代理(或CDN)之后

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/pprof"
 	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/selfupdate"
 	"github.com/nange/easyss/v3/server"
 	"github.com/nange/easyss/v3/server/config"
 	"github.com/nange/easyss/v3/util"
@@ -25,6 +26,13 @@ import (
 )
 
 func main() {
+	// The "selfupdate" subcommand is handled before flag parsing so it never
+	// collides with the server flags. It replaces the running binary and
+	// exits without starting the server.
+	if len(os.Args) > 1 && os.Args[1] == "selfupdate" {
+		os.Exit(runSelfupdate())
+	}
+
 	var printVer, showConfigExample bool
 	var configFile string
 	var pprofEnabled bool
@@ -83,6 +91,10 @@ func main() {
 	}
 
 	log.Init(fileCfg.Log.FilePath, fileCfg.Log.Level)
+
+	// Remove leftovers from a previous self-update (the renamed old binary
+	// kept for Windows and stale staging directories).
+	selfupdate.CleanupOld()
 
 	log.Info("[EASYSS-SERVER-V3] " + version.String())
 	log.Info("[EASYSS-SERVER-V3] config loaded",

--- a/cmd/easyss-server/selfupdate.go
+++ b/cmd/easyss-server/selfupdate.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/nange/easyss/v3/log"
+	"github.com/nange/easyss/v3/selfupdate"
+	"github.com/nange/easyss/v3/version"
+)
+
+// runSelfupdate implements the "selfupdate" subcommand: check the latest
+// release and, by default, download and replace the server binary in place
+// without restarting. The service manager (or the user) starts the new
+// binary afterwards.
+func runSelfupdate() int {
+	fs := flag.NewFlagSet("selfupdate", flag.ContinueOnError)
+	var proxyPort int
+	var checkOnly bool
+	fs.IntVar(&proxyPort, "proxy-port", 0, "route fetches through the local easyss HTTP proxy at 127.0.0.1:<port>")
+	fs.BoolVar(&checkOnly, "check", false, "only check whether a new version is available, do not download")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), selfupdate.CheckTimeout)
+	defer cancel()
+
+	if checkOnly {
+		rel, err := selfupdate.CheckCLI(ctx, proxyPort, selfupdate.ProductServer)
+		if err != nil {
+			if errors.Is(err, selfupdate.ErrUpToDate) {
+				fmt.Println("已是最新版本:", version.Tag())
+				return 0
+			}
+			log.Error("[EASYSS-SERVER-V3] selfupdate check", "err", err)
+			return 1
+		}
+		fmt.Printf("发现新版本 %s（当前 %s），执行 easyss-server selfupdate 可升级\n",
+			rel.TagName, version.Tag())
+		return 0
+	}
+
+	if err := selfupdate.RunCLI(ctx, proxyPort, selfupdate.ProductServer); err != nil {
+		if errors.Is(err, selfupdate.ErrUpToDate) {
+			fmt.Println("已是最新版本:", version.Tag())
+			return 0
+		}
+		log.Error("[EASYSS-SERVER-V3] selfupdate", "err", err)
+		return 1
+	}
+	fmt.Println("已更新到最新版本，请重启 easyss-server 完成升级")
+	return 0
+}

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -30,6 +30,13 @@ import (
 )
 
 func main() {
+	// The "selfupdate" subcommand is handled before flag parsing so it never
+	// collides with the proxy flags. It replaces the running binary and
+	// exits without starting anything.
+	if runSelfupdateSubcommand() {
+		return
+	}
+
 	var printVer, showConfigExample, showConfigExampleSimple, daemon, disableTray, enableTun2socks, tunHelper bool
 	var configFile, cmdOutboundProto string
 	var pprofEnabled bool

--- a/cmd/easyss/selfupdate_cli.go
+++ b/cmd/easyss/selfupdate_cli.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nange/easyss/v3/log"
+	"github.com/nange/easyss/v3/selfupdate"
+	"github.com/nange/easyss/v3/version"
+)
+
+// runSelfupdateSubcommand handles the "selfupdate" subcommand (check the
+// latest release, and by default download and replace the running binary
+// without restarting). It reports whether the subcommand was handled, in
+// which case the process has already exited.
+func runSelfupdateSubcommand() bool {
+	if len(os.Args) < 2 || os.Args[1] != "selfupdate" {
+		return false
+	}
+	os.Exit(runSelfupdate())
+	return true
+}
+
+// runSelfupdate implements the "selfupdate" subcommand shared by the tray
+// and headless client builds. It never starts the proxy or the tray; on a
+// successful update the binary has been replaced in place and the user
+// restarts the app manually.
+func runSelfupdate() int {
+	fs := flag.NewFlagSet("selfupdate", flag.ContinueOnError)
+	var proxyPort int
+	var checkOnly bool
+	fs.IntVar(&proxyPort, "proxy-port", 0, "route fetches through the local easyss HTTP proxy at 127.0.0.1:<port>")
+	fs.BoolVar(&checkOnly, "check", false, "only check whether a new version is available, do not download")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), selfupdate.CheckTimeout)
+	defer cancel()
+	product := selfupdateProduct()
+
+	if checkOnly {
+		rel, err := selfupdate.CheckCLI(ctx, proxyPort, product)
+		if err != nil {
+			if errors.Is(err, selfupdate.ErrUpToDate) {
+				fmt.Println("已是最新版本:", version.Tag())
+				return 0
+			}
+			log.Error("[EASYSS-V3] selfupdate check", "err", err)
+			return 1
+		}
+		fmt.Printf("发现新版本 %s（当前 %s），执行 %s selfupdate 可升级\n",
+			rel.TagName, version.Tag(), filepath.Base(os.Args[0]))
+		return 0
+	}
+
+	if err := selfupdate.RunCLI(ctx, proxyPort, product); err != nil {
+		if errors.Is(err, selfupdate.ErrUpToDate) {
+			fmt.Println("已是最新版本:", version.Tag())
+			return 0
+		}
+		log.Error("[EASYSS-V3] selfupdate", "err", err)
+		return 1
+	}
+	fmt.Println("已更新到最新版本，请重启 easyss 完成升级")
+	return 0
+}

--- a/cmd/easyss/selfupdate_gui.go
+++ b/cmd/easyss/selfupdate_gui.go
@@ -1,0 +1,11 @@
+//go:build !headless
+
+package main
+
+import "github.com/nange/easyss/v3/selfupdate"
+
+// selfupdateProduct returns the release product updated by the "selfupdate"
+// subcommand in tray builds.
+func selfupdateProduct() selfupdate.Product {
+	return selfupdate.ProductClient
+}

--- a/cmd/easyss/selfupdate_headless.go
+++ b/cmd/easyss/selfupdate_headless.go
@@ -1,0 +1,11 @@
+//go:build headless
+
+package main
+
+import "github.com/nange/easyss/v3/selfupdate"
+
+// selfupdateProduct returns the release product updated by the "selfupdate"
+// subcommand in headless builds.
+func selfupdateProduct() selfupdate.Product {
+	return selfupdate.ProductHeadless
+}

--- a/selfupdate/cli.go
+++ b/selfupdate/cli.go
@@ -1,0 +1,60 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nange/easyss/v3/log"
+	"github.com/nange/easyss/v3/version"
+)
+
+// ErrUpToDate reports that the local build already matches the latest
+// release. runCheck returns it when no update is needed.
+var ErrUpToDate = errors.New("already up to date")
+
+// CheckCLI checks the latest published release for the given product and
+// returns it when a newer version is available, or ErrUpToDate when the
+// local build is already up to date. It never downloads anything.
+// proxyPort > 0 routes the fetches through the local easyss HTTP proxy at
+// 127.0.0.1:<proxyPort>; otherwise a direct connection is used.
+func CheckCLI(ctx context.Context, proxyPort int, product Product) (*Release, error) {
+	return runCheck(ctx, NewClient(proxyPort), version.Tag())
+}
+
+// RunCLI performs a one-shot self-update for the given product from the
+// command line: it checks the latest release and, when a newer one exists,
+// downloads the release asset and replaces the running binary in place. It
+// never restarts the process — the caller exits afterwards so the user or
+// service manager starts the new binary. It returns ErrUpToDate when the
+// local build is already the latest release. proxyPort > 0 routes the
+// fetches through the local easyss HTTP proxy at 127.0.0.1:<proxyPort>;
+// otherwise a direct connection is used.
+func RunCLI(ctx context.Context, proxyPort int, product Product) error {
+	c := NewClient(proxyPort)
+	rel, err := runCheck(ctx, c, version.Tag())
+	if err != nil {
+		return err
+	}
+	log.Info("[SELFUPDATE] downloading and installing", "product", product, "version", rel.TagName)
+	if err := updateFor(ctx, c, product, rel); err != nil {
+		return fmt.Errorf("update to %s: %w", rel.TagName, err)
+	}
+	return nil
+}
+
+// runCheck fetches the latest release and reports whether currentTag is
+// behind it. It applies CheckTimeout to the whole check.
+func runCheck(ctx context.Context, c *Client, currentTag string) (*Release, error) {
+	checkCtx, cancel := context.WithTimeout(ctx, CheckTimeout)
+	defer cancel()
+
+	rel, err := CheckLatest(checkCtx, c)
+	if err != nil {
+		return nil, fmt.Errorf("check latest release: %w", err)
+	}
+	if !HasNewVersion(currentTag, rel.TagName) {
+		return nil, ErrUpToDate
+	}
+	return rel, nil
+}

--- a/selfupdate/github.go
+++ b/selfupdate/github.go
@@ -30,6 +30,10 @@ type Release struct {
 // the built commit is ahead of the tag, e.g. "v3.0.1-5-gabc1234".
 var gitDescribeSuffix = regexp.MustCompile(`-\d+-g[0-9a-f]+$`)
 
+// repoLatestURL is the GitHub API endpoint for the latest release. It is a
+// variable (not a constant) so tests can redirect it to a local server.
+var repoLatestURL = "https://api.github.com/repos/nange/easyss/releases/latest"
+
 // CheckLatest fetches the latest published release from GitHub. The
 // /releases/latest endpoint only returns full releases: pre-releases and
 // drafts are excluded by GitHub itself.
@@ -177,14 +181,22 @@ func newerThan(a, b *semver.Version) bool {
 	return a.Compare(b) > 0
 }
 
-// PickAsset returns the release asset for the given platform, following the
-// CI naming scheme (easyss-<goos>-<goarch>.zip), or nil when absent.
-func PickAsset(rel *Release, goos, goarch string) *Asset {
-	name := fmt.Sprintf("easyss-%s-%s.zip", goos, goarch)
+// PickAssetFor returns the release asset for the given product and platform,
+// following the CI naming scheme (<product>-<goos>-<goarch>.zip), or nil when
+// absent.
+func PickAssetFor(rel *Release, product Product, goos, goarch string) *Asset {
+	name := product.assetName(goos, goarch)
 	for i := range rel.Assets {
 		if rel.Assets[i].Name == name {
 			return &rel.Assets[i]
 		}
 	}
 	return nil
+}
+
+// PickAsset returns the client release asset for the given platform,
+// following the CI naming scheme (easyss-<goos>-<goarch>.zip), or nil when
+// absent.
+func PickAsset(rel *Release, goos, goarch string) *Asset {
+	return PickAssetFor(rel, ProductClient, goos, goarch)
 }

--- a/selfupdate/install.go
+++ b/selfupdate/install.go
@@ -70,15 +70,21 @@ func appBundleRoot(exePath string) string {
 }
 
 // Install moves the artifact staged in stagingDir over the current install
-// location. Windows cannot overwrite a running executable, so the running
-// binary is renamed aside (allowed) and removed on next start; unix replaces
-// the file atomically via rename; macOS swaps the whole .app bundle.
+// location, replacing the client binary. Windows cannot overwrite a running
+// executable, so the running binary is renamed aside (allowed) and removed on
+// next start; unix replaces the file atomically via rename; macOS swaps the
+// whole .app bundle.
 func Install(stagingDir string) error {
+	return InstallFor(stagingDir, ProductClient)
+}
+
+// InstallFor is Install for a specific product (client, headless or server).
+func InstallFor(stagingDir string, product Product) error {
 	exe, err := resolvedExe()
 	if err != nil {
 		return err
 	}
-	return installAt(exe, stagingDir)
+	return installAt(exe, stagingDir, product)
 }
 
 // permissionHint rewrites a permission failure into a user-friendly message,
@@ -104,12 +110,12 @@ func clearQuarantine(path string) {
 	}
 }
 
-func installAt(exe, stagingDir string) error {
+func installAt(exe, stagingDir string, product Product) error {
 	if bundle := appBundleRoot(exe); bundle != "" {
 		return installBundle(stagingDir, bundle)
 	}
 
-	staged, err := stagedBinary(stagingDir)
+	staged, err := stagedBinary(stagingDir, product)
 	if err != nil {
 		return err
 	}
@@ -137,13 +143,9 @@ func installAt(exe, stagingDir string) error {
 	return nil
 }
 
-// stagedBinary locates the client binary extracted into stagingDir.
-func stagedBinary(stagingDir string) (string, error) {
-	name := "easyss"
-	if runtime.GOOS == "windows" {
-		name = "easyss.exe"
-	}
-	p := filepath.Join(stagingDir, name)
+// stagedBinary locates the product binary extracted into stagingDir.
+func stagedBinary(stagingDir string, product Product) (string, error) {
+	p := filepath.Join(stagingDir, product.binaryName())
 	info, err := os.Stat(p)
 	if err != nil || info.IsDir() {
 		return "", fmt.Errorf("staged binary %s not found", p)

--- a/selfupdate/product.go
+++ b/selfupdate/product.go
@@ -1,0 +1,36 @@
+package selfupdate
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Product identifies which binary variant is being updated. It drives both
+// the release asset name and the staged binary name inside the release zip,
+// following the CI naming scheme (<product>-<goos>-<goarch>.zip).
+type Product string
+
+const (
+	// ProductClient is the tray client build (binary "easyss"/"easyss.exe").
+	ProductClient Product = "easyss"
+	// ProductHeadless is the headless client build (binary "easyss-headless").
+	ProductHeadless Product = "easyss-headless"
+	// ProductServer is the server build (binary "easyss-server"/"easyss-server.exe").
+	ProductServer Product = "easyss-server"
+)
+
+// assetName returns the release asset name for the product on a platform,
+// e.g. ("easyss-server", "linux", "amd64") -> "easyss-server-linux-amd64.zip".
+func (p Product) assetName(goos, goarch string) string {
+	return fmt.Sprintf("%s-%s-%s.zip", p, goos, goarch)
+}
+
+// binaryName returns the staged binary name inside the release zip for the
+// current platform.
+func (p Product) binaryName() string {
+	name := string(p)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return name
+}

--- a/selfupdate/selfupdate.go
+++ b/selfupdate/selfupdate.go
@@ -15,8 +15,6 @@ const (
 	CheckTimeout = 15 * time.Second
 	// DownloadTimeout bounds downloading and installing a release asset.
 	DownloadTimeout = 10 * time.Minute
-
-	repoLatestURL = "https://api.github.com/repos/nange/easyss/releases/latest"
 )
 
 // Update downloads the release asset for the current platform, extracts it
@@ -25,15 +23,25 @@ const (
 // restart the process (see Restart). localHTTPPort is the local HTTP proxy
 // port tried first for fetching; a direct connection is used as fallback.
 func Update(ctx context.Context, localHTTPPort int, rel *Release) error {
-	asset := PickAsset(rel, runtime.GOOS, runtime.GOARCH)
+	return UpdateFor(ctx, localHTTPPort, ProductClient, rel)
+}
+
+// UpdateFor is Update for a specific product (client, headless or server).
+func UpdateFor(ctx context.Context, localHTTPPort int, product Product, rel *Release) error {
+	return updateFor(ctx, NewClient(localHTTPPort), product, rel)
+}
+
+// updateFor downloads, extracts and installs the release asset for product
+// using the given fetch client.
+func updateFor(ctx context.Context, c *Client, product Product, rel *Release) error {
+	asset := PickAssetFor(rel, product, runtime.GOOS, runtime.GOARCH)
 	if asset == nil {
-		return fmt.Errorf("no release asset for %s/%s", runtime.GOOS, runtime.GOARCH)
+		return fmt.Errorf("no release asset for %s on %s/%s", product, runtime.GOOS, runtime.GOARCH)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, DownloadTimeout)
 	defer cancel()
 
-	c := NewClient(localHTTPPort)
 	zipPath, err := c.DownloadAsset(ctx, asset)
 	if err != nil {
 		return fmt.Errorf("download asset %s: %w", asset.Name, err)
@@ -55,7 +63,7 @@ func Update(ctx context.Context, localHTTPPort int, rel *Release) error {
 	if err := Unzip(zipPath, staging); err != nil {
 		return fmt.Errorf("unzip asset %s: %w", asset.Name, err)
 	}
-	if err := Install(staging); err != nil {
+	if err := InstallFor(staging, product); err != nil {
 		return fmt.Errorf("install: %w", err)
 	}
 	return nil

--- a/selfupdate/selfupdate_test.go
+++ b/selfupdate/selfupdate_test.go
@@ -77,6 +77,78 @@ func TestPickAsset(t *testing.T) {
 	assert.Nil(t, PickAsset(rel, "freebsd", "amd64"))
 }
 
+func TestPickAssetFor(t *testing.T) {
+	rel := &Release{
+		TagName: "v3.1.0",
+		Assets: []Asset{
+			{Name: "easyss-windows-amd64.zip"},
+			{Name: "easyss-headless-linux-amd64.zip"},
+			{Name: "easyss-server-linux-amd64.zip"},
+			{Name: "easyss-server-windows-amd64.zip"},
+		},
+	}
+
+	cases := []struct {
+		product Product
+		goos    string
+		goarch  string
+		want    string
+	}{
+		{ProductServer, "linux", "amd64", "easyss-server-linux-amd64.zip"},
+		{ProductServer, "windows", "amd64", "easyss-server-windows-amd64.zip"},
+		{ProductHeadless, "linux", "amd64", "easyss-headless-linux-amd64.zip"},
+		{ProductClient, "windows", "amd64", "easyss-windows-amd64.zip"},
+	}
+	for _, c := range cases {
+		a := PickAssetFor(rel, c.product, c.goos, c.goarch)
+		require.NotNil(t, a, "%s/%s/%s", c.product, c.goos, c.goarch)
+		assert.Equal(t, c.want, a.Name)
+	}
+
+	// Platform without a published asset for the product.
+	assert.Nil(t, PickAssetFor(rel, ProductServer, "darwin", "arm64"))
+	assert.Nil(t, PickAssetFor(rel, ProductHeadless, "windows", "amd64"))
+}
+
+func TestRunCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.0.0","assets":[]}`))
+	}))
+	defer srv.Close()
+
+	orig := repoLatestURL
+	repoLatestURL = srv.URL + "/latest"
+	defer func() { repoLatestURL = orig }()
+
+	c := &Client{direct: srv.Client()}
+
+	// Already up to date.
+	_, err := runCheck(context.Background(), c, "v9.9.9")
+	assert.ErrorIs(t, err, ErrUpToDate)
+
+	// Newer version available (runCheck never downloads).
+	rel, err := runCheck(context.Background(), c, "v0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, rel)
+	assert.Equal(t, "v1.0.0", rel.TagName)
+}
+
+func TestRunCheckFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	orig := repoLatestURL
+	repoLatestURL = srv.URL + "/latest"
+	defer func() { repoLatestURL = orig }()
+
+	c := &Client{direct: srv.Client()}
+	_, err := runCheck(context.Background(), c, "v0.0.1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check latest release")
+}
+
 func TestUnzipRejectsTraversal(t *testing.T) {
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "dest")
@@ -180,7 +252,7 @@ func TestInstallAtBinary(t *testing.T) {
 	require.NoError(t, os.MkdirAll(staging, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(staging, "easyss.exe"), []byte("new"), 0o755))
 
-	require.NoError(t, installAt(exe, staging))
+	require.NoError(t, installAt(exe, staging, ProductClient))
 
 	content, err := os.ReadFile(exe)
 	require.NoError(t, err)
@@ -202,7 +274,7 @@ func TestInstallAtBundle(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(stagedExe), 0o755))
 	require.NoError(t, os.WriteFile(stagedExe, []byte("new"), 0o755))
 
-	require.NoError(t, installAt(exe, staging))
+	require.NoError(t, installAt(exe, staging, ProductClient))
 
 	content, err := os.ReadFile(exe) // same path now resolves to the new bundle
 	require.NoError(t, err)


### PR DESCRIPTION
## 背景

当前客户端托盘版本已支持检查更新功能，但服务端和 headless 客户端没有自动升级能力。本 PR 为服务端、headless 与托盘客户端统一添加 selfupdate CLI 子命令：检查 GitHub 最新 release，下载并**原地替换当前二进制**，完成后退出（不重启、不启动服务），由用户或 systemd/supervisor 自行重启生效。

## 变更内容

- **selfupdate 包参数化**（最大化复用客户端升级代码）
  - 新增 Product 类型（easyss / easyss-headless / easyss-server），驱动 release 资产名与 staged 二进制名
  - PickAssetFor / UpdateFor / InstallFor 支持指定产品；原有 PickAsset / Update / Install 保持兼容，托盘逻辑无感
  - epoLatestURL 改为包级变量以便测试重定向
  - 新增 CheckCLI / RunCLI / unCheck / ErrUpToDate，复用 CheckLatest、HasNewVersion、NewClient（本地代理优先 + 直连回退）与下载/解压/替换流程；**不调用 Restart()**
- **三个二进制统一支持子命令**
  - cmd/easyss：托盘与 headless 构建共享 selfupdate_cli.go，按 build tag 区分产品（selfupdate_headless.go / selfupdate_gui.go）
  - cmd/easyss-server：新增 selfupdate.go 子命令，并在 log.Init 后补充 CleanupOld() 清理 .old 残留
- **用法**
  - ./easyss selfupdate --check / ./easyss selfupdate [--proxy-port <port>]
  - ./easyss-headless selfupdate
  - ./easyss-server selfupdate --check
  - 退出码：成功/已是最新 = 0，检查失败 = 1，参数错误 = 2
- **测试**：适配 installAt 新签名；新增 TestPickAssetFor、TestRunCheck、TestRunCheckFailure
- **文档**：README 新增「自更新」章节

## 验证

- make lint 通过（0 issues），go vet 通过，全量 go test ./... 通过
- 已真实冒烟验证：--check（发现新版本 / 已是最新）、完整 selfupdate（下载真实 release 资产、替换二进制、旧文件保留为 .old、退出 0）