### PR TITLE
feat: notify startup dns resolution failures via tray

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -35,6 +35,11 @@ type Client struct {
 	closeIdleDone chan struct{}
 	closeOnce     sync.Once
 
+	// fileWarn records a non-fatal failure while loading custom
+	// direct/proxy rule files, surfaced as a startup warning (see
+	// StartupWarning). The client keeps running with built-in rules.
+	fileWarn error
+
 	mu sync.RWMutex
 }
 
@@ -253,6 +258,7 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 		router:        rt,
 		shaperCfg:     shaperCfg,
 		masterKey:     masterKey,
+		fileWarn:      rt.CustomFileError(),
 		closeIdleDone: make(chan struct{}),
 	}
 	client.bound.Store(boundIface{})
@@ -504,6 +510,14 @@ func detectIPV6Networking() bool {
 
 func (c *Client) Router() *router.Router {
 	return c.router
+}
+
+// StartupWarning returns the first non-fatal warning detected during client
+// initialization (e.g. a custom direct/proxy rule file that failed to load),
+// or nil when initialization completed cleanly. The client keeps running
+// with built-in rules; callers may surface the warning to the user.
+func (c *Client) StartupWarning() error {
+	return c.fileWarn
 }
 
 func (c *Client) Transport() transport.Transport {

--- a/client/dns/cache.go
+++ b/client/dns/cache.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -142,7 +143,9 @@ func jitterTTL(ttl int) int {
 // active, avoiding a DNS deadlock.
 // When requireIPv4 is true, the A query must succeed; otherwise either
 // A or AAAA success is sufficient.
-func (c *Cache) PrePopulate(domain, dnsServer string, requireIPv4 bool) error {
+// The ctx bounds the whole resolution so an unreachable DNS server cannot
+// stall startup for the per-query 5s timeout.
+func (c *Cache) PrePopulate(ctx context.Context, domain, dnsServer string, requireIPv4 bool) error {
 	store := func(msg *dns.Msg) {
 		if msg == nil {
 			return
@@ -157,7 +160,7 @@ func (c *Cache) PrePopulate(domain, dnsServer string, requireIPv4 bool) error {
 
 	var ok bool
 	var aErr error
-	if msgA, err := DNSMsgTypeA(dnsServer, domain); err == nil {
+	if msgA, err := DNSMsgTypeAContext(ctx, dnsServer, domain); err == nil {
 		store(msgA)
 		ok = true
 	} else {
@@ -165,7 +168,7 @@ func (c *Cache) PrePopulate(domain, dnsServer string, requireIPv4 bool) error {
 		log.Warn("[DNS] PrePopulate type A", "domain", domain, "err", err)
 	}
 
-	if msgAAAA, err := DNSMsgTypeAAAA(dnsServer, domain); err == nil {
+	if msgAAAA, err := DNSMsgTypeAAAAContext(ctx, dnsServer, domain); err == nil {
 		store(msgAAAA)
 		if !requireIPv4 {
 			ok = true
@@ -187,10 +190,11 @@ func (c *Cache) PrePopulate(domain, dnsServer string, requireIPv4 bool) error {
 // servers in order, then falls back to the system dns servers when all of
 // them are unavailable, storing the results in both the direct and proxied
 // caches. See PrePopulate for the requireIPv4 semantics.
-func (c *Cache) PrePopulateWithFallback(domain string, dnsServers []string, requireIPv4 bool) error {
+// The ctx bounds the whole resolution (see PrePopulate).
+func (c *Cache) PrePopulateWithFallback(ctx context.Context, domain string, dnsServers []string, requireIPv4 bool) error {
 	var lastErr error
 	try := func(server string) bool {
-		err := c.PrePopulate(domain, server, requireIPv4)
+		err := c.PrePopulate(ctx, domain, server, requireIPv4)
 		if err == nil {
 			return true
 		}

--- a/client/dns/cache_test.go
+++ b/client/dns/cache_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -295,7 +296,7 @@ func TestCachePrePopulateWithFallback(t *testing.T) {
 	})
 
 	c := NewCache("example.com")
-	if err := c.PrePopulateWithFallback("example.com", []string{failAddr}, true); err != nil {
+	if err := c.PrePopulateWithFallback(context.Background(), "example.com", []string{failAddr}, true); err != nil {
 		t.Fatalf("PrePopulateWithFallback error: %v", err)
 	}
 	if got := c.Get("example.com.", "A", true); got == nil {
@@ -316,7 +317,35 @@ func TestCachePrePopulateWithFallbackAllFail(t *testing.T) {
 	})
 
 	c := NewCache("example.com")
-	if err := c.PrePopulateWithFallback("example.com", []string{failAddr}, true); err == nil {
+	if err := c.PrePopulateWithFallback(context.Background(), "example.com", []string{failAddr}, true); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// TestCachePrePopulateWithFallbackBoundedByContext verifies that a context
+// deadline bounds the whole pre-population: a blackhole DNS server would
+// otherwise hold the query for the per-query 5s timeout per record type.
+func TestCachePrePopulateWithFallbackBoundedByContext(t *testing.T) {
+	old := systemDNSServersFunc
+	systemDNSServersFunc = func() []string {
+		return nil
+	}
+	t.Cleanup(func() {
+		systemDNSServersFunc = old
+		resetSystemDNSCache()
+		resetBuiltinDNSCircuit()
+	})
+
+	c := NewCache("example.com")
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := c.PrePopulateWithFallback(ctx, "example.com", []string{"127.0.0.1:1"}, true)
+	if err == nil {
+		t.Fatal("expected error against blackhole dns server")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("pre-population took %v, want bounded by the context deadline", elapsed)
 	}
 }

--- a/client/dns/lookup.go
+++ b/client/dns/lookup.go
@@ -14,6 +14,14 @@ func DNSMsgTypeA(dnsServer, domain string) (*dns.Msg, error) {
 	return queryMsg(context.Background(), dns.TypeA, dnsServer, domain)
 }
 
+// DNSMsgTypeAContext is DNSMsgTypeA bounded by ctx: the query fails as
+// soon as the context is done, even if the per-query client timeout (5s) has
+// not elapsed. Used by startup paths (server domain pre-resolution) that must
+// not stall proxy initialization on unreachable DNS servers.
+func DNSMsgTypeAContext(ctx context.Context, dnsServer, domain string) (*dns.Msg, error) {
+	return queryMsg(ctx, dns.TypeA, dnsServer, domain)
+}
+
 // DNSMsgTypeAAAA sends a DNS AAAA record query for domain to the specified server.
 func DNSMsgTypeAAAA(dnsServer, domain string) (*dns.Msg, error) {
 	return queryMsg(context.Background(), dns.TypeAAAA, dnsServer, domain)

--- a/client/proxy/socks5.go
+++ b/client/proxy/socks5.go
@@ -122,8 +122,10 @@ func defaultDirectDialContext(ctx context.Context, network, addr string) (net.Co
 // given domain, trying each of the given dns servers in order and falling
 // back to the system dns servers when all of them fail. This avoids a DNS
 // deadlock when TUN routes are active.
-func (s *Socks5Server) PrePopulateDNS(domain string, dnsServers []string, requireIPv4 bool) error {
-	return s.dnsCache.PrePopulateWithFallback(domain, dnsServers, requireIPv4)
+// The ctx bounds the whole resolution so an unreachable DNS server cannot
+// stall startup (see dns.Cache.PrePopulateWithFallback).
+func (s *Socks5Server) PrePopulateDNS(ctx context.Context, domain string, dnsServers []string, requireIPv4 bool) error {
+	return s.dnsCache.PrePopulateWithFallback(ctx, domain, dnsServers, requireIPv4)
 }
 
 // isServerDomain reports whether the given domain is the proxy server's own

--- a/client/router/router.go
+++ b/client/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -163,6 +164,12 @@ type Router struct {
 	customProxyCIDRIPs  []*net.IPNet
 	customProxyDomains  map[string]struct{}
 	customProxyRegexps  []*regexp.Regexp
+
+	// customFileErr records the first failure to load a custom direct/proxy
+	// rule file. Loading is deliberately non-fatal (the router keeps the
+	// built-in rules), but the error is surfaced as a startup warning so the
+	// user learns that their custom rules were not applied.
+	customFileErr error
 }
 
 func New(cfg Config) (*Router, error) {
@@ -181,10 +188,17 @@ func New(cfg Config) (*Router, error) {
 	r.ipv6Rule.Store(int32(cfg.IPV6Rule))
 
 	if err := r.loadCustomIPDomains(); err != nil {
+		r.customFileErr = fmt.Errorf("load custom rule file: %w", err)
 		log.Error("[ROUTER] load custom ip/domains", "err", err)
 	}
 
 	return r, nil
+}
+
+// CustomFileError returns the first failure encountered while loading the
+// custom direct/proxy rule files, or nil when both loaded successfully.
+func (r *Router) CustomFileError() error {
+	return r.customFileErr
 }
 
 func (r *Router) loadCustomIPDomains() error {

--- a/client/router/router_test.go
+++ b/client/router/router_test.go
@@ -208,6 +208,34 @@ func TestNewRouter(t *testing.T) {
 	}
 }
 
+// TestCustomFileError verifies that a missing custom direct/proxy rule file
+// does not fail router construction (built-in rules keep working) but is
+// recorded as a startup warning via CustomFileError.
+func TestCustomFileError(t *testing.T) {
+	r, err := New(Config{
+		ProxyRule:  ProxyRuleAuto,
+		IPV6Rule:   IPV6RuleAuto,
+		DirectFile: "missing-direct.txt",
+	})
+	if err != nil {
+		t.Fatalf("New() with a missing direct file should stay non-fatal, got error: %v", err)
+	}
+	if r.CustomFileError() == nil {
+		t.Fatal("expected a custom-file warning for a missing direct file")
+	}
+
+	r2, err := New(Config{
+		ProxyRule: ProxyRuleAuto,
+		IPV6Rule:  IPV6RuleAuto,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if r2.CustomFileError() != nil {
+		t.Fatalf("unexpected custom-file warning: %v", r2.CustomFileError())
+	}
+}
+
 func TestRouter_ShouldIPV6Disable(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/cmd/easyss/main.go
+++ b/cmd/easyss/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -124,6 +123,9 @@ Flags:
 			cfg, err = config.BuildSimpleConfig(sc)
 			if err != nil {
 				log.Error("[EASYSS-V3] build config from args", "err", err)
+				if !disableTray {
+					notifyConfigError(err)
+				}
 				os.Exit(1)
 			}
 		} else {
@@ -211,6 +213,12 @@ type App struct {
 	tunMgr     *tun.Manager
 	pprofSrv   *http.Server
 
+	// startupWarn records the first non-fatal startup warning (e.g. the
+	// server domain failed to resolve, or a custom rule file failed to
+	// load). The client keeps running; the tray surfaces it as a system
+	// notification, headless builds log it.
+	startupWarn error
+
 	statsCloser chan struct{}
 	statsOnce   sync.Once
 }
@@ -221,6 +229,7 @@ func (a *App) Start() error {
 		return err
 	}
 	a.core = core
+	a.setStartupWarn(core.StartupWarn)
 
 	if a.cfg.Local.EnableTun2socks {
 		// On macOS and Linux non-root, TUN is started via privilege
@@ -229,60 +238,32 @@ func (a *App) Start() error {
 		if (runtime.GOOS == "darwin" || runtime.GOOS == "linux") && !IsRoot() {
 			log.Warn("[EASYSS-V3] tun2socks requires root; skipped (use sudo, or run with system tray for automatic elevation)")
 		} else {
-			// Pre-resolve the proxy server hostname and populate the
-			// DNS cache so that TUN-mode DNS queries for the server
-			// domain never require a network round-trip (avoids a
-			// circular dependency: DNS → TUN → proxy → DNS).
-			prepopulated := true
-			if serverAddr := a.cfg.DefaultServer().Address; net.ParseIP(serverAddr) == nil {
-				var err error
-				for i := range 3 {
-					if a.core.SocksServer == nil || len(config.DirectDNSServers) == 0 {
-						prepopulated = false
-						break
-					}
-					err = a.core.SocksServer.PrePopulateDNS(serverAddr, config.DirectDNSServers,
-						a.cfg.Routing.IPV6Rule != "enable")
-					if err == nil {
-						log.Info("[EASYSS-V3] pre-populated dns cache for server", "host", serverAddr)
-						break
-					}
-					if i < 2 {
-						time.Sleep(time.Second)
-					}
-				}
-				if err != nil {
-					log.Error("[EASYSS-V3] failed to pre-resolve server hostname, skipping TUN",
-						"host", serverAddr, "err", err)
-					prepopulated = false
-				}
+			// runner.Run already ensured the server hostname resolves and
+			// pre-populated the DNS cache (resolveServerDomain), so TUN-mode
+			// DNS can never deadlock on the server domain.
+			socksProxyAddr := "socks5://127.0.0.1:" + strconv.Itoa(a.cfg.Local.SocksPort)
+			tunCfg := tun.Config{
+				Socks5Addr: socksProxyAddr,
+				DNSServer:  tunDNS(a.cfg),
 			}
-
-			if prepopulated {
-				socksProxyAddr := "socks5://127.0.0.1:" + strconv.Itoa(a.cfg.Local.SocksPort)
-				tunCfg := tun.Config{
-					Socks5Addr: socksProxyAddr,
-					DNSServer:  tunDNS(a.cfg),
-				}
-				if ipv6 := a.core.Client.Router().ServerIPV6(); ipv6 != "" {
-					tunCfg.ServerIPV6 = ipv6
-				}
-				a.tunMgr = tun.New(tunCfg)
-
-				method := protocol.MethodFromString(a.cfg.DefaultServer().Method)
-				if method == 0 {
-					method = protocol.MethodAES256GCM
-				}
-				icmpHandler := tun.NewICMPHandler(a.core.Client.Router())
-				icmpHandler.SetProxy(a.core.StreamHandler, method)
-				a.tunMgr.SetICMPHandler(icmpHandler)
-
-				go func() {
-					if err := a.tunMgr.Start(); err != nil {
-						log.Error("[EASYSS-V3] tun2socks", "err", err)
-					}
-				}()
+			if ipv6 := a.core.Client.Router().ServerIPV6(); ipv6 != "" {
+				tunCfg.ServerIPV6 = ipv6
 			}
+			a.tunMgr = tun.New(tunCfg)
+
+			method := protocol.MethodFromString(a.cfg.DefaultServer().Method)
+			if method == 0 {
+				method = protocol.MethodAES256GCM
+			}
+			icmpHandler := tun.NewICMPHandler(a.core.Client.Router())
+			icmpHandler.SetProxy(a.core.StreamHandler, method)
+			a.tunMgr.SetICMPHandler(icmpHandler)
+
+			go func() {
+				if err := a.tunMgr.Start(); err != nil {
+					log.Error("[EASYSS-V3] tun2socks", "err", err)
+				}
+			}()
 		}
 	}
 
@@ -294,6 +275,17 @@ func (a *App) Start() error {
 	}
 
 	return nil
+}
+
+// setStartupWarn records the first non-fatal startup warning. The client
+// keeps running; the tray surfaces it as a system notification, headless
+// builds log it.
+func (a *App) setStartupWarn(err error) {
+	if err == nil || a.startupWarn != nil {
+		return
+	}
+	a.startupWarn = err
+	log.Warn("[EASYSS-V3] startup warning", "err", err)
 }
 
 func (a *App) Stop() {

--- a/cmd/easyss/notify_test.go
+++ b/cmd/easyss/notify_test.go
@@ -52,8 +52,35 @@ func TestFriendlyStartupError(t *testing.T) {
 		t.Fatalf("windows in-use error should get the hint: %q", msg)
 	}
 
+	// Empty password (crypto.DeriveMasterKey).
+	passwordErr := errors.New("crypto: password is empty")
+	if msg := friendlyStartupError(passwordErr); !strings.Contains(msg, "服务器密码为空") {
+		t.Fatalf("empty-password error should get the config hint: %q", msg)
+	}
+
+	// HTTP proxy without socks_port (runner.errSocksRequired).
+	socksRequiredErr := errors.New("http proxy requires socks_port to be enabled")
+	if msg := friendlyStartupError(socksRequiredErr); !strings.Contains(msg, "socks_port 需大于 0") {
+		t.Fatalf("socks-required error should get the config hint: %q", msg)
+	}
+
+	// Server domain failed to resolve (runner.resolveServerDomain): fatal.
+	dnsErr := errors.New("server domain proxy.example.com resolution failed: dns boom")
+	if msg := friendlyStartupError(dnsErr); !strings.Contains(msg, "服务端域名解析失败") {
+		t.Fatalf("resolution error should get the dns hint: %q", msg)
+	}
+
 	other := errors.New("boom")
 	if msg := friendlyStartupError(other); msg != "服务启动失败：boom" {
 		t.Fatalf("unexpected generic startup message: %q", msg)
+	}
+}
+
+func TestFriendlyStartupWarning(t *testing.T) {
+	// Non-fatal startup warnings (e.g. a custom rule file that failed to
+	// load) keep the "启动警告" prefix and the detail.
+	msg := friendlyStartupWarning(errors.New("load custom rule file: open direct.txt: no such file or directory"))
+	if msg != "启动警告：load custom rule file: open direct.txt: no such file or directory" {
+		t.Fatalf("unexpected startup warning message: %q", msg)
 	}
 }

--- a/cmd/easyss/start.go
+++ b/cmd/easyss/start.go
@@ -66,6 +66,9 @@ func runApp(disableTray, daemon bool, app *App) {
 			}
 			os.Exit(1)
 		}
+		if app.startupWarn != nil {
+			log.Warn("[EASYSS-V3] startup warning (no tray to notify)", "err", app.startupWarn)
+		}
 		sigWait()
 
 		if proxyWasSet {

--- a/cmd/easyss/start_headless.go
+++ b/cmd/easyss/start_headless.go
@@ -20,6 +20,9 @@ func runApp(disableTray, daemon bool, app *App) {
 		log.Error("[EASYSS-V3] start", "err", err)
 		os.Exit(1)
 	}
+	if app.startupWarn != nil {
+		log.Warn("[EASYSS-V3] startup warning", "err", app.startupWarn)
+	}
 	sigWait()
 	app.Stop()
 	os.Exit(0)

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -135,6 +135,13 @@ func (a *TrayApp) buildTray() {
 		os.Exit(1)
 	}
 
+	// A non-fatal startup warning (e.g. the server domain failed to resolve
+	// and TUN was skipped) is surfaced as a notification without blocking
+	// or exiting: the proxy core keeps running.
+	if a.startupWarn != nil {
+		a.tray.ShowNotification("Easyss", friendlyStartupWarning(a.startupWarn))
+	}
+
 	a.startLocalService()
 	go a.statsRefresher()
 	go a.autoCheckUpdate()
@@ -183,7 +190,26 @@ func friendlyStartupError(err error) string {
 	if isAddrInUse(err) {
 		return "服务启动失败：本地端口可能被占用，请关闭占用该端口的程序后重试。详情：" + err.Error()
 	}
+	// 以下分类按稳定错误文本匹配（均为各自包内固定的字面量错误，
+	// 不随平台/环境变化）。匹配失败则落入通用提示。
+	if strings.Contains(err.Error(), "crypto: password is empty") {
+		return "配置错误：服务器密码为空，请在配置文件（或 -k 参数）中设置 password。详情：" + err.Error()
+	}
+	if strings.Contains(err.Error(), "http proxy requires socks_port to be enabled") {
+		return "配置错误：启用 HTTP 代理需要先启用 SOCKS5 代理（socks_port 需大于 0）。详情：" + err.Error()
+	}
+	// runner.resolveServerDomain: the server domain failed to resolve, so
+	// the proxy cannot reach the server and startup aborts.
+	if strings.Contains(err.Error(), "resolution failed") {
+		return "服务启动失败：服务端域名解析失败，请检查网络或域名配置。详情：" + err.Error()
+	}
 	return "服务启动失败：" + err.Error()
+}
+
+// friendlyStartupWarning 将非致命启动警告（例如自定义规则文件加载失败）
+// 转换为用户友好的中文提示。
+func friendlyStartupWarning(err error) string {
+	return "启动警告：" + err.Error()
 }
 
 // isAddrInUse 判断错误是否为"端口已被占用"的绑定失败（Unix 走 errno，
@@ -612,6 +638,9 @@ func (a *TrayApp) restartService(newCfg *config.ClientConfig) error {
 	}
 	if err := a.Start(); err != nil {
 		return err
+	}
+	if a.startupWarn != nil {
+		log.Warn("[SYSTRAY] restart service: startup warning", "err", a.startupWarn)
 	}
 
 	if sysProxyEnabled {

--- a/cmd/easyss/tray_tun_helper_unix.go
+++ b/cmd/easyss/tray_tun_helper_unix.go
@@ -3,8 +3,8 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"net"
 	"os"
 	"runtime"
 	"time"
@@ -13,8 +13,15 @@ import (
 	"github.com/nange/easyss/v3/client/proxy"
 	"github.com/nange/easyss/v3/client/tun"
 	"github.com/nange/easyss/v3/log"
+	"github.com/nange/easyss/v3/util"
 	"golang.org/x/sys/unix"
 )
+
+// tunHelperResolveTimeout bounds each server-domain pre-resolution attempt
+// performed before spawning the TUN helper (a runtime toggle, unlike the
+// startup check inside runner.Run). Kept in sync with
+// runner.serverStartupResolveTimeout.
+const tunHelperResolveTimeout = 3 * time.Second
 
 // createTun2socksViaHelper spawns a long-running elevated helper to open the
 // TUN device, set up routes/DNS, and pass the fd back. The helper stays alive
@@ -71,15 +78,17 @@ func (a *TrayApp) createTun2socksViaHelper() error {
 	// 3. Pre-resolve the proxy server hostname and populate the DNS cache
 	// before spawning the helper, to avoid a circular dependency once the
 	// helper sets the system DNS to go through TUN.
-	if serverAddr := a.cfg.DefaultServer().Address; net.ParseIP(serverAddr) == nil {
+	if serverAddr := a.cfg.DefaultServer().Address; !util.IsIP(serverAddr) {
 		var err error
 		for i := range 3 {
 			if a.core.SocksServer == nil || len(config.DirectDNSServers) == 0 {
 				err = fmt.Errorf("dns cache not available")
 				break
 			}
-			err = a.core.SocksServer.PrePopulateDNS(serverAddr, config.DirectDNSServers,
+			ctx, cancel := context.WithTimeout(context.Background(), tunHelperResolveTimeout)
+			err = a.core.SocksServer.PrePopulateDNS(ctx, serverAddr, config.DirectDNSServers,
 				a.cfg.Routing.IPV6Rule != "enable")
+			cancel()
 			if err == nil {
 				log.Info("[SYSTRAY] pre-populated dns cache for server", "host", serverAddr)
 				break

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -17,9 +18,26 @@ import (
 	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/shaper"
 	"github.com/nange/easyss/v3/stats"
+	"github.com/nange/easyss/v3/util"
 )
 
 var errSocksRequired = errors.New("http proxy requires socks_port to be enabled")
+
+// serverStartupResolveTimeout bounds each synchronous server-domain
+// resolution attempt at startup. It mirrors client.serverIPV6ResolveTimeout:
+// 3s is enough for a healthy network and keeps the worst-case startup delay
+// short. serverStartupRetryDelay is the pause between TUN-mode retries.
+// Both are vars (not consts) so tests can shorten them.
+var (
+	serverStartupResolveTimeout = 3 * time.Second
+	serverStartupRetryDelay     = time.Second
+)
+
+// prePopulateServerDomain is a package-level var so tests can inject
+// deterministic failures (same pattern as client.boundDialContext).
+var prePopulateServerDomain = func(s *proxy.Socks5Server, ctx context.Context, domain string, dnsServers []string, requireIPv4 bool) error {
+	return s.PrePopulateDNS(ctx, domain, dnsServers, requireIPv4)
+}
 
 type Core struct {
 	Cfg           *config.ClientConfig
@@ -28,6 +46,11 @@ type Core struct {
 	HTTPServer    *proxy.HTTPProxyServer
 	StreamHandler *proxy.StreamHandler
 	DNSServer     *dns.ForwardServer
+
+	// StartupWarn carries a non-fatal warning detected while initializing
+	// the core (e.g. a custom rule file that failed to load), so the caller
+	// can surface it to the user without failing startup.
+	StartupWarn error
 }
 
 func Run(cfg *config.ClientConfig) (*Core, error) {
@@ -63,6 +86,7 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 		Cfg:           cfg,
 		Client:        cli,
 		StreamHandler: streamHandler,
+		StartupWarn:   cli.StartupWarning(),
 	}
 
 	// Pre-bind all local listen addresses before starting any server
@@ -103,7 +127,7 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 
 	if socksAddr != "" {
 		serverDomain := ""
-		if svr := cfg.DefaultServer(); svr != nil && net.ParseIP(svr.Address) == nil {
+		if svr := cfg.DefaultServer(); svr != nil && !util.IsIP(svr.Address) {
 			serverDomain = svr.Address
 		}
 		socksServer, err := proxy.NewSocks5Server(socksAddr, cfg.AuthUsername, cfg.AuthPassword,
@@ -149,6 +173,15 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 		}()
 	}
 
+	// The server domain must resolve for the proxied path to work at all,
+	// so the resolution check belongs to core startup. A failed resolution
+	// means the server is unreachable and the proxy cannot work, so it
+	// aborts startup like any other fatal core error.
+	if err := c.resolveServerDomain(cfg); err != nil {
+		c.cleanup()
+		return nil, err
+	}
+
 	log.Info("[EASYSS] started successfully", "elapsed_ms", time.Since(start).Milliseconds())
 	// Start a fresh stats session: the process may host multiple
 	// start/stop cycles (e.g. Android), so reset both the session
@@ -162,6 +195,64 @@ func Run(cfg *config.ClientConfig) (*Core, error) {
 func (c *Core) Stop() {
 	c.cleanup()
 	log.Info("[EASYSS] stopped")
+}
+
+// resolveServerDomain pre-resolves the proxy server hostname via the direct
+// DNS servers (with system fallback) and pre-seeds the DNS cache, so the
+// proxied path never waits on a cold lookup. A failure is returned as a
+// fatal error: without the domain resolving the server is unreachable and
+// the proxy cannot work at all, so the caller aborts startup.
+//
+// TUN mode retries (3 attempts) because a failed pre-population there would
+// deadlock TUN DNS once the system DNS is switched to the forward server;
+// non-TUN mode is best-effort with a single bounded attempt. An address
+// that is a literal IP needs no resolution and returns nil.
+func (c *Core) resolveServerDomain(cfg *config.ClientConfig) error {
+	svr := cfg.DefaultServer()
+	if svr == nil || util.IsIP(svr.Address) {
+		return nil
+	}
+	if c.SocksServer == nil {
+		return nil
+	}
+
+	attempts := 1
+	if cfg.Local.EnableTun2socks {
+		attempts = 3
+	}
+
+	start := time.Now()
+	var err error
+	for i := range attempts {
+		if len(config.DirectDNSServers) == 0 {
+			err = errors.New("no direct dns servers configured")
+			break
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), serverStartupResolveTimeout)
+		err = prePopulateServerDomain(c.SocksServer, ctx, svr.Address, config.DirectDNSServers,
+			cfg.Routing.IPV6Rule != "enable")
+		cancel()
+		if err == nil {
+			break
+		}
+		if i < attempts-1 {
+			time.Sleep(serverStartupRetryDelay)
+		}
+	}
+
+	if err != nil {
+		log.Warn("[EASYSS] server domain resolution failed at startup",
+			"host", svr.Address,
+			"elapsed_ms", time.Since(start).Milliseconds(),
+			"err", err,
+		)
+		return fmt.Errorf("server domain %s resolution failed: %w", svr.Address, err)
+	}
+	log.Info("[EASYSS] server domain resolved at startup",
+		"host", svr.Address,
+		"elapsed_ms", time.Since(start).Milliseconds(),
+	)
+	return nil
 }
 
 // prebindTCP verifies the given TCP address is bindable before server

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,18 +1,25 @@
 package runner
 
 import (
+	"context"
+	"errors"
 	"net"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nange/easyss/v3/client/config"
+	"github.com/nange/easyss/v3/client/proxy"
 )
 
 func testConfig() *config.ClientConfig {
 	cfg := config.DefaultConfig()
 	cfg.Servers = []*config.ServerProfile{{
-		Address:  "example.com",
+		// A literal IP keeps startup-side DNS work out of the tests:
+		// resolveServerDomain (and the IPv6 resolution in client.New) both
+		// skip literal IPs, so tests never issue real DNS queries.
+		Address:  "127.0.0.1",
 		Port:     443,
 		Password: "test-password",
 		Method:   "aes-256-gcm",
@@ -145,4 +152,138 @@ func TestRunOKWhenPortsAreFree(t *testing.T) {
 		t.Fatal("core is nil")
 	}
 	core.Stop()
+}
+
+// TestResolveServerDomain covers the startup server-domain resolution with
+// an injected prePopulateServerDomain so no real DNS query ever leaves the
+// test. A failed resolution is a fatal error (the server is unreachable).
+func TestResolveServerDomain(t *testing.T) {
+	oldFn := prePopulateServerDomain
+	oldTimeout := serverStartupResolveTimeout
+	oldDelay := serverStartupRetryDelay
+	t.Cleanup(func() {
+		prePopulateServerDomain = oldFn
+		serverStartupResolveTimeout = oldTimeout
+		serverStartupRetryDelay = oldDelay
+	})
+	serverStartupResolveTimeout = 50 * time.Millisecond
+	serverStartupRetryDelay = 0
+
+	// A literal IP needs no resolution: skipped without touching the DNS.
+	cfgIP := testConfig() // Address is 127.0.0.1
+	attempts := 0
+	prePopulateServerDomain = func(*proxy.Socks5Server, context.Context, string, []string, bool) error {
+		attempts++
+		return nil
+	}
+	c := &Core{}
+	if err := c.resolveServerDomain(cfgIP); err != nil {
+		t.Fatalf("IP address should not resolve: %v", err)
+	}
+	if attempts != 0 {
+		t.Fatalf("IP address should not query DNS, got %d attempts", attempts)
+	}
+
+	// No default server: skipped.
+	cfgNone := testConfig()
+	cfgNone.Servers = nil
+	c = &Core{}
+	if err := c.resolveServerDomain(cfgNone); err != nil {
+		t.Fatalf("no server should not resolve: %v", err)
+	}
+
+	// Non-TUN failure: a single bounded attempt, fatal error returned.
+	cfgDomain := testConfig()
+	cfgDomain.Servers[0].Address = "proxy.example.com"
+	cfgDomain.Local.EnableTun2socks = false
+	prePopulateServerDomain = func(*proxy.Socks5Server, context.Context, string, []string, bool) error {
+		attempts++
+		return errors.New("dns boom")
+	}
+	attempts = 0
+	c = &Core{SocksServer: &proxy.Socks5Server{}}
+	err := c.resolveServerDomain(cfgDomain)
+	if err == nil {
+		t.Fatal("expected error on resolution failure")
+	}
+	if !strings.Contains(err.Error(), "resolution failed") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("non-TUN should attempt once, got %d", attempts)
+	}
+
+	// TUN failure: retried 3 times (the pre-population is mandatory there).
+	cfgTun := testConfig()
+	cfgTun.Servers[0].Address = "proxy.example.com"
+	cfgTun.Local.EnableTun2socks = true
+	attempts = 0
+	c = &Core{SocksServer: &proxy.Socks5Server{}}
+	if err := c.resolveServerDomain(cfgTun); err == nil {
+		t.Fatal("expected error on TUN resolution failure")
+	}
+	if attempts != 3 {
+		t.Fatalf("TUN should attempt 3 times, got %d", attempts)
+	}
+
+	// Success: no error.
+	prePopulateServerDomain = func(*proxy.Socks5Server, context.Context, string, []string, bool) error {
+		attempts++
+		return nil
+	}
+	attempts = 0
+	c = &Core{SocksServer: &proxy.Socks5Server{}}
+	if err := c.resolveServerDomain(cfgDomain); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected a single successful attempt, got %d", attempts)
+	}
+
+	// No DNS servers configured: reported as a resolution failure.
+	oldDirect := config.DirectDNSServers
+	config.DirectDNSServers = nil
+	t.Cleanup(func() { config.DirectDNSServers = oldDirect })
+	attempts = 0
+	c = &Core{SocksServer: &proxy.Socks5Server{}}
+	if err := c.resolveServerDomain(cfgDomain); err == nil {
+		t.Fatal("expected error when no dns servers configured")
+	}
+	if attempts != 0 {
+		t.Fatalf("no dns servers should short-circuit without attempts, got %d", attempts)
+	}
+}
+
+// TestRunFailsOnServerDomainResolve verifies that a failed server-domain
+// resolution aborts startup: Run returns a fatal error instead of starting
+// the servers, because the proxy cannot work without it.
+func TestRunFailsOnServerDomainResolve(t *testing.T) {
+	oldFn := prePopulateServerDomain
+	oldTimeout := serverStartupResolveTimeout
+	oldDelay := serverStartupRetryDelay
+	t.Cleanup(func() {
+		prePopulateServerDomain = oldFn
+		serverStartupResolveTimeout = oldTimeout
+		serverStartupRetryDelay = oldDelay
+	})
+	serverStartupResolveTimeout = 50 * time.Millisecond
+	serverStartupRetryDelay = 0
+
+	cfg := testConfig()
+	cfg.Servers[0].Address = "proxy.example.com"
+	cfg.Local.SocksPort = freePort(t)
+	cfg.Local.HTTPPort = 0
+
+	prePopulateServerDomain = func(*proxy.Socks5Server, context.Context, string, []string, bool) error {
+		return errors.New("dns boom")
+	}
+
+	core, err := Run(cfg)
+	if err == nil {
+		core.Stop()
+		t.Fatal("expected Run to fail when the server domain cannot resolve")
+	}
+	if !strings.Contains(err.Error(), "resolution failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }

--- a/util/file.go
+++ b/util/file.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -117,7 +118,13 @@ func WriteToTemp(filename string, content []byte) (namePath string, err error) {
 
 func ReadFileLines(file string) ([]string, error) {
 	if e, err := FileExists(file); !e || err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
+		// FileExists reports (false, nil) for a missing file; surface it
+		// as a proper error instead of silently returning empty lines
+		// (which would hide a misconfigured rule file path).
+		return nil, fmt.Errorf("%s: %w", file, os.ErrNotExist)
 	}
 	f, err := os.Open(file)
 	if err != nil {

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,6 +44,15 @@ func TestReadFileLinesMap(t *testing.T) {
 	assert.Len(t, m, 2)
 	_, ok := m["Ni hao!"]
 	assert.True(t, ok)
+}
+
+func TestReadFileLinesMapMissingFile(t *testing.T) {
+	// A missing file must be reported as an error rather than silently
+	// treated as empty lines (a misconfigured rule file path must not be
+	// invisible to the caller).
+	_, err := ReadFileLinesMap("definitely-not-exists.txt")
+	assert.NotNil(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 }
 
 func TestResolvePath(t *testing.T) {


### PR DESCRIPTION
﻿## 概述

修复客户端启动期错误通知遗漏问题：**服务端域名 DNS 查询失败**此前在 TUN 模式下仅写日志、TUN 被静默跳过，用户完全无感知；非 TUN 模式启动时则根本不检查服务端域名。本次为托盘版补齐全部启动期通知，并将服务端域名解析检查下沉到核心启动器 unner.Run，**解析失败按致命启动错误处理（服务不可用则整个服务不启动）**。

## 改动内容

### 服务端域名启动期解析（下沉 runner，失败即启动失败）

服务端域名无法解析时代理核心必然无法工作，解析检查属于核心启动的前置校验，统一在 unner.Run 中执行（Core.resolveServerDomain），**失败直接返回错误、启动中止**（与端口冲突同级，走既有 riendlyStartupError 通知 + 退出流程）：

- 地址为域名时通过直连 DNS（含系统 DNS 回退）预解析并预填充 DNS 缓存；**TUN 模式重试 3 次**（预填充失败会导致 TUN 模式下 DNS 死锁：DNS → TUN → 代理 → DNS），非 TUN 模式单次有界尝试（3s）。
- 成功打 log.Info("server domain resolved at startup")（含耗时）；失败返回 server domain <host> resolution failed 错误并 log.Warn，Run 清理已启动的服务器后返回错误。
- cmd/easyss 的 App.Start 不再自行解析、也无「跳过 TUN」分支：unner.Run 成功后 TUN 直接创建（解析已保证成功且缓存已预填充）。
- 地址为 IP / 无默认服务器 / 无 socks 服务器时跳过检查，正常启动。
- 运行中手动开启 TUN（helper 路径）仍自行预解析，属运行时操作，不受影响。

### 启动错误通知补齐

- **服务端域名解析失败（致命）**：托盘弹出「服务启动失败：服务端域名解析失败，请检查网络或域名配置。详情：…」，5 秒后退出——与端口冲突体验一致。
- 空密码（crypto: password is empty）与 HTTP 未启用 socks_port 增加明确中文分类文案。
- 自定义 direct_file/proxy_file 加载失败经 Router.CustomFileError() → Client.StartupWarning() → Core.StartupWarn 上报为**启动警告**（仍非致命，客户端照常运行）；顺带修复 util.ReadFileLines 对缺失文件静默返回空（服务端 
extproxy 同路径受益）。
- -s/-k 参数下 BuildSimpleConfig 失败补通知。
- 
et.ParseIP 地址判断统一改用 util.IsIP。
- headless / --disable-tray 路径仅日志，行为不变。

### 行为变更说明

- **离线启动能力取消**：无网络时直连 DNS 与系统 DNS 均不可达 → 启动失败并通知（服务端域名不可用则代理本也无法工作）。
- **移动端**：mobile.Start → unner.Run 在域名解析失败时返回错误，VPN 建立失败并提示，语义一致。

## 测试

- 新增/改造：TestResolveServerDomain（IP 跳过 / 非 TUN 单次尝试 / TUN 三次重试 / 失败返回 error / 成功 nil / 无 DNS 服务器短路）、TestRunFailsOnServerDomainResolve（Run 在解析失败时返回错误）、riendlyStartupError DNS 分类用例、riendlyStartupWarning、PrePopulateWithFallback ctx 超时有界、Router.CustomFileError、ReadFileLines 缺失文件用例。
- runner 测试配置改用 IP 地址，避免测试发起真实外部 DNS 查询；解析失败通过注入 prePopulateServerDomain 确定性复现。
- go test ./... 全绿；make lint 0 issues；Windows/headless/Linux/Darwin 构建均编译通过。
