### PR TITLE
refactor: rename server http2 transport config keys to h2_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,9 @@ regexp:^.*\.youtube\..*$ # 正则表达式：匹配包含 .youtube. 的域名
 | `shaper.cover_budget_ratio` | 否 | 0.03 | cover traffic 占真实流量的预算比例，设为 0 或负数使用默认值，范围 (0, 1] |
 | `shaper.cover_budget_cap` | 否 | 16384 | cover traffic 最大累积预算，单位字节，默认 16KB |
 | `transport.protocols` | 否 | h2 | 支持的传输协议列表，目前仅支持 `h2`，配置其他值启动时报错；未来可同时启用多个（如 h2 + h3） |
-| `transport.http2_max_frame_size` | 否 | 16777215 | 服务端 HTTP/2 最大帧大小（16MB-1），0 使用默认值 |
-| `transport.http2_recv_buf_conn` | 否 | 4194304 | 服务端连接级上行窗口（4MB），0 使用默认值 |
-| `transport.http2_recv_buf_stream` | 否 | 1048576 | 服务端流级上行窗口（1MB），0 使用默认值 |
+| `transport.h2_max_frame_size` | 否 | 16777215 | 服务端 HTTP/2 最大帧大小（16MB-1），0 使用默认值 |
+| `transport.h2_recv_buf_conn` | 否 | 4194304 | 服务端连接级上行窗口（4MB），0 使用默认值 |
+| `transport.h2_recv_buf_stream` | 否 | 1048576 | 服务端流级上行窗口（1MB），0 使用默认值 |
 | `pprof_enabled` | 否 | false | 是否启用 pprof 调试服务（127.0.0.1:6060） |
 | `timeout` | 否 | 30 | 超时时间，单位秒 |
 

--- a/cmd/easyss-server/main.go
+++ b/cmd/easyss-server/main.go
@@ -190,10 +190,10 @@ func exampleV3ServerConfig() string {
 			CoverBudgetCap:   16 * 1024,
 		},
 		Transport: config.TransportConfig{
-			Protocols:          []string{"h2"},
-			HTTP2MaxFrameSize:  sharedconfig.HTTP2ServerMaxReadFrameSize,
-			HTTP2RecvBufConn:   sharedconfig.HTTP2ServerReceiveBufferPerConnection,
-			HTTP2RecvBufStream: sharedconfig.HTTP2ServerReceiveBufferPerStream,
+			Protocols:       []string{"h2"},
+			H2MaxFrameSize:  sharedconfig.HTTP2ServerMaxReadFrameSize,
+			H2RecvBufConn:   sharedconfig.HTTP2ServerReceiveBufferPerConnection,
+			H2RecvBufStream: sharedconfig.HTTP2ServerReceiveBufferPerStream,
 		},
 		NextProxy: config.NextProxyConfig{
 			URL:           "",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -11,10 +11,10 @@ type LogConfig struct {
 }
 
 type TransportConfig struct {
-	Protocols          []string `json:"protocols"`
-	HTTP2MaxFrameSize  int      `json:"http2_max_frame_size"`
-	HTTP2RecvBufConn   int      `json:"http2_recv_buf_conn"`
-	HTTP2RecvBufStream int      `json:"http2_recv_buf_stream"`
+	Protocols       []string `json:"protocols"`
+	H2MaxFrameSize  int      `json:"h2_max_frame_size"`
+	H2RecvBufConn   int      `json:"h2_recv_buf_conn"`
+	H2RecvBufStream int      `json:"h2_recv_buf_stream"`
 }
 
 type FallbackConfig struct {

--- a/server/server.go
+++ b/server/server.go
@@ -342,14 +342,14 @@ func buildHTTPServer(cfg *config.ServerConfig, tlsConfig *tls.Config, mux *http.
 		MaxReceiveBufferPerConnection: sharedconfig.HTTP2ServerReceiveBufferPerConnection,
 		MaxReceiveBufferPerStream:     sharedconfig.HTTP2ServerReceiveBufferPerStream,
 	}
-	if cfg.Transport.HTTP2MaxFrameSize > 0 {
-		http2Cfg.MaxReadFrameSize = cfg.Transport.HTTP2MaxFrameSize
+	if cfg.Transport.H2MaxFrameSize > 0 {
+		http2Cfg.MaxReadFrameSize = cfg.Transport.H2MaxFrameSize
 	}
-	if cfg.Transport.HTTP2RecvBufConn > 0 {
-		http2Cfg.MaxReceiveBufferPerConnection = cfg.Transport.HTTP2RecvBufConn
+	if cfg.Transport.H2RecvBufConn > 0 {
+		http2Cfg.MaxReceiveBufferPerConnection = cfg.Transport.H2RecvBufConn
 	}
-	if cfg.Transport.HTTP2RecvBufStream > 0 {
-		http2Cfg.MaxReceiveBufferPerStream = cfg.Transport.HTTP2RecvBufStream
+	if cfg.Transport.H2RecvBufStream > 0 {
+		http2Cfg.MaxReceiveBufferPerStream = cfg.Transport.H2RecvBufStream
 	}
 
 	srv := &http.Server{


### PR DESCRIPTION
## 背景

服务端传输配置中有 3 个以 `http2_` 开头的 JSON 配置键，本次统一重命名为更简洁的 `h2_*` 前缀（与客户端 `transport.protocol: "h2"` 命名风格一致）。

## 改动

| 旧键 | 新键 |
| --- | --- |
| `transport.http2_max_frame_size` | `transport.h2_max_frame_size` |
| `transport.http2_recv_buf_conn` | `transport.h2_recv_buf_conn` |
| `transport.http2_recv_buf_stream` | `transport.h2_recv_buf_stream` |

涉及文件：

- `server/config/config.go`：`TransportConfig` 字段与 JSON tag 重命名（`HTTP2*` → `H2*`）
- `server/server.go`：`buildHTTPServer` 中 3 处字段引用同步更新
- `cmd/easyss-server/main.go`：`-show-config-example` 示例配置同步更新
- `README.md`：配置表键名更新

## 兼容性说明

尚未发布正式版，直接重命名、不兼容旧键：已有配置中的 `http2_*` 旧键会被忽略并回退默认值（默认值与文档一致：16777215 / 4194304 / 1048576），不做向后兼容。

## 验证

- `go build ./...` 通过
- `go test ./...` 全部通过
- `make lint` 0 issues
- `-show-config-example` 输出已包含 `h2_max_frame_size` / `h2_recv_buf_conn` / `h2_recv_buf_stream`
