### PR TITLE
fix: prevent wrong tray menu action when UWP submenu refreshes

### DIFF
--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -53,9 +53,10 @@ type TrayApp struct {
 	updateMu      sync.Mutex
 
 	// UWP loopback exemption menu (Windows only).
-	uwpMu    sync.Mutex     //nolint:unused // used in uwp_windows.go
-	uwpMenu  *systray.Menu  //nolint:unused // used in uwp_windows.go
-	uwpItems []*UWPMenuItem //nolint:unused // used in uwp_windows.go
+	uwpMu           sync.Mutex        //nolint:unused // used in uwp_windows.go
+	uwpMenu         *systray.Menu     //nolint:unused // used in uwp_windows.go
+	uwpItems        []*UWPMenuItem    //nolint:unused // used in uwp_windows.go
+	uwpOverflowHint *systray.MenuItem //nolint:unused // used in uwp_windows.go
 
 	// TUN helper management (darwin non-root).
 	tunHelperStdin io.WriteCloser // FIFO writer; close to signal helper shutdown

--- a/cmd/easyss/uwp_windows.go
+++ b/cmd/easyss/uwp_windows.go
@@ -4,12 +4,31 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/gogpu/systray"
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/util"
+)
+
+const (
+	// uwpMenuSlots is the fixed number of UWP-app checkbox slots pre-built
+	// into the submenu at startup. The menu tree is never structurally
+	// rebuilt at runtime: gogpu/systray's SetMenu renumbers every item
+	// positionally and destroys the native HMENU, so a rebuild while the
+	// context menu is open can dispatch a click to another item's callback
+	// (https://github.com/gogpu/systray/issues/39). Pre-allocating a fixed
+	// number of slots and only updating label/checked/disabled state in
+	// place keeps the root menu shape constant, so no stale-ID aliasing is
+	// possible. Any future feature that changes the menu tree structure at
+	// runtime must respect the same constraint.
+	uwpMenuSlots = 48
+
+	// uwpSlotLoadingLabel is the placeholder shown in unpopulated slots
+	// until the first refresh fills them in.
+	uwpSlotLoadingLabel = "…"
 )
 
 func (a *TrayApp) addUWPLoopbackMenu(root *systray.Menu) {
@@ -19,8 +38,30 @@ func (a *TrayApp) addUWPLoopbackMenu(root *systray.Menu) {
 
 	a.uwpMenu.Add("刷新列表", func() { go a.uwpRefresh() })
 
+	a.buildUWPSlots()
+
 	// Populate the list asynchronously; the menu already shows "刷新列表".
 	go a.uwpRefresh()
+}
+
+// buildUWPSlots pre-builds the fixed slot layout of the UWP submenu: one
+// overflow hint item followed by uwpMenuSlots checkbox slots, all disabled
+// with a placeholder label. Slots are filled in place by applyUWPAppsToSlots,
+// so the menu tree is never rebuilt after startup (see uwpMenuSlots).
+func (a *TrayApp) buildUWPSlots() {
+	a.uwpOverflowHint = a.uwpMenu.Add(uwpSlotLoadingLabel, nil)
+	a.uwpOverflowHint.SetDisabled(true)
+
+	a.uwpItems = make([]*UWPMenuItem, 0, uwpMenuSlots)
+	for range uwpMenuSlots {
+		uwpItem := &UWPMenuItem{}
+		item := a.uwpMenu.AddCheckbox(uwpSlotLoadingLabel, false, func(u *UWPMenuItem) func() {
+			return func() { a.onUWPItemClicked(u) }
+		}(uwpItem))
+		item.SetDisabled(true)
+		uwpItem.MenuItem = item
+		a.uwpItems = append(a.uwpItems, uwpItem)
+	}
 }
 
 func (a *TrayApp) uwpRefresh() {
@@ -49,40 +90,39 @@ func (a *TrayApp) uwpRefresh() {
 		return strings.ToLower(apps[i].Name) < strings.ToLower(apps[j].Name)
 	})
 
-	// gogpu/systray builds the native menu (HMENU) on SetMenu; there is no
-	// Show/Hide for menu items. Reuse existing items and append new ones,
-	// then re-SetMenu only when the menu tree shape changed. Items that no
-	// longer correspond to an installed app are disabled instead of hidden.
-	needsRebuild := false
-	appIndex := 0
-	for _, app := range apps {
-		if app.Name == "" || app.PackageFamilyName == "" {
+	a.applyUWPAppsToSlots(apps)
+}
+
+// applyUWPAppsToSlots writes apps into the pre-built slot layout in place.
+// Apps beyond the slot count are dropped (reported by the overflow hint),
+// and slots without a matching app stay disabled with their previous label.
+// The menu tree shape is never changed here — no SetMenu, so the stale
+// command-ID aliasing of gogpu/systray issue #39 cannot be triggered.
+func (a *TrayApp) applyUWPAppsToSlots(apps []UWPApp) {
+	slot := 0
+	for i := range apps {
+		if apps[i].Name == "" || apps[i].PackageFamilyName == "" {
 			continue
 		}
-
-		if appIndex >= len(a.uwpItems) {
-			uwpItem := &UWPMenuItem{App: &app}
-			item := a.uwpMenu.AddCheckbox(app.Name, app.Exempt, func(u *UWPMenuItem) func() {
-				return func() { a.onUWPItemClicked(u) }
-			}(uwpItem))
-			uwpItem.MenuItem = item
-			item.SetChecked(app.Exempt)
-			a.uwpItems = append(a.uwpItems, uwpItem)
-			needsRebuild = true
-		} else {
-			uwpItem := a.uwpItems[appIndex]
-			uwpItem.Mu.Lock()
-			uwpItem.App = &app
-			uwpItem.Mu.Unlock()
-
-			uwpItem.MenuItem.SetLabel(app.Name)
-			uwpItem.MenuItem.SetDisabled(false)
-			uwpItem.MenuItem.SetChecked(app.Exempt)
+		if slot >= len(a.uwpItems) {
+			break
 		}
-		appIndex++
+		app := &apps[i]
+		uwpItem := a.uwpItems[slot]
+
+		uwpItem.Mu.Lock()
+		uwpItem.App = app
+		uwpItem.Mu.Unlock()
+
+		uwpItem.MenuItem.SetLabel(app.Name)
+		uwpItem.MenuItem.SetDisabled(false)
+		uwpItem.MenuItem.SetChecked(app.Exempt)
+		slot++
 	}
 
-	for i := appIndex; i < len(a.uwpItems); i++ {
+	// Slots without a corresponding app are disabled (their previous label
+	// is preserved so the user still sees which app used to sit there).
+	for i := slot; i < len(a.uwpItems); i++ {
 		uwpItem := a.uwpItems[i]
 		uwpItem.MenuItem.SetDisabled(true)
 		uwpItem.Mu.Lock()
@@ -90,8 +130,14 @@ func (a *TrayApp) uwpRefresh() {
 		uwpItem.Mu.Unlock()
 	}
 
-	if needsRebuild && a.tray != nil {
-		a.tray.SetMenu(a.rootMenu)
+	if a.uwpOverflowHint != nil {
+		if len(apps) > len(a.uwpItems) {
+			a.uwpOverflowHint.SetLabel(fmt.Sprintf("共 %d 个应用，仅显示前 %d 个", len(apps), len(a.uwpItems)))
+		} else {
+			a.uwpOverflowHint.SetLabel(fmt.Sprintf("共 %d 个应用", len(apps)))
+		}
+		// The hint stays disabled: it is informational only, and clicking it
+		// must never do anything.
 	}
 }
 

--- a/cmd/easyss/uwp_windows_test.go
+++ b/cmd/easyss/uwp_windows_test.go
@@ -1,0 +1,129 @@
+//go:build windows && !headless
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogpu/systray"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestUWPTrayApp builds a TrayApp with a fresh UWP submenu and its
+// pre-built slot layout, without touching the real system tray.
+func newTestUWPTrayApp() *TrayApp {
+	a := &TrayApp{}
+	a.uwpMenu = systray.NewMenu()
+	a.buildUWPSlots()
+	return a
+}
+
+func makeFakeUWPApps(n, exemptCount int) []UWPApp {
+	apps := make([]UWPApp, 0, n)
+	for i := range n {
+		apps = append(apps, UWPApp{
+			Name:              fmt.Sprintf("App %03d", i),
+			PackageFamilyName: fmt.Sprintf("Fake.App_%03d_pkg", i),
+			Exempt:            i < exemptCount,
+		})
+	}
+	return apps
+}
+
+func TestUWPBuildSlots(t *testing.T) {
+	a := newTestUWPTrayApp()
+
+	require.NotNil(t, a.uwpOverflowHint)
+	require.True(t, a.uwpOverflowHint.IsDisabled())
+	require.Len(t, a.uwpItems, uwpMenuSlots)
+	for i, it := range a.uwpItems {
+		require.NotNil(t, it.MenuItem, "slot %d missing menu item", i)
+		require.True(t, it.MenuItem.IsDisabled(), "slot %d should start disabled", i)
+		require.False(t, it.MenuItem.IsChecked(), "slot %d should start unchecked", i)
+		require.Nil(t, it.App, "slot %d should start with no app", i)
+	}
+}
+
+func TestUWPApplySlots_Overflow(t *testing.T) {
+	a := newTestUWPTrayApp()
+	apps := makeFakeUWPApps(uwpMenuSlots+6, 20)
+	a.applyUWPAppsToSlots(apps)
+
+	// All slots are populated (the overflow is dropped); the first 20 are
+	// checked.
+	for i := range uwpMenuSlots {
+		require.False(t, a.uwpItems[i].MenuItem.IsDisabled(), "slot %d should be enabled", i)
+		require.Equal(t, i < 20, a.uwpItems[i].MenuItem.IsChecked(), "slot %d checked", i)
+		require.NotNil(t, a.uwpItems[i].App, "slot %d app", i)
+		require.Equal(t, apps[i].PackageFamilyName, a.uwpItems[i].App.PackageFamilyName, "slot %d pfn", i)
+	}
+	// Overflow hint stays disabled: it is informational only.
+	require.True(t, a.uwpOverflowHint.IsDisabled())
+}
+
+func TestUWPApplySlots_Partial(t *testing.T) {
+	a := newTestUWPTrayApp()
+	apps := makeFakeUWPApps(30, 5)
+	a.applyUWPAppsToSlots(apps)
+
+	for i := range 30 {
+		require.False(t, a.uwpItems[i].MenuItem.IsDisabled(), "slot %d should be enabled", i)
+		require.NotNil(t, a.uwpItems[i].App, "slot %d app", i)
+	}
+	for i := 30; i < uwpMenuSlots; i++ {
+		require.True(t, a.uwpItems[i].MenuItem.IsDisabled(), "slot %d should stay disabled", i)
+		require.Nil(t, a.uwpItems[i].App, "slot %d app should be nil", i)
+	}
+	// Overflow hint stays disabled: it is informational only.
+	require.True(t, a.uwpOverflowHint.IsDisabled())
+}
+
+func TestUWPApplySlots_Empty(t *testing.T) {
+	a := newTestUWPTrayApp()
+	a.applyUWPAppsToSlots(nil)
+
+	for i := range uwpMenuSlots {
+		require.True(t, a.uwpItems[i].MenuItem.IsDisabled(), "slot %d should stay disabled", i)
+		require.Nil(t, a.uwpItems[i].App, "slot %d app", i)
+	}
+}
+
+func TestUWPApplySlots_SkipsInvalid(t *testing.T) {
+	a := newTestUWPTrayApp()
+
+	apps := []UWPApp{
+		{Name: "", PackageFamilyName: "Bad.NoName_pkg"},   // skipped: no name
+		{Name: "Good", PackageFamilyName: "Good.App_pkg"}, // fills slot 0
+		{Name: "NoPfn", PackageFamilyName: ""},            // skipped: no PFN
+	}
+	a.applyUWPAppsToSlots(apps)
+
+	require.False(t, a.uwpItems[0].MenuItem.IsDisabled())
+	require.NotNil(t, a.uwpItems[0].App)
+	require.Equal(t, "Good.App_pkg", a.uwpItems[0].App.PackageFamilyName)
+
+	require.True(t, a.uwpItems[1].MenuItem.IsDisabled())
+	require.Nil(t, a.uwpItems[1].App)
+}
+
+// TestUWPApplySlots_Twice ensures repeated refreshes are idempotent: the
+// slot count never grows and disabled state converges after apps disappear.
+func TestUWPApplySlots_Twice(t *testing.T) {
+	a := newTestUWPTrayApp()
+
+	a.applyUWPAppsToSlots(makeFakeUWPApps(10, 3))
+	require.Len(t, a.uwpItems, uwpMenuSlots)
+
+	a.applyUWPAppsToSlots(makeFakeUWPApps(8, 1))
+	require.Len(t, a.uwpItems, uwpMenuSlots)
+	for i := range 8 {
+		require.False(t, a.uwpItems[i].MenuItem.IsDisabled(), "slot %d should be enabled", i)
+	}
+	for i := 8; i < 10; i++ {
+		require.True(t, a.uwpItems[i].MenuItem.IsDisabled(), "slot %d should be disabled", i)
+		require.Nil(t, a.uwpItems[i].App, "slot %d app should be nil", i)
+	}
+	// Slots beyond the previous fill are untouched.
+	require.True(t, a.uwpItems[10].MenuItem.IsDisabled())
+}


### PR DESCRIPTION
﻿## 背景

上游 `gogpu/systray`（v0.3.0）存在 bug（[gogpu/systray#39](https://github.com/gogpu/systray/issues/39)）：每次 `SetMenu` 都会重置 command ID 计数器并按树顺序重新编号所有菜单项、重建 dispatch map。若菜单打开期间后台 goroutine 调用了 `SetMenu` 且布局形状变化（增删项），点击返回的旧 ID 会在新 map 中别名到另一项，触发错误回调。

本项目唯一触发点：`uwpRefresh()` 在 UWP 应用数量变化时调用 `SetMenu` 重建整个根菜单，导致其后"查看日志 / 检查更新 / 退出"等项 ID 移位——与 issue 中观察到的误触发 `[UWP] Added exemption` 场景一致。

## 修复方式

采用**固定槽位**策略，运行时永不重建菜单：

- `uwpMenuSlots = 48`：启动时一次性预建 48 个 checkbox 槽位 + 1 个提示项
- 刷新（`applyUWPAppsToSlots`）只做 in-place 的 `SetLabel / SetChecked / SetDisabled` 更新，删除 `SetMenu` 重建分支
- 超出槽位的应用截断，提示项显示"共 N 个应用，仅显示前 48 个"（保持禁用）
- 新增 6 个单元测试覆盖槽位构建、溢出、部分填充、空列表、无效项过滤、重复刷新幂等

## 取舍

- 槽位上限 48（可调常量），超出部分截断并明示
- 首次刷新完成前子菜单显示灰色占位项（约 1–3 秒）
- macOS/Linux 上本项目无运行时 `SetMenu`，不受影响

## 验证

- `go build ./...` / `go vet` / `make lint` 通过
- `go test ./cmd/easyss/` 全量通过（含新增 6 个 UWP 用例）
- 静态确认运行时 `SetMenu` 调用点清零
