### PR TITLE
feat: pre-warm the first connection on startup (mobile)

### DIFF
--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/rand/v2"
 	"net"
 	"strings"
 	"time"
@@ -46,6 +47,74 @@ func (s *Socks5Server) handleUDP(srv *socks5.Server, clientAddr *net.UDPAddr, d 
 	}
 
 	return s.handleRegularUDP(srv, clientAddr, d, dst)
+}
+
+// WarmUp primes the proxied path right after startup without adding a
+// detectable traffic pattern: it waits a random jitter, then opens a UDP
+// exchange to the proxied DNS server carrying a benign A-record query for
+// domain and closes it immediately. The synchronous open establishes the
+// first HTTP/2 connection (dial + TLS + bootstrap handshake), so the first
+// real page load no longer pays the multi-second cold-start cost. Closing
+// right after the open keeps the stream short, and the query itself travels
+// inside the encrypted tunnel (visible only to the user's own server) and
+// mirrors the domain Android's own connectivity check queries anyway, so
+// the stream is behaviorally indistinguishable from the check's.
+//
+// jitterMin..jitterMax randomize the warm-up moment so startup traffic is
+// not a fixed, machine-timed event. Best-effort by contract: every failure
+// is logged and swallowed — startup must never depend on warm-up.
+func (s *Socks5Server) WarmUp(domain string, jitterMin, jitterMax, timeout time.Duration) {
+	if s == nil || s.closing.Load() {
+		return
+	}
+	if jitterMax > 0 {
+		d := jitterMin
+		if span := jitterMax - jitterMin; span > 0 {
+			d += time.Duration(rand.Float64() * float64(span))
+		}
+		select {
+		case <-time.After(d):
+		case <-s.quit:
+			return
+		}
+	}
+
+	msg := &dns.Msg{}
+	msg.SetQuestion(dns.Fqdn(domain), dns.TypeA)
+	msg.RecursionDesired = true
+	data, err := msg.Pack()
+	if err != nil {
+		log.Debug("[WARMUP] pack query", "domain", domain, "err", err)
+		return
+	}
+
+	dst := config.ProxyDNSServer
+	key := "warmup_0_" + strings.ToLower(domain)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ue, created, err := s.getOrCreateUDPExchange(ctx, key, dst, data)
+	if err != nil {
+		log.Warn("[WARMUP] open exchange failed", "domain", domain, "err", err)
+		return
+	}
+	if !created {
+		// A real flow beat us to the exchange; the connection is (being)
+		// warmed already.
+		log.Debug("[WARMUP] exchange already exists, skip", "domain", domain)
+		return
+	}
+
+	// The connection is warm once the exchange is open; close it right away
+	// and deliberately do not wait for the DNS response, keeping the stream
+	// short and the traffic pattern minimal.
+	stats.RecordDNSProxyQuery()
+	s.udpMu.Lock()
+	delete(s.udpExch, key)
+	s.udpMu.Unlock()
+	ue.Close() //nolint:errcheck
+	log.Info("[WARMUP] done", "domain", domain)
 }
 
 func (s *Socks5Server) handleDNS(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg) error {
@@ -200,7 +269,7 @@ func (s *Socks5Server) proxyDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr
 	dst := config.ProxyDNSServer
 	key := clientAddr.String() + "_" + dst
 
-	ue, created, err := s.getOrCreateUDPExchange(key, dst, d.Data)
+	ue, created, err := s.getOrCreateUDPExchange(context.Background(), key, dst, d.Data)
 	if err != nil {
 		log.Error("[UDP_PROXY] open exchange", "dst", dst, "err", err)
 		return err
@@ -234,13 +303,16 @@ const maxUDPExchanges = 128
 // bootstrap record when the exchange is newly created (saving one RTT). If
 // the exchange already existed, firstPayload is ignored. If this call created
 // the exchange, created is true and the caller MUST NOT call ue.Send for the
-// first payload (it was already sent in the handshake).
+// first payload (it was already sent in the handshake). ctx bounds the
+// exchange creation (dial + TLS + bootstrap) for callers that need a hard
+// deadline (e.g. startup warm-up); the DNS path passes context.Background()
+// and relies on its own response timeout instead.
 //
 // Concurrent creations for the same key are deduplicated through a
 // singleflight group: the first caller performs the (slow) OpenUDPExchange
 // call, concurrent waiters block and reuse the result, so exactly one
 // HTTP/2 stream and one receiveLoop exist per (client, target) flow.
-func (s *Socks5Server) getOrCreateUDPExchange(key, dst string, firstPayload []byte) (ue *UDPExchange, created bool, err error) {
+func (s *Socks5Server) getOrCreateUDPExchange(ctx context.Context, key, dst string, firstPayload []byte) (ue *UDPExchange, created bool, err error) {
 	s.udpMu.RLock()
 	existing, ok := s.udpExch[key]
 	s.udpMu.RUnlock()
@@ -272,7 +344,7 @@ func (s *Socks5Server) getOrCreateUDPExchange(key, dst string, firstPayload []by
 		s.udpInflightCount.Add(1)
 		defer s.udpInflightCount.Add(-1)
 
-		ue, err := s.handler.OpenUDPExchange(context.Background(), dst, s.method, firstPayload)
+		ue, err := s.handler.OpenUDPExchange(ctx, dst, s.method, firstPayload)
 		if err != nil {
 			return nil, err
 		}
@@ -556,7 +628,7 @@ func (s *Socks5Server) directUDPReadLoop(srv *socks5.Server, clientAddr *net.UDP
 func (s *Socks5Server) proxyUDPRelay(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, dst string) error {
 	key := clientAddr.String() + "_" + dst
 
-	ue, created, err := s.getOrCreateUDPExchange(key, dst, d.Data)
+	ue, created, err := s.getOrCreateUDPExchange(context.Background(), key, dst, d.Data)
 	if err != nil {
 		log.Error("[UDP_PROXY] open exchange", "dst", dst, "err", err)
 		return err

--- a/client/proxy/udp_timeout_test.go
+++ b/client/proxy/udp_timeout_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"net"
 	"sync"
 	"testing"
@@ -94,7 +95,7 @@ func TestUDPExchangeDNSResponseTimeout(t *testing.T) {
 	srv := newTimeoutTestServer(t, []transport.Stream{bs})
 
 	key := "127.0.0.1:12345_8.8.8.8:53"
-	ue, created, err := srv.getOrCreateUDPExchange(key, "8.8.8.8:53", []byte("dns query payload"))
+	ue, created, err := srv.getOrCreateUDPExchange(context.Background(), key, "8.8.8.8:53", []byte("dns query payload"))
 	if err != nil {
 		t.Fatalf("getOrCreateUDPExchange: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestUDPExchangeNoTimeoutWhenDisabled(t *testing.T) {
 	srv := newTimeoutTestServer(t, []transport.Stream{bs})
 
 	key := "127.0.0.1:12345_8.8.8.8:443"
-	ue, created, err := srv.getOrCreateUDPExchange(key, "8.8.8.8:443", []byte("udp payload"))
+	ue, created, err := srv.getOrCreateUDPExchange(context.Background(), key, "8.8.8.8:443", []byte("udp payload"))
 	if err != nil {
 		t.Fatalf("getOrCreateUDPExchange: %v", err)
 	}

--- a/client/proxy/warmup_test.go
+++ b/client/proxy/warmup_test.go
@@ -1,0 +1,102 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nange/easyss/v3/protocol"
+	"github.com/nange/easyss/v3/transport"
+	"golang.org/x/sync/singleflight"
+)
+
+// newTestSocksServer builds a Socks5Server wired to a mock transport so
+// WarmUp can be exercised without any real network.
+func newTestSocksServer(tr transport.Transport) *Socks5Server {
+	s := &Socks5Server{
+		handler:        newTestStreamHandler(tr),
+		method:         protocol.MethodAES256GCM,
+		udpExch:        make(map[string]*UDPExchange),
+		quit:           make(chan struct{}),
+		dnsRespTimeout: 0,
+	}
+	s.udpExchangeSF = singleflight.Group{}
+	s.directUDPSF = singleflight.Group{}
+	return s
+}
+
+func TestWarmUp_OpensAndClosesExchange(t *testing.T) {
+	tr := &mockTransport{
+		streams: []transport.Stream{
+			&mockStream{},
+		},
+	}
+	s := newTestSocksServer(tr)
+
+	// jitter 0: deterministic for tests.
+	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
+
+	if got := tr.openCalls(); got != 1 {
+		t.Errorf("expected exactly 1 transport Open (connection warmed), got %d", got)
+	}
+	if len(s.udpExch) != 0 {
+		t.Errorf("expected exchange map to be empty after warm-up, got %d entries", len(s.udpExch))
+	}
+}
+
+func TestWarmUp_NoopWhenClosing(t *testing.T) {
+	tr := &mockTransport{}
+	s := newTestSocksServer(tr)
+	s.closing.Store(true)
+
+	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
+
+	if got := tr.openCalls(); got != 0 {
+		t.Errorf("expected no transport Open when server is closing, got %d", got)
+	}
+}
+
+func TestWarmUp_NoopWhenExchangeExists(t *testing.T) {
+	tr := &mockTransport{
+		streams: []transport.Stream{
+			&mockStream{},
+			&mockStream{},
+		},
+	}
+	s := newTestSocksServer(tr)
+
+	// First call opens and closes the exchange; the second call must not
+	// open a new one beyond the first.
+	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
+	if got := tr.openCalls(); got != 1 {
+		t.Fatalf("expected 1 transport Open after first warm-up, got %d", got)
+	}
+
+	// Pre-register an exchange for the same key: the warm-up must skip it.
+	key := "warmup_0_connectivitycheck.gstatic.com"
+	s.udpMu.Lock()
+	s.udpExch[key] = &UDPExchange{}
+	s.udpMu.Unlock()
+
+	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
+	if got := tr.openCalls(); got != 1 {
+		t.Errorf("expected no additional transport Open when exchange exists, got %d", got)
+	}
+}
+
+func TestWarmUp_JitterBounded(t *testing.T) {
+	tr := &mockTransport{
+		streams: []transport.Stream{&mockStream{}},
+	}
+	s := newTestSocksServer(tr)
+
+	// jitterMax must never exceed the timeout; with a 50ms jitter window the
+	// warm-up must still complete (bounded), not hang.
+	start := time.Now()
+	s.WarmUp("connectivitycheck.gstatic.com", 10*time.Millisecond, 50*time.Millisecond, 2*time.Second)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("warm-up with jitter took too long: %v", elapsed)
+	}
+	if got := tr.openCalls(); got != 1 {
+		t.Errorf("expected 1 transport Open, got %d", got)
+	}
+}

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -3,6 +3,7 @@ package mobile
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/nange/easyss/v3/client/config"
 	sharedconfig "github.com/nange/easyss/v3/config"
@@ -13,6 +14,18 @@ import (
 var (
 	mCore *runner.Core
 	mMu   sync.Mutex
+)
+
+// Warm-up tuning: the domain mirrors what Android's own connectivity check
+// queries the moment a VPN goes live, so the warm-up stream is behaviorally
+// indistinguishable from the check's. The jitter randomizes the warm-up
+// moment so startup traffic is not a fixed, machine-timed event; the timeout
+// bounds the whole warm-up (jitter + connection establishment).
+const (
+	mobileWarmUpDomain    = "connectivitycheck.gstatic.com"
+	mobileWarmUpJitterMin = 500 * time.Millisecond
+	mobileWarmUpJitterMax = 1500 * time.Millisecond
+	mobileWarmUpTimeout   = 8 * time.Second
 )
 
 func Start(cfg *sharedconfig.SimpleConfig) error {
@@ -33,6 +46,27 @@ func Start(cfg *sharedconfig.SimpleConfig) error {
 		return err
 	}
 	mCore = core
+	return nil
+}
+
+// WarmUp primes the first proxied connection so the first real request does
+// not pay the cold-start cost (dial + TLS + bootstrap handshake). It blocks
+// (bounded by jitter + connection establishment) and should be called
+// between the SOCKS5 server being ready and the VPN going live: the
+// "connecting" state stays visible while it runs, and the VPN comes up with
+// a warm connection. Best-effort: failures are logged inside and never fail
+// startup.
+func WarmUp() error {
+	mMu.Lock()
+	defer mMu.Unlock()
+
+	if mCore == nil {
+		return fmt.Errorf("not started, call Start first")
+	}
+	if mCore.SocksServer == nil {
+		return nil
+	}
+	mCore.SocksServer.WarmUp(mobileWarmUpDomain, mobileWarmUpJitterMin, mobileWarmUpJitterMax, mobileWarmUpTimeout)
 	return nil
 }
 


### PR DESCRIPTION
﻿## 背景

首个 HTTP/2 连接是懒建立的：手机端开启 VPN 后第一次打开网页，需要现场支付"拨号 + TLS + bootstrap 握手"的冷启动成本（实测 5s+）。即便 #145 的就绪门控已上线，首开延迟依然存在——连接一旦建立（通知栏出现 RTT/下载数值），后续页面都是 ~1s。

## 改动

- `client/proxy/udp.go`：新增 `Socks5Server.WarmUp`（最小预热）：等待随机抖动 0.5~1.5s → 打开一条到代理 DNS 服务器（8.8.8.8:53）的 UDP exchange，bootstrap 记录内合并一条 `connectivitycheck.gstatic.com` 的 A 记录查询（该域名正是 Android 系统连通性检查在 VPN 上线瞬间会查询的域名，流行为上无法与系统检查区分）→ 立即关闭
  - 同步的 exchange 打开即完成连接建立（dial+TLS+bootstrap）；立即关闭保持流短小
  - 抖动避免"每次启动固定时刻出现流量"的机器特征
  - 查询内容全程在加密隧道内，路径观测者不可见；仅自有服务器可见（可信方）
  - `getOrCreateUDPExchange` 增加 ctx 参数，预热受总时限（8s）约束
- `mobile/mobile.go`：导出 `WarmUp()`（AAR 侧 API），配置域名/抖动/超时
- 单元测试：`warmup_test.go`（exchange 打开即关闭、关闭中 no-op、已有 exchange 跳过、抖动有界）

## 配套

EasyssTun 侧（PR #23）在 SOCKS5 就绪探测之后、`establish()` 之前调用 `Mobile.warmUp()`：连接中通知保持可见，VPN 以热连接上线，首次开网页 ~1s。

## 验证

- `go test ./...` 全绿；golangci-lint 0 issues
- 手机实测：连接中通知可见 1~3s，VPN 上线后立即开网页 ~1s（待用户最终确认）
