### PR TITLE
fix: skip direct dialer interface detection on android

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -143,11 +143,41 @@ var listInterfaces = net.Interfaces
 // tests can inject deterministic addresses for synthetic interfaces.
 var ifaceAddrs = func(iface *net.Interface) ([]net.Addr, error) { return iface.Addrs() }
 
+// ifaceBindUnsupported reports whether the platform cannot bind the direct
+// dialer to an interface (see util.SysDirectIfaceBindUnsupported). It is a
+// package-level var so tests can exercise the platform branch
+// deterministically.
+var ifaceBindUnsupported = util.SysDirectIfaceBindUnsupported
+
+// initDirectDialer stores the direct dialer in c.dialer and returns the
+// name of the bound physical interface ("" when unbound). On platforms
+// where interface binding is unsupported (android: netlink blocked, the
+// VpnService routes only selected apps through the TUN) the dialer stays
+// unbound and no detection or warning runs.
+func (c *Client) initDirectDialer() string {
+	if ifaceBindUnsupported() {
+		c.dialer.Store(dialer.New())
+		return ""
+	}
+	iface := c.startupDialIface()
+	if iface == nil {
+		log.Warn("[CLIENT] no physical interface found for direct dialer, using unbound dialer")
+		c.dialer.Store(dialer.New())
+		return ""
+	}
+	c.dialer.Store(dialer.New(dialer.WithBindToInterface(iface)))
+	c.bound.Store(boundIface{name: iface.Name, index: iface.Index})
+	return iface.Name
+}
+
 // startupDialIface determines the interface the direct dialer is bound to at
 // startup. It prefers the route probe, but rejects the easyss TUN device
 // (e.g. when routes left over from a crashed TUN session redirect the probe
 // to it) and falls back to enumerating physical interfaces. Returns nil when
-// no suitable interface exists, in which case an unbound dialer is used.
+// no suitable interface exists, in which case an unbound dialer is used. On
+// platforms where interface binding is unsupported (android) initDirectDialer
+// never calls this — the dialer stays unbound (see
+// util.SysDirectIfaceBindUnsupported).
 func (c *Client) startupDialIface() *net.Interface {
 	iface, err := detectDialIface()
 	if err == nil && iface != nil && !c.isTunIface(iface) {
@@ -263,16 +293,7 @@ func New(cfg *config.ClientConfig) (*Client, error) {
 	}
 	client.bound.Store(boundIface{})
 
-	directIface := ""
-	iface := client.startupDialIface()
-	if iface == nil {
-		log.Warn("[CLIENT] no physical interface found for direct dialer, using unbound dialer")
-		client.dialer.Store(dialer.New())
-	} else {
-		client.dialer.Store(dialer.New(dialer.WithBindToInterface(iface)))
-		client.bound.Store(boundIface{name: iface.Name, index: iface.Index})
-		directIface = iface.Name
-	}
+	directIface := client.initDirectDialer()
 
 	probeToken, err := crypto.ProbeToken(masterKey)
 	if err != nil {
@@ -371,8 +392,14 @@ func (c *Client) dialWithConfig(ctx context.Context, network, addr string) (net.
 // interface-bound direct dialer when the binding changed (name or index). It
 // reports whether the dialer was replaced. On detection failure the existing
 // dialer is kept so a transient network state cannot degrade connectivity
-// further.
+// further. On platforms where interface binding is unsupported (android) it
+// is a no-op returning false.
 func (c *Client) refreshDirectDialer() bool {
+	if ifaceBindUnsupported() {
+		// Platforms that cannot bind the direct dialer keep the unbound
+		// dialer: there is nothing to refresh.
+		return false
+	}
 	iface, err := detectDialIface()
 	if err != nil {
 		log.Warn("[CLIENT] refresh direct dialer: detect interface failed", "err", err)

--- a/client/dialer_test.go
+++ b/client/dialer_test.go
@@ -394,3 +394,88 @@ func TestStartupDialIface(t *testing.T) {
 		}
 	})
 }
+
+func TestInitDirectDialerUnsupportedPlatform(t *testing.T) {
+	orig := ifaceBindUnsupported
+	t.Cleanup(func() { ifaceBindUnsupported = orig })
+	ifaceBindUnsupported = func() bool { return true }
+
+	c := &Client{}
+	c.bound.Store(boundIface{name: "en0", index: 4})
+
+	if name := c.initDirectDialer(); name != "" {
+		t.Fatalf("initDirectDialer = %q, want unbound", name)
+	}
+	if c.dialer.Load() == nil {
+		t.Fatal("dialer should not be nil on the unbound path")
+	}
+	got, _ := c.bound.Load().(boundIface)
+	if got.name != "en0" || got.index != 4 {
+		t.Fatalf("bound = %+v, want previous en0/index 4 kept", got)
+	}
+}
+
+func TestInitDirectDialerBindsWhenSupported(t *testing.T) {
+	orig := ifaceBindUnsupported
+	origDetect := detectDialIface
+	t.Cleanup(func() {
+		ifaceBindUnsupported = orig
+		detectDialIface = origDetect
+	})
+	ifaceBindUnsupported = func() bool { return false }
+	detectDialIface = func() (*net.Interface, error) {
+		return &net.Interface{Index: 7, Name: "en0", Flags: net.FlagUp}, nil
+	}
+
+	c := &Client{}
+	if name := c.initDirectDialer(); name != "en0" {
+		t.Fatalf("initDirectDialer = %q, want en0", name)
+	}
+	got, _ := c.bound.Load().(boundIface)
+	if got.name != "en0" || got.index != 7 {
+		t.Fatalf("bound = %+v, want en0/index 7", got)
+	}
+}
+
+func TestInitDirectDialerUnboundOnDetectionFailure(t *testing.T) {
+	orig := ifaceBindUnsupported
+	origDetect := detectDialIface
+	origList := listInterfaces
+	t.Cleanup(func() {
+		ifaceBindUnsupported = orig
+		detectDialIface = origDetect
+		listInterfaces = origList
+	})
+	ifaceBindUnsupported = func() bool { return false }
+	detectDialIface = func() (*net.Interface, error) { return nil, errors.New("no route") }
+	listInterfaces = func() ([]net.Interface, error) { return nil, nil }
+
+	c := &Client{}
+	if name := c.initDirectDialer(); name != "" {
+		t.Fatalf("initDirectDialer = %q, want unbound", name)
+	}
+	if c.dialer.Load() == nil {
+		t.Fatal("dialer should not be nil on the unbound path")
+	}
+	if _, ok := c.bound.Load().(boundIface); ok {
+		t.Fatal("expected no binding recorded")
+	}
+}
+
+func TestRefreshDirectDialerSkipsOnUnsupportedPlatform(t *testing.T) {
+	orig := ifaceBindUnsupported
+	t.Cleanup(func() { ifaceBindUnsupported = orig })
+	ifaceBindUnsupported = func() bool { return true }
+
+	c := &Client{}
+	c.bound.Store(boundIface{name: "en0", index: 4})
+	c.dialer.Store(dialer.New())
+
+	if c.refreshDirectDialer() {
+		t.Fatal("expected no refresh on an unsupported platform")
+	}
+	got, _ := c.bound.Load().(boundIface)
+	if got.name != "en0" || got.index != 4 {
+		t.Fatalf("bound = %+v, want previous en0/index 4 kept", got)
+	}
+}

--- a/util/sys.go
+++ b/util/sys.go
@@ -125,6 +125,19 @@ func SysDefaultRoute() (iface *net.Interface, gateway net.IP, err error) {
 	}
 }
 
+// SysDirectIfaceBindUnsupported reports whether the platform cannot bind
+// the direct dialer to a physical interface. On Android netlink route
+// sockets are blocked for apps (net.Interfaces, net.Interface.Addrs and
+// go-netroute's route probes all fail with permission denied), and
+// SO_BINDTODEVICE requires CAP_NET_RAW which apps lack. The VpnService-based
+// VPN there uses per-app routing (only the selected apps enter the TUN), so
+// the app's own sockets — including the transport connections to the remote
+// server — bypass the tunnel without any binding. The direct dialer
+// therefore stays unbound on Android.
+func SysDirectIfaceBindUnsupported() bool {
+	return runtime.GOOS == "android"
+}
+
 func SysGatewayAndDevice() (gw string, dev string, err error) {
 	iface, gateway, err := SysDefaultRoute()
 	if err == nil && iface != nil && gateway != nil {


### PR DESCRIPTION
## 问题

Android 手机客户端启动时，后台日志出现三条警告：

```
[CLIENT] detect default interface failed err="bind netlink socket: permission denied"
[CLIENT] list interfaces failed err="netlinkrib: permission denied"
[CLIENT] no physical interface found for direct dialer, using unbound dialer
```

## 根因

1. **netlink 被系统禁止**：Android SELinux 不允许应用绑定 `NETLINK_ROUTE` socket，因此 `go-netroute` 路由探测、`net.Interfaces()` 等在 Android 上必然失败（社区已知限制，如 libp2p/go-libp2p#3382）。
2. **Android 架构上根本不需要接口绑定**：EasyssTun 的 VPN 由 `VpnService` + hev-socks5-tunnel（C）接管，Go 核心仅作为本地 SOCKS5 代理运行（`EnableTun2socks` 恒为 false，bound dialer 从不参与拨号）；且 VpnService 采用 **per-app 路由**（`addDisallowedApplication(selfName)` / proxy-only 模式过滤自身），应用自身 socket（含到远程服务器的传输连接）天然绕过 TUN，无需任何 socket 级绑定。

因此启动时的 `startupDialIface` 网卡检测在 Android 上是死代码：检测必失败、结果无人使用，只产生噪音警告。

## 改动

- `util/sys.go`：新增 `SysDirectIfaceBindUnsupported()`（`runtime.GOOS == "android"`），集中平台判定。
- `client/client.go`：
  - 从 `New` 提取 `initDirectDialer()`；Android 上直接使用 unbound dialer，跳过全部检测与警告；桌面平台逻辑不变。
  - `refreshDirectDialer()` 增加防御性早退，避免 Android 上每 30s 重试 netlink 探测。
- `client/dialer_test.go`：新增 4 个测试覆盖两个平台分支（通过注入 `ifaceBindUnsupported`，对齐仓库既有注入模式）。

## 验证

- `go test ./...` 全绿（含新增测试）
- `GOOS=android GOARCH=arm64 go build ./client/... ./util/... ./mobile/... ./runner/...` 编译通过
- `make lint` 0 issues

## 真机验证建议

重新打包 AAR 并升级 EasyssTun 依赖后，启动时三条警告应消失；VPN 联网与直连功能不受影响（hev-socks5-tunnel 路径不变）。
