### PR TITLE
feat: return the warm-up failure at the mobile binding

### DIFF
--- a/client/proxy/openAndBootstrap_test.go
+++ b/client/proxy/openAndBootstrap_test.go
@@ -53,7 +53,8 @@ func (m *mockTransport) Open(ctx context.Context, req transport.OpenRequest) (tr
 }
 
 // WarmUp records the call so the proxy layer's warm-up plumbing can be
-// asserted without any real network.
+// asserted without any real network; warmUpErr is returned to the proxy layer,
+// which logs it and hands it back to its own caller.
 func (m *mockTransport) WarmUp(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -57,11 +57,15 @@ func (s *Socks5Server) handleUDP(srv *socks5.Server, clientAddr *net.UDPAddr, d 
 // degradation detector issues, visible only to the user's own server.
 //
 // jitterMin..jitterMax randomize the warm-up moment; timeout bounds the whole
-// warm-up (jitter + connection establishment). Best-effort by contract: every
-// failure is logged and swallowed — startup must never depend on warm-up.
-func (s *Socks5Server) WarmUp(jitterMin, jitterMax, timeout time.Duration) {
+// warm-up (jitter + connection establishment). Best-effort by contract: the
+// failure is logged here and returned so the caller can decide what to do with
+// it, but startup must never depend on warm-up. A nil error can also mean the
+// warm-up was skipped (server closing or quit during the jitter), and a
+// non-nil error does not mean the warm-up was useless: the connection may be
+// established while the probe that confirms it did not answer in time.
+func (s *Socks5Server) WarmUp(jitterMin, jitterMax, timeout time.Duration) error {
 	if s == nil || s.closing.Load() {
-		return
+		return nil
 	}
 	if jitterMax > 0 {
 		d := jitterMin
@@ -71,7 +75,10 @@ func (s *Socks5Server) WarmUp(jitterMin, jitterMax, timeout time.Duration) {
 		select {
 		case <-time.After(d):
 		case <-s.quit:
-			return
+			// Shutting down during the jitter: the warm-up is skipped, not
+			// failed.
+			log.Debug("[WARMUP] skipped, server closing")
+			return nil
 		}
 	}
 
@@ -80,9 +87,10 @@ func (s *Socks5Server) WarmUp(jitterMin, jitterMax, timeout time.Duration) {
 
 	if err := s.handler.Transport().WarmUp(ctx); err != nil {
 		log.Warn("[WARMUP] failed", "err", err)
-		return
+		return err
 	}
 	log.Info("[WARMUP] done")
+	return nil
 }
 
 func (s *Socks5Server) handleDNS(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg) error {

--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"math/rand/v2"
 	"net"
 	"strings"
 	"time"
@@ -47,50 +46,6 @@ func (s *Socks5Server) handleUDP(srv *socks5.Server, clientAddr *net.UDPAddr, d 
 	}
 
 	return s.handleRegularUDP(srv, clientAddr, d, dst)
-}
-
-// WarmUp primes the transport's connection pools right after startup, so the
-// first real request of each traffic class does not pay the cold-start cost
-// (dial + TLS + HTTP/2). It waits a random jitter first, so startup traffic is
-// not a fixed, machine-timed event, then primes the pools with real probe
-// requests to the server's /v3/probe endpoint — the same request the
-// degradation detector issues, visible only to the user's own server.
-//
-// jitterMin..jitterMax randomize the warm-up moment; timeout bounds the whole
-// warm-up (jitter + connection establishment). Best-effort by contract: the
-// failure is logged here and returned so the caller can decide what to do with
-// it, but startup must never depend on warm-up. A nil error can also mean the
-// warm-up was skipped (server closing or quit during the jitter), and a
-// non-nil error does not mean the warm-up was useless: the connection may be
-// established while the probe that confirms it did not answer in time.
-func (s *Socks5Server) WarmUp(jitterMin, jitterMax, timeout time.Duration) error {
-	if s == nil || s.closing.Load() {
-		return nil
-	}
-	if jitterMax > 0 {
-		d := jitterMin
-		if span := jitterMax - jitterMin; span > 0 {
-			d += time.Duration(rand.Float64() * float64(span))
-		}
-		select {
-		case <-time.After(d):
-		case <-s.quit:
-			// Shutting down during the jitter: the warm-up is skipped, not
-			// failed.
-			log.Debug("[WARMUP] skipped, server closing")
-			return nil
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	if err := s.handler.Transport().WarmUp(ctx); err != nil {
-		log.Warn("[WARMUP] failed", "err", err)
-		return err
-	}
-	log.Info("[WARMUP] done")
-	return nil
 }
 
 func (s *Socks5Server) handleDNS(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg) error {

--- a/client/proxy/warmup.go
+++ b/client/proxy/warmup.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	"github.com/nange/easyss/v3/log"
+)
+
+// WarmUp primes the transport's connection pools right after startup, so the
+// first real request of each traffic class does not pay the cold-start cost
+// (dial + TLS + HTTP/2). It waits a random jitter first, so startup traffic is
+// not a fixed, machine-timed event, then primes the pools with real probe
+// requests to the server's /v3/probe endpoint — the same request the
+// degradation detector issues, visible only to the user's own server.
+//
+// jitterMin..jitterMax randomize the warm-up moment; timeout bounds the whole
+// warm-up (jitter + connection establishment). Best-effort by contract: the
+// failure is logged here and returned so the caller can decide what to do with
+// it, but startup must never depend on warm-up. A nil error can also mean the
+// warm-up was skipped (server closing or quit during the jitter), and a
+// non-nil error does not mean the warm-up was useless: the connection may be
+// established while the probe that confirms it did not answer in time.
+func (s *Socks5Server) WarmUp(jitterMin, jitterMax, timeout time.Duration) error {
+	if s == nil || s.closing.Load() {
+		return nil
+	}
+	if jitterMax > 0 {
+		d := jitterMin
+		if span := jitterMax - jitterMin; span > 0 {
+			d += time.Duration(rand.Float64() * float64(span))
+		}
+		select {
+		case <-time.After(d):
+		case <-s.quit:
+			// Shutting down during the jitter: the warm-up is skipped, not
+			// failed.
+			log.Debug("[WARMUP] skipped, server closing")
+			return nil
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := s.handler.Transport().WarmUp(ctx); err != nil {
+		log.Warn("[WARMUP] failed", "err", err)
+		return err
+	}
+	log.Info("[WARMUP] done")
+	return nil
+}

--- a/client/proxy/warmup_test.go
+++ b/client/proxy/warmup_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +34,9 @@ func TestWarmUp_WarmsTransport(t *testing.T) {
 	s := newTestSocksServer(tr)
 
 	// jitter 0: deterministic for tests.
-	s.WarmUp(0, 0, 2*time.Second)
+	if err := s.WarmUp(0, 0, 2*time.Second); err != nil {
+		t.Fatalf("unexpected error from a confirmed warm-up: %v", err)
+	}
 
 	if got := tr.warmUpCalls(); got != 1 {
 		t.Errorf("expected exactly 1 transport WarmUp, got %d", got)
@@ -51,21 +54,31 @@ func TestWarmUp_NoopWhenClosing(t *testing.T) {
 	s := newTestSocksServer(tr)
 	s.closing.Store(true)
 
-	s.WarmUp(0, 0, 2*time.Second)
+	// A skipped warm-up is not a failure: closing returns nil, never an error.
+	if err := s.WarmUp(0, 0, 2*time.Second); err != nil {
+		t.Errorf("expected nil when server is closing, got %v", err)
+	}
 
 	if got := tr.warmUpCalls(); got != 0 {
 		t.Errorf("expected no transport WarmUp when server is closing, got %d", got)
 	}
 }
 
-// TestWarmUp_ErrorIsSwallowed verifies the best-effort contract: a failing
-// transport warm-up is logged and swallowed, never surfaced to the caller.
-func TestWarmUp_ErrorIsSwallowed(t *testing.T) {
+// TestWarmUp_ErrorIsReturned verifies the best-effort contract: the failure is
+// logged here and handed back to the caller (which may swallow it), but the
+// error is never replaced or dropped by the proxy layer.
+func TestWarmUp_ErrorIsReturned(t *testing.T) {
 	tr := &mockTransport{warmUpErr: errors.New("probe failed")}
 	s := newTestSocksServer(tr)
 
-	s.WarmUp(0, 0, 2*time.Second)
+	err := s.WarmUp(0, 0, 2*time.Second)
 
+	if err == nil {
+		t.Fatal("expected the transport warm-up error to be returned, got nil")
+	}
+	if !strings.Contains(err.Error(), "probe failed") {
+		t.Errorf("expected the transport error to be preserved, got %v", err)
+	}
 	if got := tr.warmUpCalls(); got != 1 {
 		t.Errorf("expected 1 transport WarmUp attempt, got %d", got)
 	}
@@ -78,11 +91,30 @@ func TestWarmUp_JitterBounded(t *testing.T) {
 	// With a 50ms jitter window the warm-up must still complete (bounded),
 	// not hang, and reach the transport exactly once.
 	start := time.Now()
-	s.WarmUp(10*time.Millisecond, 50*time.Millisecond, 2*time.Second)
+	if err := s.WarmUp(10*time.Millisecond, 50*time.Millisecond, 2*time.Second); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("warm-up with jitter took too long: %v", elapsed)
 	}
 	if got := tr.warmUpCalls(); got != 1 {
 		t.Errorf("expected 1 transport WarmUp, got %d", got)
+	}
+}
+
+// TestWarmUp_QuitDuringJitterIsNotAnError verifies the shutdown path: when the
+// server quits while the warm-up is waiting for its jitter, the warm-up is
+// reported as skipped (nil), so a deliberate Stop never surfaces as a failure.
+func TestWarmUp_QuitDuringJitterIsNotAnError(t *testing.T) {
+	tr := &mockTransport{}
+	s := newTestSocksServer(tr)
+
+	close(s.quit)
+
+	if err := s.WarmUp(time.Second, 2*time.Second, 2*time.Second); err != nil {
+		t.Errorf("expected nil when quit during jitter, got %v", err)
+	}
+	if got := tr.warmUpCalls(); got != 0 {
+		t.Errorf("expected no transport WarmUp after quit, got %d", got)
 	}
 }

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -51,8 +51,13 @@ func Start(cfg *sharedconfig.SimpleConfig) error {
 // warmed with real probe requests to the server. It blocks (bounded by jitter
 // + connection establishment) and should be called between the SOCKS5 server
 // being ready and the VPN going live: the "connecting" state stays visible
-// while it runs, and the VPN comes up with warm connections. Best-effort:
-// failures are logged inside and never fail startup.
+// while it runs, and the VPN comes up with warm connections.
+//
+// Best-effort by contract: a warm-up that could not be confirmed is returned
+// (and logged by the proxy layer) so the caller can record it, but the caller
+// must not fail startup because of it — a nil error can equally mean the
+// warm-up was skipped (no SOCKS5 server, or shutting down). gomobile surfaces
+// a non-nil error as a Java exception, so callers must handle it.
 func WarmUp() error {
 	mMu.Lock()
 	defer mMu.Unlock()
@@ -61,10 +66,11 @@ func WarmUp() error {
 		return fmt.Errorf("not started, call Start first")
 	}
 	if mCore.SocksServer == nil {
+		// No local SOCKS5 proxy in this configuration: there is nothing to
+		// warm, which is not a failure.
 		return nil
 	}
-	mCore.SocksServer.WarmUp(mobileWarmUpJitterMin, mobileWarmUpJitterMax, mobileWarmUpTimeout)
-	return nil
+	return mCore.SocksServer.WarmUp(mobileWarmUpJitterMin, mobileWarmUpJitterMax, mobileWarmUpTimeout)
 }
 
 func Stop() {

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -1,0 +1,50 @@
+package mobile
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nange/easyss/v3/runner"
+)
+
+// withCore swaps the package-level Core under the same lock the binding uses,
+// restoring the previous value when the test ends.
+func withCore(t *testing.T, core *runner.Core) {
+	t.Helper()
+
+	mMu.Lock()
+	prev := mCore
+	mCore = core
+	mMu.Unlock()
+
+	t.Cleanup(func() {
+		mMu.Lock()
+		mCore = prev
+		mMu.Unlock()
+	})
+}
+
+// TestWarmUpWithoutStart verifies that calling the binding before Start is
+// reported to the caller instead of being silently ignored.
+func TestWarmUpWithoutStart(t *testing.T) {
+	withCore(t, nil)
+
+	err := WarmUp()
+
+	if err == nil {
+		t.Fatal("expected an error when the core is not started, got nil")
+	}
+	if !strings.Contains(err.Error(), "not started") {
+		t.Errorf("error = %v, want it to mention that Start must be called first", err)
+	}
+}
+
+// TestWarmUpWithoutSocksServer verifies the skip path: a core without a local
+// SOCKS5 proxy has nothing to warm, which is not a failure and must not block.
+func TestWarmUpWithoutSocksServer(t *testing.T) {
+	withCore(t, &runner.Core{})
+
+	if err := WarmUp(); err != nil {
+		t.Errorf("expected nil when there is no SOCKS5 server, got %v", err)
+	}
+}

--- a/transport/http2/client.go
+++ b/transport/http2/client.go
@@ -361,19 +361,27 @@ func (t *HTTP2Transport) WarmUp(ctx context.Context) error {
 
 // warmPool activates one scheduling pool (first activation adds 2 slots) and
 // establishes its first connection with a probe request over a slot of that
-// pool. The pick must run under the scheduler read lock, mirroring Open.
+// pool. The pick must run under the scheduler read lock, mirroring Open. A
+// probe that does not confirm the connection is reported as
+// errProbeNotConfirmed wrapped with the pool name, so the caller can tell
+// which traffic class stayed cold.
 func (t *HTTP2Transport) warmPool(ctx context.Context, highPriority bool) error {
 	t.sched.grow(highPriority)
 	t.sched.mu.RLock()
 	slot := t.sched.pick(highPriority)
 	t.sched.mu.RUnlock()
 
+	poolName := "bulk"
+	if highPriority {
+		poolName = "priority"
+	}
+
 	if _, verdict := t.lifecycle.probeFunc(ctx, slot); verdict == probeInconclusive {
 		// The probe did not confirm the connection: the dial/TLS failed
 		// (the pool stays cold) or the server answered a transient
 		// rejection. Either way, best-effort: report and let the caller
 		// decide.
-		return errors.New("probe did not confirm the connection")
+		return fmt.Errorf("warm up %s pool: %w", poolName, errProbeNotConfirmed)
 	}
 	return nil
 }

--- a/transport/http2/client_test.go
+++ b/transport/http2/client_test.go
@@ -2,9 +2,11 @@ package http2
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -355,8 +357,9 @@ func TestHTTP2Transport_WarmUp(t *testing.T) {
 }
 
 // TestHTTP2Transport_WarmUpFailsWhenUnreachable verifies that a failed probe
-// (unreachable server) surfaces as an error so the caller can log and swallow
-// it.
+// (unreachable server) surfaces as an error so the caller can decide whether to
+// swallow it. The error names the pool that stayed cold and wraps the sentinel
+// verdict, so callers can classify the failure instead of matching text.
 func TestHTTP2Transport_WarmUpFailsWhenUnreachable(t *testing.T) {
 	ts, token := newProbeServer(t)
 	deadURL := ts.URL
@@ -373,7 +376,14 @@ func TestHTTP2Transport_WarmUpFailsWhenUnreachable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = tr.Close() })
 
-	if err := tr.WarmUp(context.Background()); err == nil {
+	err = tr.WarmUp(context.Background())
+	if err == nil {
 		t.Fatal("expected an error when the server is unreachable, got nil")
+	}
+	if !errors.Is(err, errProbeNotConfirmed) {
+		t.Errorf("error = %v, want it to wrap errProbeNotConfirmed", err)
+	}
+	if !strings.Contains(err.Error(), "priority") {
+		t.Errorf("error = %v, want it to name the pool that failed", err)
 	}
 }

--- a/transport/http2/probe.go
+++ b/transport/http2/probe.go
@@ -2,12 +2,20 @@ package http2
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
 	sharedconfig "github.com/nange/easyss/v3/config"
 	"github.com/nange/easyss/v3/stats"
 )
+
+// errProbeNotConfirmed classifies a probe that did not confirm the slot
+// connection: a RoundTrip failure (dial/TLS/stream error, or the probe
+// timeout elapsing before the response headers) or a non-200 rejection (e.g.
+// 429 rate limit). Warm-up wraps it with the pool it failed to warm; the
+// lifecycle treats the same verdict as "no state change" instead.
+var errProbeNotConfirmed = errors.New("probe did not confirm the connection")
 
 // probeVerdict classifies a single probe result.
 type probeVerdict int

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -108,8 +108,10 @@ type Transport interface {
 	// HTTP/2). Implementations activate the pool and issue one request over
 	// a connection of that pool; any answer proves the path works, so only
 	// a request that cannot confirm the connection is reported as an error.
-	// Best-effort by contract: callers log and swallow the error, startup
-	// must never depend on warm-up.
+	// Best-effort by contract: implementations must not silently drop a
+	// failure they already determined, but callers decide what to do with
+	// it — startup must never depend on warm-up, so the usual handling is
+	// to log it and continue.
 	WarmUp(ctx context.Context) error
 	CloseIdle()
 	Stats() TransportStats


### PR DESCRIPTION
## 背景

`mobile.WarmUp()` 在预热失败时返回的信息被丢弃了两次：`client/proxy` 打完 `log.Warn("[WARMUP] failed")` 后直接 `return`，`mobile` 又在 `SocksServer != nil` 时无条件 `return nil`。结果是 AAR 永远无法知道 VPN 到底是"带着热连接起来"还是"连接池仍然是冷的"，Java 侧只能去翻 Go 日志。

本次把这个信号一路上抛到绑定边界，同时**保持 best-effort 契约不变**：返回的 error 是信息性的，启动绝不依赖预热。

## 改动

| 层 | 改动 |
| --- | --- |
| `transport/http2` | 把 `probeInconclusive` 归类为包内哨兵 `errProbeNotConfirmed`，并在包装消息里带上失冷的池名（priority/bulk），调用方可用 `errors.Is` 分类而不是匹配错误文本 |
| `client/proxy` | `WarmUp(...) error`：传输层错误保留原有 `log.Warn` 后上抛；"跳过"路径（无 server、`closing`、jitter 期间 `quit`）仍返回 `nil`，所以主动 `Stop` 不会凭空冒出一个"预热失败" |
| `mobile` | 透传预热错误；`SocksServer == nil`（该配置下没有本地 SOCKS 入口）仍返回 `nil`，因为没什么可预热 |
| `transport` | 接口文档从 "callers log and swallow" 改为"实现不得静默丢弃已判定的失败，是否致命由调用方决定" |

## 文件归属整理

`Socks5Server.WarmUp` 原本放在 `client/proxy/udp.go`，是历史遗留：最初的预热实现是"向代理 DNS 服务器发一个 UDP 交换"（PR #146），改成走 `/v3/probe` 探测（PR #149）后 UDP 依赖已被完全删除，方法体只剩"jitter + 委托 transport"，却仍留在 UDP 文件里。本 PR 的第二个 commit 把它**原样搬进新建的 `client/proxy/warmup.go`**（与已有的 `warmup_test.go` 配对，符合本包按主题拆文件的风格），并移除 `udp.go` 中因此不再使用的 `math/rand/v2` 导入。无行为变更。

## 行为变化（升级 AAR 需要注意）

`gomobile` 会把 `func() error` 映射成检查型异常，已实测新 AAR 的 Java 签名为：

```java
public static native void warmUp() throws java.lang.Exception;
```

所以 EasyssTun 升级 AAR 时必须同步处理该异常（**编译期可发现**，不会静默崩溃）：捕获后只记录日志，**不得因预热失败而阻止 VPN 建立**；非 nil 也只代表"这次探测没确认连接"，不代表预热无用（TCP/TLS 可能已经建好，只是探测请求没及时应答）。

## 测试

- `client/proxy/warmup_test.go`：`TestWarmUp_ErrorIsReturned`（错误被保留而非替换）、`TestWarmUp_QuitDuringJitterIsNotAnError`（跳过语义）、成功/关闭路径补返回值断言
- `mobile/mobile_test.go`（新增）：未 `Start`、无 `SocksServer` 两条路径
- `transport/http2/client_test.go`：补 `errors.Is(err, errProbeNotConfirmed)` 与池名断言
- `go test -count=1 -timeout 15m ./...` 全绿；`make lint` → `0 issues`
- `make easyss-android-aar` 构建成功，解包 `classes.jar` 后用 `javap` 确认上面的 `throws` 签名
