### PR TITLE
feat: warm up both connection pools on mobile startup

### DIFF
--- a/client/proxy/openAndBootstrap_test.go
+++ b/client/proxy/openAndBootstrap_test.go
@@ -29,10 +29,12 @@ func (s *mockStream) CloseWrite() error { return nil }
 func (s *mockStream) Close() error      { return nil }
 
 type mockTransport struct {
-	mu        sync.Mutex
-	openCount int
-	streams   []transport.Stream
-	openErrs  []error
+	mu          sync.Mutex
+	openCount   int
+	warmUpCount int
+	warmUpErr   error
+	streams     []transport.Stream
+	openErrs    []error
 }
 
 func (m *mockTransport) Open(ctx context.Context, req transport.OpenRequest) (transport.Stream, error) {
@@ -50,6 +52,15 @@ func (m *mockTransport) Open(ctx context.Context, req transport.OpenRequest) (tr
 	return &mockStream{}, nil
 }
 
+// WarmUp records the call so the proxy layer's warm-up plumbing can be
+// asserted without any real network.
+func (m *mockTransport) WarmUp(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.warmUpCount++
+	return m.warmUpErr
+}
+
 func (m *mockTransport) CloseIdle()                      {}
 func (m *mockTransport) Stats() transport.TransportStats { return transport.TransportStats{} }
 func (m *mockTransport) Close() error                    { return nil }
@@ -58,6 +69,12 @@ func (m *mockTransport) openCalls() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.openCount
+}
+
+func (m *mockTransport) warmUpCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.warmUpCount
 }
 
 func newTestStreamHandler(tr transport.Transport) *StreamHandler {
@@ -186,9 +203,10 @@ func (t *saltCapturingTransport) Open(ctx context.Context, req transport.OpenReq
 	return t.inner.Open(ctx, req)
 }
 
-func (t *saltCapturingTransport) CloseIdle()                      {}
-func (t *saltCapturingTransport) Stats() transport.TransportStats { return transport.TransportStats{} }
-func (t *saltCapturingTransport) Close() error                    { return t.inner.Close() }
+func (t *saltCapturingTransport) WarmUp(ctx context.Context) error { return t.inner.WarmUp(ctx) }
+func (t *saltCapturingTransport) CloseIdle()                       {}
+func (t *saltCapturingTransport) Stats() transport.TransportStats  { return transport.TransportStats{} }
+func (t *saltCapturingTransport) Close() error                     { return t.inner.Close() }
 
 func TestOpenAndBootstrap_FreshSaltPerAttempt(t *testing.T) {
 	tr := &mockTransport{

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -49,21 +49,17 @@ func (s *Socks5Server) handleUDP(srv *socks5.Server, clientAddr *net.UDPAddr, d 
 	return s.handleRegularUDP(srv, clientAddr, d, dst)
 }
 
-// WarmUp primes the proxied path right after startup without adding a
-// detectable traffic pattern: it waits a random jitter, then opens a UDP
-// exchange to the proxied DNS server carrying a benign A-record query for
-// domain and closes it immediately. The synchronous open establishes the
-// first HTTP/2 connection (dial + TLS + bootstrap handshake), so the first
-// real page load no longer pays the multi-second cold-start cost. Closing
-// right after the open keeps the stream short, and the query itself travels
-// inside the encrypted tunnel (visible only to the user's own server) and
-// mirrors the domain Android's own connectivity check queries anyway, so
-// the stream is behaviorally indistinguishable from the check's.
+// WarmUp primes the transport's connection pools right after startup, so the
+// first real request of each traffic class does not pay the cold-start cost
+// (dial + TLS + HTTP/2). It waits a random jitter first, so startup traffic is
+// not a fixed, machine-timed event, then primes the pools with real probe
+// requests to the server's /v3/probe endpoint — the same request the
+// degradation detector issues, visible only to the user's own server.
 //
-// jitterMin..jitterMax randomize the warm-up moment so startup traffic is
-// not a fixed, machine-timed event. Best-effort by contract: every failure
-// is logged and swallowed — startup must never depend on warm-up.
-func (s *Socks5Server) WarmUp(domain string, jitterMin, jitterMax, timeout time.Duration) {
+// jitterMin..jitterMax randomize the warm-up moment; timeout bounds the whole
+// warm-up (jitter + connection establishment). Best-effort by contract: every
+// failure is logged and swallowed — startup must never depend on warm-up.
+func (s *Socks5Server) WarmUp(jitterMin, jitterMax, timeout time.Duration) {
 	if s == nil || s.closing.Load() {
 		return
 	}
@@ -79,42 +75,14 @@ func (s *Socks5Server) WarmUp(domain string, jitterMin, jitterMax, timeout time.
 		}
 	}
 
-	msg := &dns.Msg{}
-	msg.SetQuestion(dns.Fqdn(domain), dns.TypeA)
-	msg.RecursionDesired = true
-	data, err := msg.Pack()
-	if err != nil {
-		log.Debug("[WARMUP] pack query", "domain", domain, "err", err)
-		return
-	}
-
-	dst := config.ProxyDNSServer
-	key := "warmup_0_" + strings.ToLower(domain)
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	ue, created, err := s.getOrCreateUDPExchange(ctx, key, dst, data)
-	if err != nil {
-		log.Warn("[WARMUP] open exchange failed", "domain", domain, "err", err)
+	if err := s.handler.Transport().WarmUp(ctx); err != nil {
+		log.Warn("[WARMUP] failed", "err", err)
 		return
 	}
-	if !created {
-		// A real flow beat us to the exchange; the connection is (being)
-		// warmed already.
-		log.Debug("[WARMUP] exchange already exists, skip", "domain", domain)
-		return
-	}
-
-	// The connection is warm once the exchange is open; close it right away
-	// and deliberately do not wait for the DNS response, keeping the stream
-	// short and the traffic pattern minimal.
-	stats.RecordDNSProxyQuery()
-	s.udpMu.Lock()
-	delete(s.udpExch, key)
-	s.udpMu.Unlock()
-	ue.Close() //nolint:errcheck
-	log.Info("[WARMUP] done", "domain", domain)
+	log.Info("[WARMUP] done")
 }
 
 func (s *Socks5Server) handleDNS(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg) error {

--- a/client/proxy/warmup_test.go
+++ b/client/proxy/warmup_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -24,19 +25,21 @@ func newTestSocksServer(tr transport.Transport) *Socks5Server {
 	return s
 }
 
-func TestWarmUp_OpensAndClosesExchange(t *testing.T) {
-	tr := &mockTransport{
-		streams: []transport.Stream{
-			&mockStream{},
-		},
-	}
+// TestWarmUp_WarmsTransport verifies that WarmUp hands the work to the
+// transport exactly once: the proxy layer only jitters and delegates, the
+// transport primes its own pools.
+func TestWarmUp_WarmsTransport(t *testing.T) {
+	tr := &mockTransport{}
 	s := newTestSocksServer(tr)
 
 	// jitter 0: deterministic for tests.
-	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
+	s.WarmUp(0, 0, 2*time.Second)
 
-	if got := tr.openCalls(); got != 1 {
-		t.Errorf("expected exactly 1 transport Open (connection warmed), got %d", got)
+	if got := tr.warmUpCalls(); got != 1 {
+		t.Errorf("expected exactly 1 transport WarmUp, got %d", got)
+	}
+	if got := tr.openCalls(); got != 0 {
+		t.Errorf("expected no transport Open, got %d", got)
 	}
 	if len(s.udpExch) != 0 {
 		t.Errorf("expected exchange map to be empty after warm-up, got %d entries", len(s.udpExch))
@@ -48,55 +51,38 @@ func TestWarmUp_NoopWhenClosing(t *testing.T) {
 	s := newTestSocksServer(tr)
 	s.closing.Store(true)
 
-	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
+	s.WarmUp(0, 0, 2*time.Second)
 
-	if got := tr.openCalls(); got != 0 {
-		t.Errorf("expected no transport Open when server is closing, got %d", got)
+	if got := tr.warmUpCalls(); got != 0 {
+		t.Errorf("expected no transport WarmUp when server is closing, got %d", got)
 	}
 }
 
-func TestWarmUp_NoopWhenExchangeExists(t *testing.T) {
-	tr := &mockTransport{
-		streams: []transport.Stream{
-			&mockStream{},
-			&mockStream{},
-		},
-	}
+// TestWarmUp_ErrorIsSwallowed verifies the best-effort contract: a failing
+// transport warm-up is logged and swallowed, never surfaced to the caller.
+func TestWarmUp_ErrorIsSwallowed(t *testing.T) {
+	tr := &mockTransport{warmUpErr: errors.New("probe failed")}
 	s := newTestSocksServer(tr)
 
-	// First call opens and closes the exchange; the second call must not
-	// open a new one beyond the first.
-	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
-	if got := tr.openCalls(); got != 1 {
-		t.Fatalf("expected 1 transport Open after first warm-up, got %d", got)
-	}
+	s.WarmUp(0, 0, 2*time.Second)
 
-	// Pre-register an exchange for the same key: the warm-up must skip it.
-	key := "warmup_0_connectivitycheck.gstatic.com"
-	s.udpMu.Lock()
-	s.udpExch[key] = &UDPExchange{}
-	s.udpMu.Unlock()
-
-	s.WarmUp("connectivitycheck.gstatic.com", 0, 0, 2*time.Second)
-	if got := tr.openCalls(); got != 1 {
-		t.Errorf("expected no additional transport Open when exchange exists, got %d", got)
+	if got := tr.warmUpCalls(); got != 1 {
+		t.Errorf("expected 1 transport WarmUp attempt, got %d", got)
 	}
 }
 
 func TestWarmUp_JitterBounded(t *testing.T) {
-	tr := &mockTransport{
-		streams: []transport.Stream{&mockStream{}},
-	}
+	tr := &mockTransport{}
 	s := newTestSocksServer(tr)
 
-	// jitterMax must never exceed the timeout; with a 50ms jitter window the
-	// warm-up must still complete (bounded), not hang.
+	// With a 50ms jitter window the warm-up must still complete (bounded),
+	// not hang, and reach the transport exactly once.
 	start := time.Now()
-	s.WarmUp("connectivitycheck.gstatic.com", 10*time.Millisecond, 50*time.Millisecond, 2*time.Second)
+	s.WarmUp(10*time.Millisecond, 50*time.Millisecond, 2*time.Second)
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("warm-up with jitter took too long: %v", elapsed)
 	}
-	if got := tr.openCalls(); got != 1 {
-		t.Errorf("expected 1 transport Open, got %d", got)
+	if got := tr.warmUpCalls(); got != 1 {
+		t.Errorf("expected 1 transport WarmUp, got %d", got)
 	}
 }

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -16,15 +16,12 @@ var (
 	mMu   sync.Mutex
 )
 
-// Warm-up tuning: the domain mirrors what Android's own connectivity check
-// queries the moment a VPN goes live, so the warm-up stream is behaviorally
-// indistinguishable from the check's. The jitter randomizes the warm-up
-// moment so startup traffic is not a fixed, machine-timed event; the timeout
-// bounds the whole warm-up (jitter + connection establishment).
+// Warm-up tuning: the jitter randomizes the warm-up moment so startup traffic
+// is not a fixed, machine-timed event; the timeout bounds the whole warm-up
+// (jitter + connection establishment).
 const (
-	mobileWarmUpDomain    = "connectivitycheck.gstatic.com"
-	mobileWarmUpJitterMin = 500 * time.Millisecond
-	mobileWarmUpJitterMax = 1500 * time.Millisecond
+	mobileWarmUpJitterMin = 300 * time.Millisecond
+	mobileWarmUpJitterMax = 1000 * time.Millisecond
 	mobileWarmUpTimeout   = 8 * time.Second
 )
 
@@ -49,13 +46,13 @@ func Start(cfg *sharedconfig.SimpleConfig) error {
 	return nil
 }
 
-// WarmUp primes the first proxied connection so the first real request does
-// not pay the cold-start cost (dial + TLS + bootstrap handshake). It blocks
-// (bounded by jitter + connection establishment) and should be called
-// between the SOCKS5 server being ready and the VPN going live: the
-// "connecting" state stays visible while it runs, and the VPN comes up with
-// a warm connection. Best-effort: failures are logged inside and never fail
-// startup.
+// WarmUp primes the first proxied connections so the first real requests do
+// not pay the cold-start cost (dial + TLS + HTTP/2). Both scheduling pools are
+// warmed with real probe requests to the server. It blocks (bounded by jitter
+// + connection establishment) and should be called between the SOCKS5 server
+// being ready and the VPN going live: the "connecting" state stays visible
+// while it runs, and the VPN comes up with warm connections. Best-effort:
+// failures are logged inside and never fail startup.
 func WarmUp() error {
 	mMu.Lock()
 	defer mMu.Unlock()
@@ -66,7 +63,7 @@ func WarmUp() error {
 	if mCore.SocksServer == nil {
 		return nil
 	}
-	mCore.SocksServer.WarmUp(mobileWarmUpDomain, mobileWarmUpJitterMin, mobileWarmUpJitterMax, mobileWarmUpTimeout)
+	mCore.SocksServer.WarmUp(mobileWarmUpJitterMin, mobileWarmUpJitterMax, mobileWarmUpTimeout)
 	return nil
 }
 

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -3,6 +3,7 @@ package http2
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -331,6 +332,50 @@ func (t *HTTP2Transport) Open(ctx context.Context, req transport.OpenRequest) (t
 	}()
 
 	return stream, nil
+}
+
+// WarmUp primes the first connection of both scheduling pools so the first
+// real stream of each class reuses an established connection instead of
+// paying the cold-start cost (dial + TLS + HTTP/2): interactive streams
+// (browsing on 443/80/8080/8443/22) live in the priority pool, everything
+// else (DNS on 53, arbitrary ports) in the bulk pool. Each pool is primed
+// with a real probe request over one of its slots — the slot's http.Transport
+// pins the request to that slot's own connection, so the synchronous round
+// trip establishes it. Any answer counts: the probe payload, a fallback page
+// (a server without /v3/probe) or a rejection all prove the path works; only
+// a probe that cannot confirm the connection is reported, and the caller logs
+// and swallows it: startup must never depend on warm-up.
+func (t *HTTP2Transport) WarmUp(ctx context.Context) error {
+	if t.lifecycle.probeFunc == nil {
+		return errors.New("probe not configured")
+	}
+
+	var firstErr error
+	for _, highPriority := range []bool{true, false} {
+		if err := t.warmPool(ctx, highPriority); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// warmPool activates one scheduling pool (first activation adds 2 slots) and
+// establishes its first connection with a probe request over a slot of that
+// pool. The pick must run under the scheduler read lock, mirroring Open.
+func (t *HTTP2Transport) warmPool(ctx context.Context, highPriority bool) error {
+	t.sched.grow(highPriority)
+	t.sched.mu.RLock()
+	slot := t.sched.pick(highPriority)
+	t.sched.mu.RUnlock()
+
+	if _, verdict := t.lifecycle.probeFunc(ctx, slot); verdict == probeInconclusive {
+		// The probe did not confirm the connection: the dial/TLS failed
+		// (the pool stays cold) or the server answered a transient
+		// rejection. Either way, best-effort: report and let the caller
+		// decide.
+		return errors.New("probe did not confirm the connection")
+	}
+	return nil
 }
 
 // protoOfEndpoint maps a proxy endpoint path to its short protocol name

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -11,6 +11,7 @@ import (
 	utls "github.com/refraction-networking/utls"
 
 	sharedconfig "github.com/nange/easyss/v3/config"
+	"github.com/nange/easyss/v3/stats"
 	"github.com/nange/easyss/v3/transport"
 )
 
@@ -315,4 +316,64 @@ func TestTrackReadMarksSlotHeavy(t *testing.T) {
 			t.Fatalf("double release changed counter: %d", slot.heavy.Load())
 		}
 	})
+}
+
+// TestHTTP2Transport_WarmUp verifies that both scheduling pools are activated
+// and get their first connection established with a real probe request: after
+// WarmUp each pool reports 2 live slots (first activation) and the server
+// served exactly one probe per pool, so the first real stream of either class
+// reuses an established connection.
+func TestHTTP2Transport_WarmUp(t *testing.T) {
+	ts, token := newProbeServer(t)
+
+	tr, err := New(Config{
+		ServerURL:  ts.URL,
+		TLSConfig:  &utls.Config{InsecureSkipVerify: true, NextProtos: sharedconfig.NextProtos},
+		Timeout:    time.Second,
+		ProbeToken: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tr.Close() })
+
+	stats.ResetCounters()
+	if err := tr.WarmUp(context.Background()); err != nil {
+		t.Fatalf("WarmUp: %v", err)
+	}
+
+	st := tr.Stats()
+	if st.PriorityConns != 2 {
+		t.Fatalf("PriorityConns = %d, want 2 (priority pool first activation)", st.PriorityConns)
+	}
+	if st.BulkConns != 2 {
+		t.Fatalf("BulkConns = %d, want 2 (bulk pool first activation)", st.BulkConns)
+	}
+	if got := stats.Collect().ServerProbes; got != 2 {
+		t.Fatalf("server served %d probe requests, want 2 (one per pool)", got)
+	}
+}
+
+// TestHTTP2Transport_WarmUpFailsWhenUnreachable verifies that a failed probe
+// (unreachable server) surfaces as an error so the caller can log and swallow
+// it.
+func TestHTTP2Transport_WarmUpFailsWhenUnreachable(t *testing.T) {
+	ts, token := newProbeServer(t)
+	deadURL := ts.URL
+	ts.Close() // connection refused from now on
+
+	tr, err := New(Config{
+		ServerURL:  deadURL,
+		TLSConfig:  &utls.Config{InsecureSkipVerify: true, NextProtos: sharedconfig.NextProtos},
+		Timeout:    time.Second,
+		ProbeToken: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tr.Close() })
+
+	if err := tr.WarmUp(context.Background()); err == nil {
+		t.Fatal("expected an error when the server is unreachable, got nil")
+	}
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -102,6 +102,15 @@ type GrowEvent struct {
 
 type Transport interface {
 	Open(ctx context.Context, req OpenRequest) (Stream, error)
+	// WarmUp primes the first connection of every scheduling pool so the
+	// first real stream of each traffic class reuses an established
+	// connection instead of paying the cold-start cost (dial + TLS +
+	// HTTP/2). Implementations activate the pool and issue one request over
+	// a connection of that pool; any answer proves the path works, so only
+	// a request that cannot confirm the connection is reported as an error.
+	// Best-effort by contract: callers log and swallow the error, startup
+	// must never depend on warm-up.
+	WarmUp(ctx context.Context) error
 	CloseIdle()
 	Stats() TransportStats
 	Close() error


### PR DESCRIPTION
## 背景

移动端启动预热（`WarmUp`）原本只打开一个到代理 DNS 服务器（8.8.8.8:53）的 UDP exchange。由于端口 53 不是交互端口（`isInteractivePort` 只认 22/80/443/8080/8443），该流被归类为 bulk，只激活了调度器的 **bulk 池**；**priority 池**（真实浏览流量 443 端口所属）保持冷态，第一个交互请求仍要承担 dial + TLS 冷启动。

## 改动

- **两个池统一用 `/v3/probe` 真实探测请求预热**。`HTTP2Transport.WarmUp` 对 priority、bulk 各做一次：激活池（`grow`，首激活 +2 槽位）→ `pick` 取该池一个槽位 → 用该槽位自己的 `http.Transport` 发一次真实探测请求（`MaxConnsPerHost=1` 把请求钉在该槽位的连接上）。同步请求完成即连接已建立；探测载荷 / 回退页 / 429 都算路径可用，仅探测无法确认连接时报错（调用方记日志后吞掉）。
  > 注：必须走「激活池 + 选中槽位 + 用该槽位的 transport」这三步——单独发一个 HTTP 请求只会新建一条调度器永不复用的连接。
- **删除 `transport.PriorityWarmer` 可选接口**：`WarmUp(ctx) error` 直接进入 `transport.Transport` 接口，调用点从类型断言变成一行方法调用（全仓仅 3 个实现：`HTTP2Transport` + 2 个测试替身）。
- **删除 bulk 的 DNS exchange 预热**：`domain` 参数、DNS 报文打包、`warmUDPExchange`、`warmup_0_<domain>` key 全部移除；`Socks5Server.WarmUp(jitterMin, jitterMax, timeout)` 现在只做「抖动 + 委托」，并保留 `closing`/`quit` 取消语义与 `[WARMUP]` 日志。
- **抖动时间 0.5s~1.5s → 0.3s~1s**；`Mobile.warmUp()` 对外 API 不变（EasyssTun 无需改动）；服务端零改动。

## 会明显增加代理特征吗

不会。预热流量全部在 TLS 隧道内（uTLS Chrome 指纹 + HTTP/2），on-path 只能看到连接数、字节量与时序：

- 相对现状：启动时多约 128KB 下载（bulk 探测载荷），少一个极小的加密 POST 流；**服务端少一次转发给 8.8.8.8 的 DNS 查询，第三方可见性反而下降**。
- `/v3/probe` 本身就是协议日常行为（degraded 检测周期性使用）；错误 token 返回 fallback 页、按 IP 限流（50/s，burst 100，独立于 handshake 限流）、h2-only 校验，均不新增明文特征。
- 预热仍是一次性、抖动化（0.3~1s）、非周期性事件。

实际代价：每次连接多约 128KB 流量；极慢链路下预热时长上限由 ~3s 变为 ~6s（两次顺序探测，仍受 8s 外层超时与 best-effort 约束）。

## 测试

- 传输层：`WarmUp` 后 priority 与 bulk 各 `Conns == 2`（首激活），服务端恰好服务 2 次探测；服务端不可达时返回 error；
- 代理层：一次 `WarmUp` 恰好委托 transport 1 次、不发任何 Open；`closing` 时 0 次；transport 报错被吞掉；带抖动仍限时完成。

`go build ./...`、`go test ./...`（逐包）全部通过，`make lint` 0 issues。