### PR TITLE
refactor: make tun-helper an internal subcommand and fix /tun auth

### DIFF
--- a/client/proxy/http_proxy.go
+++ b/client/proxy/http_proxy.go
@@ -49,7 +49,7 @@ type HTTPProxyServer struct {
 	server     *http.Server
 	mu         sync.Mutex
 
-	// TUN helper support (macOS): config served at GET /tun.
+	// TUN helper support (darwin/linux): config served at GET /tun.
 	tunCfg *TunConfig
 	tunMu  sync.RWMutex
 }
@@ -146,6 +146,24 @@ func (s *HTTPProxyServer) Start() error {
 }
 
 func (s *HTTPProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Serve /tun before the proxy auth check: the elevated TUN helper
+	// (darwin/linux) fetches its configuration without credentials. The
+	// endpoint is restricted to loopback sources so the config is never
+	// exposed on the network when the proxy listens on all interfaces
+	// (bind_all).
+	if r.URL.Host == "" && r.URL.Path == "/tun" {
+		if !isLoopbackRequest(r) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		if r.Method == http.MethodGet {
+			s.handleTunGET(w)
+		} else {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+		return
+	}
+
 	if !s.authOK(r) {
 		w.Header().Set("Proxy-Authenticate", `Basic realm="Easyss"`)
 		http.Error(w, "Proxy auth required", http.StatusProxyAuthRequired)
@@ -155,16 +173,6 @@ func (s *HTTPProxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Serve /stats for direct requests to the proxy.
 	if r.URL.Host == "" && r.URL.Path == "/stats" {
 		s.serveStats(w)
-		return
-	}
-
-	// Serve /tun for TUN configuration (macOS helper).
-	if r.URL.Host == "" && r.URL.Path == "/tun" {
-		if r.Method == http.MethodGet {
-			s.handleTunGET(w)
-		} else {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		}
 		return
 	}
 
@@ -195,7 +203,7 @@ func (s *HTTPProxyServer) serveStats(w http.ResponseWriter) {
 }
 
 // SetTunConfig stores the TUN configuration served at GET /tun.
-// Called before spawning the TUN helper on macOS.
+// Called before spawning the TUN helper on darwin/linux.
 func (s *HTTPProxyServer) SetTunConfig(cfg *TunConfig) {
 	s.tunMu.Lock()
 	defer s.tunMu.Unlock()
@@ -258,6 +266,19 @@ func (s *HTTPProxyServer) isSelfTarget(r *http.Request) bool {
 	}
 	_, local := localIPSet()[ip.String()]
 	return ip.IsLoopback() || local
+}
+
+// isLoopbackRequest reports whether the request originated from a loopback
+// address (the local host itself). It guards the control endpoints (e.g.
+// GET /tun) so they are only reachable from this machine even when the
+// proxy listens on all interfaces.
+func isLoopbackRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 const localIPsCacheTTL = 60 * time.Second

--- a/client/proxy/tun_endpoint_test.go
+++ b/client/proxy/tun_endpoint_test.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newTunTestServer builds an HTTPProxyServer with proxy credentials
+// configured, mimicking a real deployment where the /tun endpoint must be
+// reachable by the unauthenticated TUN helper over loopback.
+func newTunTestServer(t *testing.T) *HTTPProxyServer {
+	t.Helper()
+	s, err := NewHTTPProxyServer("127.0.0.1:0", "127.0.0.1:4080", "user", "pass", 5*time.Second, nil, nil, 0, nil)
+	if err != nil {
+		t.Fatalf("NewHTTPProxyServer: %v", err)
+	}
+	return s
+}
+
+func testTunConfig() *TunConfig {
+	return &TunConfig{
+		Socks5Addr:   "socks5://127.0.0.1:4080",
+		DNSAddr:      "127.0.0.1",
+		Device:       "utun9",
+		TunIP:        "198.18.0.1",
+		TunGW:        "198.18.0.1",
+		TunMask:      "255.255.0.0",
+		LocalGateway: "192.168.1.1",
+		MTU:          1500,
+	}
+}
+
+// TestTunEndpointServedWithoutProxyAuth verifies the TUN helper can fetch
+// GET /tun without proxy credentials even when auth is configured (the
+// helper has no way to obtain them).
+func TestTunEndpointServedWithoutProxyAuth(t *testing.T) {
+	s := newTunTestServer(t)
+	s.SetTunConfig(testTunConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/tun", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /tun from loopback without proxy auth: code = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got TunConfig
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode tun config: %v", err)
+	}
+	if got.Device != "utun9" || got.Socks5Addr != "socks5://127.0.0.1:4080" {
+		t.Fatalf("unexpected tun config: %+v", got)
+	}
+}
+
+// TestTunEndpointRejectsNonLoopbackSource verifies /tun is never served to
+// non-loopback clients (protects the config when bind_all is enabled).
+func TestTunEndpointRejectsNonLoopbackSource(t *testing.T) {
+	s := newTunTestServer(t)
+	s.SetTunConfig(testTunConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/tun", nil)
+	req.RemoteAddr = "192.168.1.100:5555"
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("GET /tun from non-loopback source: code = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+// TestTunEndpointNotConfiguredReturns503 verifies the helper's retry loop
+// still sees 503 when the parent has not registered a TUN config yet.
+func TestTunEndpointNotConfiguredReturns503(t *testing.T) {
+	s := newTunTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/tun", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /tun before SetTunConfig: code = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+// TestProxyAuthStillRequiredForProxyRequests verifies the auth exemption is
+// scoped to /tun only: ordinary proxy requests still require credentials.
+func TestProxyAuthStillRequiredForProxyRequests(t *testing.T) {
+	s := newTunTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusProxyAuthRequired {
+		t.Fatalf("proxy request without credentials: code = %d, want %d", rec.Code, http.StatusProxyAuthRequired)
+	}
+}

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -30,20 +30,21 @@ import (
 )
 
 func main() {
-	// The "selfupdate" subcommand is handled before flag parsing so it never
-	// collides with the proxy flags. It replaces the running binary and
-	// exits without starting anything.
+	// The "selfupdate" and "tun-helper" subcommands are handled before flag
+	// parsing so they never collide with the proxy flags. selfupdate replaces
+	// the running binary and exits; tun-helper runs this binary as the
+	// elevated TUN helper (spawned internally by the tray process) and exits.
 	if runSelfupdateSubcommand() {
 		return
 	}
+	if runTunHelperSubcommand() {
+		return
+	}
 
-	var printVer, showConfigExample, showConfigExampleSimple, daemon, disableTray, enableTun2socks, tunHelper bool
+	var printVer, showConfigExample, showConfigExampleSimple, daemon, disableTray, enableTun2socks bool
 	var configFile, cmdOutboundProto string
 	var pprofEnabled bool
 	var logFile string
-
-	// TUN helper flags (used when --tun-helper is set).
-	var tunHTTPAddr, tunFDSocket string
 
 	sc := &sharedconfig.SimpleConfig{}
 
@@ -66,16 +67,14 @@ func main() {
 	flag.BoolVar(&daemon, "daemon", runtime.GOOS != "windows", "run app as daemon")
 	flag.BoolVar(&disableTray, "disable-tray", false, "disable system tray (windows/mac only)")
 	flag.BoolVar(&enableTun2socks, "enable-tun2socks", false, "enable tun2socks model")
-	flag.BoolVar(&tunHelper, "tun-helper", false, "run TUN helper (macOS privilege separation, internal)")
-	flag.StringVar(&tunHTTPAddr, "tun-http-addr", "", "HTTP address for helper to fetch config")
-	flag.StringVar(&tunFDSocket, "tun-fd-socket", "", "Unix socket path for fd passing to parent")
 	flag.StringVar(&sc.IPV6Rule, "ipv6-rule", "", "set the ipv6 rule(auto, enable, disable), default: auto")
 	flag.StringVar(&sc.DirectFile, "direct-file", "", "custom direct file (IPs/CIDRs/domains/regexps mixed, one per line; supports regexp: prefix and * glob)")
 	flag.StringVar(&sc.ProxyFile, "proxy-file", "", "custom proxy file (IPs/CIDRs/domains/regexps mixed, one per line; supports regexp: prefix and * glob)")
 	flag.BoolVar(&pprofEnabled, "pprof", false, "enable pprof debug server on :6060")
 
-	// Custom usage so --help/-h also introduces the "selfupdate" subcommand,
-	// which is handled before flag parsing and would otherwise be invisible.
+	// Custom usage so --help/-h also introduces the "selfupdate" and
+	// "tun-helper" subcommands, which are handled before flag parsing and
+	// would otherwise be invisible.
 	flag.Usage = func() {
 		bin := filepath.Base(os.Args[0])
 		out := flag.CommandLine.Output()
@@ -84,14 +83,18 @@ func main() {
 用法:
   %s [flags]              启动代理（托盘版默认带系统托盘，可用 --disable-tray 关闭）
   %s selfupdate [flags]   检查并升级到最新 release
+  %s tun-helper [flags]   内部：以提权 TUN 助手模式运行（由主程序自动拉起）
 
 子命令:
   selfupdate    从 GitHub 检查最新 release，并原地替换当前二进制（不自动重启）。
                 更新完成后请手动重启进程使新版本生效。支持 --check（仅检查）、
                 --proxy-port（走本地代理下载）。
+  tun-helper    内部子命令：打开 TUN 设备、配置路由/DNS 并把 fd 传回主进程，
+                由主程序在提权场景下自动拉起，请勿手动使用。支持
+                --tun-http-addr/--tun-fd-socket/--log-file/--log-level。
 
 Flags:
-`, bin, bin)
+`, bin, bin, bin)
 		flag.PrintDefaults()
 	}
 
@@ -108,13 +111,6 @@ Flags:
 	if showConfigExampleSimple {
 		fmt.Println(exampleSimpleConfig())
 		os.Exit(0)
-	}
-
-	// TUN helper is a long-running elevated process that opens the TUN device,
-	// sets up routing/DNS, passes the fd back to the parent, and stays alive
-	// monitoring stdin for the parent's lifecycle signal.
-	if tunHelper {
-		os.Exit(runTunHelper(tunHTTPAddr, tunFDSocket, logFile, sc.LogLevel))
 	}
 
 	// On macOS the app is often launched by Finder/launchd with cwd=/,

--- a/cmd/easyss/root_darwin.go
+++ b/cmd/easyss/root_darwin.go
@@ -109,11 +109,12 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 	// Ensure the socket is accessible by the elevated helper (root).
 	os.Chmod(fdSocketPath, 0666) //nolint:errcheck
 
-	// Build the helper command. The helper reads its config via GET /tun and
-	// sends the fd via the Unix socket. Stdin is connected to the FIFO.
+	// Build the helper command. The helper runs as the "tun-helper" subcommand,
+	// reads its config via GET /tun, and sends the fd via the Unix socket.
+	// Stdin is connected to the FIFO.
 	tunHTTPAddr := fmt.Sprintf("127.0.0.1:%d", httpPort)
 	helperArgs := []string{
-		"--tun-helper",
+		"tun-helper",
 		"--tun-http-addr", tunHTTPAddr,
 		"--tun-fd-socket", fdSocketPath,
 	}

--- a/cmd/easyss/root_linux.go
+++ b/cmd/easyss/root_linux.go
@@ -116,11 +116,12 @@ func SpawnTunHelper(httpPort int, fdSocketPath, logFile, logLevel string, timeou
 		return nil, nil, fmt.Errorf("listen on %s: %w", fdSocketPath, err)
 	}
 
-	// Build the helper command. The helper reads its config via GET /tun and
-	// sends the fd via the Unix socket. Stdin is connected to the FIFO.
+	// Build the helper command. The helper runs as the "tun-helper" subcommand,
+	// reads its config via GET /tun, and sends the fd via the Unix socket.
+	// Stdin is connected to the FIFO.
 	tunHTTPAddr := fmt.Sprintf("127.0.0.1:%d", httpPort)
 	helperArgs := []string{
-		"--tun-helper",
+		"tun-helper",
 		"--tun-http-addr", tunHTTPAddr,
 		"--tun-fd-socket", fdSocketPath,
 	}

--- a/cmd/easyss/tun_helper_other.go
+++ b/cmd/easyss/tun_helper_other.go
@@ -7,8 +7,8 @@ import (
 	"os"
 )
 
-// runTunHelper is a no-op on non-darwin platforms.
+// runTunHelper is a no-op on non-darwin/linux platforms.
 func runTunHelper(httpAddr, fdSocketPath, logFilePath, logLevel string) int {
-	fmt.Fprintln(os.Stderr, "tun helper is only supported on macOS")
+	fmt.Fprintln(os.Stderr, "tun helper is only supported on darwin/linux")
 	return 1
 }

--- a/cmd/easyss/tun_helper_subcommand.go
+++ b/cmd/easyss/tun_helper_subcommand.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"os"
+)
+
+// runTunHelperSubcommand handles the internal "tun-helper" subcommand: run
+// this binary as the elevated TUN helper (spawned by the tray process via
+// pkexec/osascript). It reports whether the subcommand was handled, in which
+// case the process has already exited.
+//
+// The helper is a long-running elevated process that opens the TUN device,
+// sets up routing/DNS, passes the fd back to the parent via a Unix socket,
+// and stays alive monitoring stdin for the parent's lifecycle signal. The
+// bootstrap parameters (where to fetch the TUN config from and where to send
+// the fd) cannot be derived by the helper itself — pkexec/osascript strip the
+// environment — so they are passed as subcommand flags.
+func runTunHelperSubcommand() bool {
+	if len(os.Args) < 2 || os.Args[1] != "tun-helper" {
+		return false
+	}
+
+	fs := flag.NewFlagSet("tun-helper", flag.ExitOnError)
+	var tunHTTPAddr, tunFDSocket, logFile, logLevel string
+	fs.StringVar(&tunHTTPAddr, "tun-http-addr", "", "HTTP address of the parent process to fetch config from")
+	fs.StringVar(&tunFDSocket, "tun-fd-socket", "", "Unix socket path for fd passing to parent")
+	fs.StringVar(&logFile, "log-file", "", "log file path")
+	fs.StringVar(&logLevel, "log-level", "", "log level (debug, info, warn, error)")
+	_ = fs.Parse(os.Args[2:])
+
+	os.Exit(runTunHelper(tunHTTPAddr, tunFDSocket, logFile, logLevel))
+	return true
+}


### PR DESCRIPTION
## 背景与动机

1. 主 CLI 的 flag 命名空间里有三个内部 TUN 助手参数（`--tun-helper` / `--tun-http-addr` / `--tun-fd-socket`），是提权助手机制的内部管道，对用户不可见且造成混淆。
2. 顺带修复一个真实 Bug：`GET /tun` 在 HTTP 代理服务器的 `authOK()` 校验之后才处理，一旦配置了 `auth_username` / `auth_password`，无凭据的 TUN 助手拉取配置会收到 407，导致 **TUN 全局代理无法启用**。

## 改动内容

### 1. refactor: make tun-helper an internal subcommand

- `--tun-helper` 从主 flag 重构为内部子命令 `easyss tun-helper`（与既有 `selfupdate` 子命令同一模式，在 flag 解析前按 `os.Args[1]` 分发），主 CLI 不再出现任何 `tun-*` 参数。
- `--tun-http-addr` / `--tun-fd-socket` / `--log-file` / `--log-level` 归入子命令自己的 FlagSet。
- `--tun-http-addr` 与 `--tun-fd-socket` 保留为子命令 flag：被 pkexec/osascript 拉起的提权进程环境被清空（pkexec 仅显式透传 HOME），引导信息无法通过 HTTP 自举，只能走命令行。
- 父进程 spawn 时 `helperArgs` 首项由 `--tun-helper` 改为 `tun-helper`，其余不变；提权助手逻辑（GET /tun 拉配置、开设备、配路由/DNS、SCM_RIGHTS 传 fd、FIFO 生命周期）完全不变。

### 2. fix: serve /tun without proxy auth for the TUN helper

- `GET /tun` 移到代理认证检查之前处理，并新增回环来源校验（非回环来源返回 403，防止 `bind_all` 开启时 TUN 配置被局域网读取）。
- 新增单元测试（`client/proxy/tun_endpoint_test.go`）：回环无凭据 200、非回环 403、未配置 503、普通代理请求仍需认证 407。

## 测试

- `make lint`：0 issues
- `go test ./...`：全量通过
- `go build ./...`：Windows 本机 + darwin/linux 交叉编译通过
- CLI 验证：`easyss --help` 不再出现三个 `tun-*` flag，新增 `tun-helper` 子命令说明；`easyss tun-helper --help` 正常列出子命令的 4 个 flag

## 说明

- `/stats` 端点存在同模式的 407 问题（托盘轮询在认证配置下失效），属既有问题且涉及 bind_all 下局域网访问 `/stats` 的既有用法，本次不处理，建议后续单独评估。
- 未做「fd_socket 放入 GET /tun 响应」的改动（价值低，子命令化后归属已清晰）。
