### PR TITLE
fix: bound server ipv6 resolution and log startup timings

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -184,7 +184,20 @@ var boundDialContext = func(c *Client, ctx context.Context, network, addr string
 	return c.dialer.Load().DialContext(ctx, network, addr)
 }
 
+// serverIPV6ResolveTimeout bounds the synchronous server-IPv6 resolution in
+// client.New. Resolving the server's AAAA records requires DNS round-trips
+// against the direct DNS servers; on networks where those servers are
+// unreachable, the per-query 5s timeout (times the number of servers) could
+// otherwise stall proxy startup for many seconds on every launch (most
+// noticeable on mobile, where the VPN must not go live before the proxy is
+// ready). 3s is enough for a healthy network and keeps the worst case short;
+// on timeout the router simply treats IPv6 as unavailable (the auto-mode
+// safe default). Overridable in tests.
+var serverIPV6ResolveTimeout = 3 * time.Second
+
 func New(cfg *config.ClientConfig) (*Client, error) {
+	start := time.Now()
+
 	masterKey, err := crypto.DeriveMasterKey(cfg.DefaultServer().Password)
 	if err != nil {
 		return nil, err
@@ -203,8 +216,17 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 	serverIPV6 := ""
 	ipv6Networking := false
 	if router.ParseIPV6Rule(cfg.Routing.IPV6Rule) != router.IPV6RuleDisable {
-		serverIPV6 = resolveServerIPV6(cfg)
+		// Bound the whole resolution (builtin + system dns fallback) so an
+		// unreachable DNS server cannot stall startup for 5s per lookup.
+		ctx, cancel := context.WithTimeout(context.Background(), serverIPV6ResolveTimeout)
+		serverIPV6 = resolveServerIPV6(ctx, cfg)
+		cancel()
 		ipv6Networking = detectIPV6Networking()
+		log.Info("[CLIENT] server ipv6 resolved",
+			"ipv6_rule", cfg.Routing.IPV6Rule,
+			"server_ipv6", serverIPV6,
+			"elapsed_ms", time.Since(start).Milliseconds(),
+		)
 	}
 	rt.SetIPV6Info(ipv6Networking, serverIPV6)
 
@@ -213,6 +235,7 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 		"ipv6_rule", cfg.Routing.IPV6Rule,
 		"ipv6_networking", ipv6Networking,
 		"server_ipv6", serverIPV6,
+		"elapsed_ms", time.Since(start).Milliseconds(),
 	)
 
 	tlsCfg := cfg.UTLSConfig()
@@ -270,7 +293,7 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 
 	client.transport = tr
 
-	log.Info("[CLIENT] transport initialized", "server_url", cfg.ServerURL(), "max_slots", cfg.Transport.ConnCountMax, "stream_threshold", cfg.Transport.StreamThreshold, "server_addr", cfg.DefaultServerAddr(), "direct_iface", directIface)
+	log.Info("[CLIENT] transport initialized", "server_url", cfg.ServerURL(), "max_slots", cfg.Transport.ConnCountMax, "stream_threshold", cfg.Transport.StreamThreshold, "server_addr", cfg.DefaultServerAddr(), "direct_iface", directIface, "elapsed_ms", time.Since(start).Milliseconds())
 
 	go client.closeIdleLoop()
 	go client.dialerRefreshLoop()
@@ -419,7 +442,7 @@ func isInterfaceStaleError(err error) bool {
 	return false
 }
 
-func resolveServerIPV6(cfg *config.ClientConfig) string {
+func resolveServerIPV6(ctx context.Context, cfg *config.ClientConfig) string {
 	svr := cfg.DefaultServer()
 	if svr == nil {
 		return ""
@@ -434,8 +457,12 @@ func resolveServerIPV6(cfg *config.ClientConfig) string {
 	if dns.BuiltinDNSAvailable() {
 		reachable := false
 		for _, dnsServer := range config.DirectDNSServers {
-			ips, err := dns.LookupIPV6From(dnsServer, svr.Address)
+			ips, err := dns.LookupIPV6FromContext(ctx, dnsServer, svr.Address)
 			if err != nil {
+				if ctx.Err() != nil {
+					log.Warn("[CLIENT] server ipv6 resolution timed out", "server", svr.Address, "err", ctx.Err())
+					return ""
+				}
 				continue
 			}
 			// the server answered (possibly NODATA), so the builtin dns
@@ -456,8 +483,12 @@ func resolveServerIPV6(cfg *config.ClientConfig) string {
 	// fallback to the system dns servers when all builtin direct dns servers
 	// are unavailable
 	for _, dnsServer := range dns.SystemDNSServers() {
-		ips, err := dns.LookupIPV6From(dnsServer, svr.Address)
+		ips, err := dns.LookupIPV6FromContext(ctx, dnsServer, svr.Address)
 		if err != nil || len(ips) == 0 {
+			if ctx.Err() != nil {
+				log.Warn("[CLIENT] server ipv6 resolution timed out", "server", svr.Address, "err", ctx.Err())
+				return ""
+			}
 			continue
 		}
 		return ips[0].String()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,1 +1,102 @@
 package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/nange/easyss/v3/client/config"
+	easydns "github.com/nange/easyss/v3/client/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startLocalDNSServer starts a local UDP DNS server answering AAAA queries
+// for "test.local." with ::1 (mirrors client/dns/lookup_test.go).
+func startLocalDNSServer(t *testing.T) (string, func()) {
+	t.Helper()
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0") // random available port
+	require.NoError(t, err)
+
+	server := &dns.Server{
+		PacketConn: pc,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			for _, q := range r.Question {
+				if q.Qtype == dns.TypeAAAA {
+					m.Answer = append(m.Answer, &dns.AAAA{
+						Hdr: dns.RR_Header{
+							Name:   q.Name,
+							Rrtype: dns.TypeAAAA,
+							Class:  dns.ClassINET,
+							Ttl:    60,
+						},
+						AAAA: net.ParseIP("::1"),
+					})
+				}
+			}
+			_ = w.WriteMsg(m)
+		}),
+	}
+
+	go func() {
+		_ = server.ActivateAndServe()
+	}()
+
+	return pc.LocalAddr().String(), func() {
+		_ = server.Shutdown()
+	}
+}
+
+func TestResolveServerIPV6IPServer(t *testing.T) {
+	cfg := &config.ClientConfig{
+		Servers: []*config.ServerProfile{{Address: "2001:db8::1", Default: true}},
+	}
+	assert.Equal(t, "2001:db8::1", resolveServerIPV6(context.Background(), cfg))
+
+	cfg = &config.ClientConfig{
+		Servers: []*config.ServerProfile{{Address: "1.2.3.4", Default: true}},
+	}
+	assert.Equal(t, "", resolveServerIPV6(context.Background(), cfg))
+}
+
+func TestResolveServerIPV6BoundedByContext(t *testing.T) {
+	// A blackhole direct DNS server makes every lookup fail; the context
+	// deadline must bound the whole resolution instead of the per-query 5s
+	// timeout stalling startup.
+	old := config.DirectDNSServers
+	config.DirectDNSServers = []string{"127.0.0.1:1"}
+	defer func() { config.DirectDNSServers = old }()
+	easydns.MarkBuiltinDNSAvailable()
+
+	cfg := &config.ClientConfig{
+		Servers: []*config.ServerProfile{{Address: "proxy.example.com", Default: true}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	got := resolveServerIPV6(ctx, cfg)
+	assert.Equal(t, "", got)
+	assert.Less(t, time.Since(start), 2*time.Second)
+}
+
+func TestResolveServerIPV6WithLocalDNS(t *testing.T) {
+	addr, shutdown := startLocalDNSServer(t)
+	defer shutdown()
+
+	old := config.DirectDNSServers
+	config.DirectDNSServers = []string{addr}
+	defer func() { config.DirectDNSServers = old }()
+	easydns.MarkBuiltinDNSAvailable()
+
+	cfg := &config.ClientConfig{
+		Servers: []*config.ServerProfile{{Address: "test.local", Default: true}},
+	}
+	got := resolveServerIPV6(context.Background(), cfg)
+	assert.Equal(t, net.ParseIP("::1").String(), got)
+}

--- a/client/dns/lookup.go
+++ b/client/dns/lookup.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -10,22 +11,30 @@ import (
 
 // DNSMsgTypeA sends a DNS A record query for domain to the specified server.
 func DNSMsgTypeA(dnsServer, domain string) (*dns.Msg, error) {
-	return queryMsg(dns.TypeA, dnsServer, domain)
+	return queryMsg(context.Background(), dns.TypeA, dnsServer, domain)
 }
 
 // DNSMsgTypeAAAA sends a DNS AAAA record query for domain to the specified server.
 func DNSMsgTypeAAAA(dnsServer, domain string) (*dns.Msg, error) {
-	return queryMsg(dns.TypeAAAA, dnsServer, domain)
+	return queryMsg(context.Background(), dns.TypeAAAA, dnsServer, domain)
 }
 
-func queryMsg(dnsType uint16, dnsServer, domain string) (*dns.Msg, error) {
+// DNSMsgTypeAAAAContext is DNSMsgTypeAAAA bounded by ctx: the query fails as
+// soon as the context is done, even if the per-query client timeout (5s) has
+// not elapsed. Used by startup paths (server IPv6 resolution) that must not
+// stall proxy initialization on unreachable DNS servers.
+func DNSMsgTypeAAAAContext(ctx context.Context, dnsServer, domain string) (*dns.Msg, error) {
+	return queryMsg(ctx, dns.TypeAAAA, dnsServer, domain)
+}
+
+func queryMsg(ctx context.Context, dnsType uint16, dnsServer, domain string) (*dns.Msg, error) {
 	c := &dns.Client{UDPSize: 8192, Timeout: 5 * time.Second}
 
 	m := &dns.Msg{}
 	m.SetQuestion(dns.Fqdn(domain), dnsType)
 	m.RecursionDesired = true
 
-	r, _, err := c.Exchange(m, dnsServer)
+	r, _, err := c.ExchangeContext(ctx, m, dnsServer)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +64,17 @@ func LookupIPV4From(dnsServer, domain string) ([]net.IP, error) {
 
 // LookupIPV6From resolves IPv6 addresses for domain from the specified DNS server.
 func LookupIPV6From(dnsServer, domain string) ([]net.IP, error) {
-	msgAAAA, err := DNSMsgTypeAAAA(dnsServer, domain)
+	return lookupIPV6From(context.Background(), dnsServer, domain)
+}
+
+// LookupIPV6FromContext is LookupIPV6From bounded by ctx (see
+// DNSMsgTypeAAAAContext).
+func LookupIPV6FromContext(ctx context.Context, dnsServer, domain string) ([]net.IP, error) {
+	return lookupIPV6From(ctx, dnsServer, domain)
+}
+
+func lookupIPV6From(ctx context.Context, dnsServer, domain string) ([]net.IP, error) {
+	msgAAAA, err := DNSMsgTypeAAAAContext(ctx, dnsServer, domain)
 	if err != nil || msgAAAA == nil {
 		return nil, err
 	}

--- a/client/dns/lookup_test.go
+++ b/client/dns/lookup_test.go
@@ -1,8 +1,10 @@
 package dns
 
 import (
+	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
@@ -80,4 +82,17 @@ func TestLookupIPV6From(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, len(ips), 0)
 	assert.Equal(t, net.ParseIP("::1").String(), ips[0].String())
+}
+
+// TestLookupIPV6FromContextBounded verifies the context-bounded variant
+// returns promptly instead of waiting out the per-query 5s timeout when the
+// context deadline expires.
+func TestLookupIPV6FromContextBounded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := LookupIPV6FromContext(ctx, "127.0.0.1:1", "test.local")
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 2*time.Second)
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/nange/easyss/v3/client"
 	"github.com/nange/easyss/v3/client/config"
@@ -30,10 +31,13 @@ type Core struct {
 }
 
 func Run(cfg *config.ClientConfig) (*Core, error) {
+	start := time.Now()
+
 	cli, err := client.New(cfg)
 	if err != nil {
 		return nil, err
 	}
+	log.Info("[EASYSS] client core ready", "elapsed_ms", time.Since(start).Milliseconds())
 
 	method := protocol.MethodFromString(cfg.DefaultServer().Method)
 	if method == 0 {
@@ -145,7 +149,7 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 		}()
 	}
 
-	log.Info("[EASYSS] started successfully")
+	log.Info("[EASYSS] started successfully", "elapsed_ms", time.Since(start).Milliseconds())
 	// Start a fresh stats session: the process may host multiple
 	// start/stop cycles (e.g. Android), so reset both the session
 	// start time and all counters.


### PR DESCRIPTION
﻿## 背景

手机端（EasyssTun）首次开启代理后打开网页需要 10s+ 甚至多次刷新，桌面端无此问题。排查发现其中一个根因：`client.New` 在启动时会**同步串行**解析代理服务器的 IPv6（AAAA）记录——对 4 个直连 DNS 服务器逐个查询，每个最坏 5s 超时；当网络到达这些 DNS 不通时（如海外网络访问国内 DNS），`Mobile.start()` 会被阻塞 5~20s，放大"VPN 已通、代理未就绪"的死窗，导致首次 DNS/页面请求超时。

## 改动

- `client/dns/lookup.go`：新增 context 感知的 DNS 查询变体 `LookupIPV6FromContext` / `DNSMsgTypeAAAAContext`（miekg/dns `ExchangeContext`），原函数保持不变，向后兼容
- `client/client.go`：`resolveServerIPV6` 改为受 `serverIPV6ResolveTimeout`（3s）总时限约束，超时按"无 IPv6"安全降级（auto 模式路由自然禁用 IPv6），并记录超时 warning 日志
- 启动时序日志：`client.New`（router / ipv6 / transport 各阶段 `elapsed_ms`）与 `runner.Run`（`[EASYSS] client core ready` / `started successfully` 总耗时），便于定位慢启动

## 验证

- 新增单元测试：`client_test.go`（IPv6 解析受 context 约束、IP 服务器短路、本地 DNS 正常解析）与 `lookup_test.go`（context 过期立即返回）
- `go test ./...` 全绿；golangci-lint 0 issues；`go fix` 无变更
- 配套的 EasyssTun 侧修复（VPN 就绪门控）见 EasyssTun 仓库对应 PR
