### PR TITLE
feat: notify startup failure via systray

### DIFF
--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -132,6 +132,9 @@ Flags:
 			}
 		} else {
 			log.Error("[EASYSS-V3] load config", "err", err)
+			if !disableTray {
+				notifyStartupError(err)
+			}
 			os.Exit(1)
 		}
 	} else {

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -133,7 +133,7 @@ Flags:
 		} else {
 			log.Error("[EASYSS-V3] load config", "err", err)
 			if !disableTray {
-				notifyStartupError(err)
+				notifyConfigError(err)
 			}
 			os.Exit(1)
 		}

--- a/cmd/easyss/notify_headless.go
+++ b/cmd/easyss/notify_headless.go
@@ -1,0 +1,8 @@
+//go:build headless
+
+package main
+
+// notifyStartupError is a no-op in headless builds: there is no system
+// tray to show a notification from, and the caller already logs the
+// startup error.
+func notifyStartupError(error) {}

--- a/cmd/easyss/notify_headless.go
+++ b/cmd/easyss/notify_headless.go
@@ -2,7 +2,7 @@
 
 package main
 
-// notifyStartupError is a no-op in headless builds: there is no system
+// notifyConfigError is a no-op in headless builds: there is no system
 // tray to show a notification from, and the caller already logs the
 // startup error.
-func notifyStartupError(error) {}
+func notifyConfigError(error) {}

--- a/cmd/easyss/notify_test.go
+++ b/cmd/easyss/notify_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestFriendlyConfigError(t *testing.T) {
+	var v any
+	err := json.Unmarshal([]byte(`{"servers": [`), &v)
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("expected *json.SyntaxError, got %T", err)
+	}
+	if got := friendlyConfigError(syntaxErr); got != "JSON配置文件解析失败："+syntaxErr.Error() {
+		t.Fatalf("unexpected JSON error message: %q", got)
+	}
+
+	var mm map[string]int
+	err = json.Unmarshal([]byte(`{"timeout": "abc"}`), &mm)
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("expected *json.UnmarshalTypeError, got %T", err)
+	}
+	if got := friendlyConfigError(typeErr); got != "JSON配置文件解析失败："+typeErr.Error() {
+		t.Fatalf("unexpected JSON type error message: %q", got)
+	}
+
+	if got := friendlyConfigError(fs.ErrNotExist); got != "配置文件不存在："+fs.ErrNotExist.Error() {
+		t.Fatalf("unexpected not-exist message: %q", got)
+	}
+
+	if got := friendlyConfigError(errors.New("server is required")); got != "配置文件加载失败：server is required" {
+		t.Fatalf("unexpected generic message: %q", got)
+	}
+}
+
+func TestFriendlyStartupError(t *testing.T) {
+	// Unix: errno-based detection.
+	msg := friendlyStartupError(syscall.EADDRINUSE)
+	if !strings.Contains(msg, "本地端口可能被占用") {
+		t.Fatalf("EADDRINUSE should get the port-in-use hint: %q", msg)
+	}
+
+	// Windows: the canonical message text.
+	windowsErr := errors.New("bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.")
+	if msg := friendlyStartupError(windowsErr); !strings.Contains(msg, "本地端口可能被占用") {
+		t.Fatalf("windows in-use error should get the hint: %q", msg)
+	}
+
+	other := errors.New("boom")
+	if msg := friendlyStartupError(other); msg != "服务启动失败：boom" {
+		t.Fatalf("unexpected generic startup message: %q", msg)
+	}
+}

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -4,15 +4,19 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/user"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/gogpu/systray"
@@ -120,7 +124,7 @@ func (a *TrayApp) buildTray() {
 	// (especially GNOME with AppIndicator) see a non-empty menu on first query.
 	if err := a.Start(); err != nil {
 		log.Error("[EASYSS-V3] tray start", "err", err)
-		a.tray.ShowNotification("Easyss", "启动失败："+err.Error())
+		a.tray.ShowNotification("Easyss", friendlyStartupError(err))
 		// Keep the tray (and its notification, e.g. Windows balloon tips
 		// bound to the icon) alive briefly so the user can read the reason,
 		// then exit with failure. Run() is deliberately not called here:
@@ -135,13 +139,13 @@ func (a *TrayApp) buildTray() {
 	go a.autoCheckUpdate()
 }
 
-// notifyStartupError surfaces a startup failure (e.g. config load error)
+// notifyConfigError surfaces a config load failure (e.g. invalid JSON)
 // via a system notification using a minimal transient tray, because the
 // real tray has not been built yet. It is best-effort: the systray public
 // API swallows tray/notification errors, and Run() is deliberately not
 // called so the process can never hang when no GUI session is available —
 // the caller still exits with a failure code after this returns.
-func notifyStartupError(err error) {
+func notifyConfigError(err error) {
 	tray := systray.New()
 	menu := systray.NewMenu()
 	menu.Add("退出", func() { tray.Remove() })
@@ -150,12 +154,43 @@ func notifyStartupError(err error) {
 		SetMenu(menu)
 
 	tray.Show()
-	tray.ShowNotification("Easyss", "启动失败："+err.Error())
+	tray.ShowNotification("Easyss", friendlyConfigError(err))
 
 	// Keep the process alive briefly so the notification is displayed
 	// (Windows balloon tips vanish when the owning process exits).
 	time.Sleep(startupErrorNotifyDelay)
 	tray.Remove()
+}
+
+// friendlyConfigError 将配置文件加载错误转换为用户友好的中文提示。
+func friendlyConfigError(err error) string {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "配置文件不存在：" + err.Error()
+	default:
+		var syntaxErr *json.SyntaxError
+		var typeErr *json.UnmarshalTypeError
+		if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+			return "JSON配置文件解析失败：" + err.Error()
+		}
+		return "配置文件加载失败：" + err.Error()
+	}
+}
+
+// friendlyStartupError 将服务启动错误转换为用户友好的中文提示。
+func friendlyStartupError(err error) string {
+	if isAddrInUse(err) {
+		return "服务启动失败：本地端口可能被占用，请关闭占用该端口的程序后重试。详情：" + err.Error()
+	}
+	return "服务启动失败：" + err.Error()
+}
+
+// isAddrInUse 判断错误是否为"端口已被占用"的绑定失败（Unix 走 errno，
+// Windows 走消息匹配，两者兼顾以保证跨平台）。
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE) ||
+		strings.Contains(err.Error(), "address already in use") ||
+		strings.Contains(err.Error(), "Only one usage of each socket address")
 }
 
 func (a *TrayApp) trayExit() {

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -58,6 +58,11 @@ type TrayApp struct {
 	tunHelperMu    sync.Mutex
 }
 
+// startupErrorNotifyDelay keeps the process alive after a startup-failure
+// notification so the OS can display it before the client exits (Windows
+// balloon tips vanish when the owning process exits).
+const startupErrorNotifyDelay = 5 * time.Second
+
 // UWPApp represents an installed Windows UWP application.
 type UWPApp struct {
 	Name              string `json:"Name"`
@@ -115,12 +120,42 @@ func (a *TrayApp) buildTray() {
 	// (especially GNOME with AppIndicator) see a non-empty menu on first query.
 	if err := a.Start(); err != nil {
 		log.Error("[EASYSS-V3] tray start", "err", err)
+		a.tray.ShowNotification("Easyss", "启动失败："+err.Error())
+		// Keep the tray (and its notification, e.g. Windows balloon tips
+		// bound to the icon) alive briefly so the user can read the reason,
+		// then exit with failure. Run() is deliberately not called here:
+		// macOS allows only one Run() per process, and the OS-level
+		// notification APIs work without the message loop.
+		time.Sleep(startupErrorNotifyDelay)
 		os.Exit(1)
 	}
 
 	a.startLocalService()
 	go a.statsRefresher()
 	go a.autoCheckUpdate()
+}
+
+// notifyStartupError surfaces a startup failure (e.g. config load error)
+// via a system notification using a minimal transient tray, because the
+// real tray has not been built yet. It is best-effort: the systray public
+// API swallows tray/notification errors, and Run() is deliberately not
+// called so the process can never hang when no GUI session is available —
+// the caller still exits with a failure code after this returns.
+func notifyStartupError(err error) {
+	tray := systray.New()
+	menu := systray.NewMenu()
+	menu.Add("退出", func() { tray.Remove() })
+	tray.SetIcon(icon.TrayData).
+		SetTooltip("Easyss").
+		SetMenu(menu)
+
+	tray.Show()
+	tray.ShowNotification("Easyss", "启动失败："+err.Error())
+
+	// Keep the process alive briefly so the notification is displayed
+	// (Windows balloon tips vanish when the owning process exits).
+	time.Sleep(startupErrorNotifyDelay)
+	tray.Remove()
 }
 
 func (a *TrayApp) trayExit() {


### PR DESCRIPTION
## 变更内容

客户端启动失败时，通过 systray 系统通知告知用户启动错误的原因，而不是像之前那样仅在日志中记录后静默退出（GUI 构建下用户完全无感知）。

覆盖两条启动失败路径：

1. **托盘模式代理服务启动失败**（`buildTray()` 中 `App.Start()` 失败，如 socks 端口被占用）：使用已构建的托盘调用 `ShowNotification("Easyss", "启动失败："+err)` 弹出系统通知，进程保持存活 5 秒（Windows 气泡通知随进程退出而消失）后以退出码 1 退出。
2. **配置文件加载失败**（真实托盘尚未构建）：新增 `notifyStartupError()` 辅助函数，用最小临时托盘弹出系统通知展示错误原因，仅在托盘模式（`!disable-tray`）下生效。headless 构建提供同名空操作桩函数。

## 设计说明

- 通知在 `Run()` 之前调用即可生效：Windows 走 `Shell_NotifyIconW`（图标已由 `Show()` 注册）、macOS 走 NSUserNotificationCenter、Linux 走 D-Bus `org.freedesktop.Notifications`，均不依赖应用自身消息循环；因此失败路径刻意不调用 `Run()`（macOS 每进程仅允许一次 `Run()`），也避免了无图形会话时进程挂死。
- systray 公共 API 会吞掉托盘/通知错误，属尽力而为，不影响以失败码退出。
- `--disable-tray` 与 headless 构建行为保持不变。

## 验证

- `make lint`：0 issues；`go vet` 通过；gofmt 干净。
- `make easyss` / `make easyss-windows` / `make easyss-headless` 均编译通过。
- macOS 端到端实测（损坏的 `config.json`）：通知路径正常执行、停留 5 秒、退出码 1、无错误日志。