### PR TITLE
feat: publish the system proxy to the Linux session environment

### DIFF
--- a/cmd/easyss/sysproxy.go
+++ b/cmd/easyss/sysproxy.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -10,25 +11,64 @@ import (
 	"github.com/wzshiming/sysproxy"
 )
 
+// setSysProxy points the system at the local http proxy through both available
+// mechanisms: the desktop proxy settings (gsettings on GNOME, kioslaverc on KDE,
+// the registry on Windows, networksetup on macOS) and -- on Linux -- the session
+// environment. The latter is what programs that do not read the desktop settings
+// use; Chromium, for example, ignores gsettings on every desktop environment it
+// does not recognise, which includes Hyprland.
+//
+// The returned error is nil as soon as one of the two mechanisms took effect,
+// so that a caller can rely on unsetSysProxy undoing it again.
 func setSysProxy(port int) error {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	if err := sysproxy.OnHTTP(addr); err != nil {
-		return fmt.Errorf("set http proxy: %w", err)
+
+	settingsErr := errors.Join(
+		wrapProxyErr("set http proxy", sysproxy.OnHTTP(addr)),
+		wrapProxyErr("set https proxy", sysproxy.OnHTTPS(addr)),
+	)
+	envApplied, envErr := setSysProxyEnv(port)
+
+	if settingsErr != nil && !envApplied {
+		return errors.Join(settingsErr, envErr)
 	}
-	if err := sysproxy.OnHTTPS(addr); err != nil {
-		return fmt.Errorf("set https proxy: %w", err)
+	if settingsErr != nil {
+		log.Warn("[SYSPROXY] desktop proxy settings not updated, relying on the session environment", "err", settingsErr)
 	}
+	if envErr != nil {
+		log.Warn("[SYSPROXY] session environment not updated", "err", envErr)
+	}
+
 	log.Info("[SYSPROXY] proxy enabled", "port", strconv.Itoa(port))
 	return nil
 }
 
 func unsetSysProxy() error {
-	if err := sysproxy.OffHTTP(); err != nil {
-		return fmt.Errorf("unset http proxy: %w", err)
+	settingsErr := errors.Join(
+		wrapProxyErr("unset http proxy", sysproxy.OffHTTP()),
+		wrapProxyErr("unset https proxy", sysproxy.OffHTTPS()),
+	)
+	envApplied, envErr := unsetSysProxyEnv()
+
+	if settingsErr != nil && !envApplied {
+		return errors.Join(settingsErr, envErr)
 	}
-	if err := sysproxy.OffHTTPS(); err != nil {
-		return fmt.Errorf("unset https proxy: %w", err)
+	if settingsErr != nil {
+		log.Warn("[SYSPROXY] desktop proxy settings not restored", "err", settingsErr)
 	}
+	if envErr != nil {
+		log.Warn("[SYSPROXY] session environment not restored", "err", envErr)
+	}
+
 	log.Info("[SYSPROXY] proxy disabled")
 	return nil
+}
+
+// wrapProxyErr labels an error without turning a nil error into a non-nil one,
+// so that errors.Join keeps reporting success when every step succeeded.
+func wrapProxyErr(msg string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", msg, err)
 }

--- a/cmd/easyss/sysproxy_env_linux.go
+++ b/cmd/easyss/sysproxy_env_linux.go
@@ -1,0 +1,250 @@
+//go:build linux && !headless
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nange/easyss/v3/log"
+	"github.com/nange/easyss/v3/util"
+)
+
+const (
+	// sysProxyNoProxy keeps traffic to the local machine itself out of the
+	// proxy. Without it a request for http://127.0.0.1:<http_port>/stats would
+	// be sent to the proxy listening at that very address.
+	sysProxyNoProxy = "localhost,127.0.0.1,::1"
+
+	// proxyEnvTimeout bounds the external commands below so that an
+	// unresponsive session bus cannot block startup or the tray.
+	proxyEnvTimeout = 5 * time.Second
+)
+
+// sysProxyEnvKeys lists every variable easyss publishes and restores.
+//
+// Programs pick the proxy source based on the desktop environment they detect:
+// Chromium reads gsettings on GNOME and kioslaverc on KDE, but on any other
+// desktop (Hyprland, sway, ...) it ignores the system settings entirely and
+// only looks at these environment variables. Publishing them to the session
+// environment therefore closes the gap that leaves a browser on a plain
+// Hyprland session talking directly to the internet.
+var sysProxyEnvKeys = []string{
+	"http_proxy", "https_proxy", "no_proxy",
+	"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+}
+
+// proxyEnvStore identifies where setSysProxyEnv published the proxy.
+type proxyEnvStore int
+
+const (
+	proxyEnvStoreNone proxyEnvStore = iota
+	proxyEnvStoreSystemd
+	proxyEnvStoreDBus
+)
+
+// proxyEnvCmd is a single external command that reads or updates the session
+// environment.
+type proxyEnvCmd struct {
+	name string
+	args []string
+}
+
+// proxyEnvExec runs such a command. It is a variable so that tests can observe
+// the commands being issued without touching the real session.
+var proxyEnvExec = func(name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), proxyEnvTimeout)
+	defer cancel()
+
+	return util.CommandContext(ctx, name, args...)
+}
+
+var sysProxyEnv struct {
+	mu sync.Mutex
+	// previous holds the values the session environment had before easyss
+	// changed them. A key missing from the map was not set at all.
+	previous map[string]string
+	store    proxyEnvStore
+}
+
+// setSysProxyEnv publishes the proxy for the given local http proxy port to the
+// session environment. It reports whether the environment was updated, which is
+// false on a session that offers neither a systemd user manager nor a D-Bus
+// session bus.
+//
+// Only applications started after this call inherit the new variables: a
+// browser that is already running has to be restarted to pick the proxy up.
+func setSysProxyEnv(port int) (bool, error) {
+	sysProxyEnv.mu.Lock()
+	defer sysProxyEnv.mu.Unlock()
+
+	if sysProxyEnv.store == proxyEnvStoreNone {
+		sysProxyEnv.previous = snapshotSysProxyEnv()
+	}
+
+	store, err := applySysProxyEnv(sysProxyEnvValues(port))
+	if store == proxyEnvStoreNone {
+		return false, err
+	}
+
+	sysProxyEnv.store = store
+	log.Info("[SYSPROXY] session environment updated, already running applications keep their previous proxy settings")
+	return true, nil
+}
+
+// unsetSysProxyEnv restores the variables setSysProxyEnv overwrote. It reports
+// whether it changed anything, which is false when this process never published
+// a proxy.
+func unsetSysProxyEnv() (bool, error) {
+	sysProxyEnv.mu.Lock()
+	defer sysProxyEnv.mu.Unlock()
+
+	if sysProxyEnv.store == proxyEnvStoreNone {
+		return false, nil
+	}
+
+	// Keep the state when the restore fails, so that a retry -- the tray
+	// reverts its checkmark and lets the user click again -- can still bring
+	// the original values back.
+	if err := restoreSysProxyEnv(sysProxyEnv.store, sysProxyEnv.previous); err != nil {
+		return false, err
+	}
+
+	sysProxyEnv.previous = nil
+	sysProxyEnv.store = proxyEnvStoreNone
+	return true, nil
+}
+
+// sysProxyEnvValues returns the session environment easyss publishes for the
+// given local http proxy port.
+func sysProxyEnvValues(port int) map[string]string {
+	addr := "http://127.0.0.1:" + strconv.Itoa(port)
+
+	return map[string]string{
+		"http_proxy":  addr,
+		"https_proxy": addr,
+		"no_proxy":    sysProxyNoProxy,
+		"HTTP_PROXY":  addr,
+		"HTTPS_PROXY": addr,
+		"NO_PROXY":    sysProxyNoProxy,
+	}
+}
+
+// snapshotSysProxyEnv records the proxy related variables the session
+// environment currently holds, so that unsetSysProxyEnv can put them back. A
+// variable missing from the result was not set before.
+func snapshotSysProxyEnv() map[string]string {
+	previous := make(map[string]string, len(sysProxyEnvKeys))
+
+	current, err := systemdUserEnv()
+	if err != nil {
+		// Restoring then degrades to clearing the variables, which still beats
+		// leaving a proxy pointing at a stopped easyss behind.
+		log.Warn("[SYSPROXY] cannot read session environment, previous proxy values will not be restored", "err", err)
+		return previous
+	}
+
+	for _, key := range sysProxyEnvKeys {
+		if value, ok := current[key]; ok {
+			previous[key] = value
+		}
+	}
+
+	return previous
+}
+
+// applySysProxyEnv publishes the given values to the session environment.
+//
+// Exactly one store is used. The systemd user manager is preferred because it is
+// what desktop sessions that launch applications through systemd -- uwsm on
+// Hyprland, for instance -- hand down to them, and because it can remove a
+// variable again. Only when there is no usable user manager does easyss fall
+// back to the D-Bus activation environment.
+//
+// Writing to both would be a mistake: with dbus-broker the activation
+// environment *is* the systemd user manager environment, so the values would be
+// published twice and could no longer be removed cleanly.
+func applySysProxyEnv(values map[string]string) (proxyEnvStore, error) {
+	assignments := make([]string, 0, len(sysProxyEnvKeys))
+	for _, key := range sysProxyEnvKeys {
+		assignments = append(assignments, key+"="+values[key])
+	}
+
+	systemdErr := runProxyEnvCmd(proxyEnvCmd{"systemctl", append([]string{"--user", "set-environment"}, assignments...)})
+	if systemdErr == nil {
+		return proxyEnvStoreSystemd, nil
+	}
+
+	dbusErr := runProxyEnvCmd(proxyEnvCmd{"dbus-update-activation-environment", assignments})
+	if dbusErr != nil {
+		return proxyEnvStoreNone, errors.Join(systemdErr, dbusErr)
+	}
+
+	log.Warn("[SYSPROXY] systemd user manager not reachable, using the D-Bus activation environment", "err", systemdErr)
+	return proxyEnvStoreDBus, nil
+}
+
+// restoreSysProxyEnv puts the session environment back to the values
+// snapshotSysProxyEnv captured, using the store the proxy was published to.
+func restoreSysProxyEnv(store proxyEnvStore, previous map[string]string) error {
+	if store == proxyEnvStoreDBus {
+		// dbus-daemon cannot remove a variable once it has been set, so the
+		// ones easyss introduced are emptied instead: Chromium, curl and
+		// friends treat an empty proxy variable the same as an unset one.
+		assignments := make([]string, 0, len(sysProxyEnvKeys))
+		for _, key := range sysProxyEnvKeys {
+			assignments = append(assignments, key+"="+previous[key])
+		}
+		return runProxyEnvCmd(proxyEnvCmd{"dbus-update-activation-environment", assignments})
+	}
+
+	var systemdSet, systemdUnset []string
+	for _, key := range sysProxyEnvKeys {
+		if value, ok := previous[key]; ok {
+			systemdSet = append(systemdSet, key+"="+value)
+			continue
+		}
+		systemdUnset = append(systemdUnset, key)
+	}
+
+	// Putting the previous values back and removing the ones easyss added are
+	// two independent commands, and both have to run.
+	var errs []error
+	if len(systemdSet) > 0 {
+		cmd := proxyEnvCmd{"systemctl", append([]string{"--user", "set-environment"}, systemdSet...)}
+		errs = append(errs, runProxyEnvCmd(cmd))
+	}
+	if len(systemdUnset) > 0 {
+		cmd := proxyEnvCmd{"systemctl", append([]string{"--user", "unset-environment"}, systemdUnset...)}
+		errs = append(errs, runProxyEnvCmd(cmd))
+	}
+
+	return errors.Join(errs...)
+}
+
+// runProxyEnvCmd runs one environment update command.
+func runProxyEnvCmd(cmd proxyEnvCmd) error {
+	_, err := proxyEnvExec(cmd.name, cmd.args...)
+	return err
+}
+
+// systemdUserEnv reads the environment of the systemd user manager.
+func systemdUserEnv() (map[string]string, error) {
+	out, err := proxyEnvExec("systemctl", "--user", "show-environment")
+	if err != nil {
+		return nil, err
+	}
+
+	env := make(map[string]string)
+	for line := range strings.SplitSeq(out, "\n") {
+		if name, value, ok := strings.Cut(line, "="); ok {
+			env[name] = value
+		}
+	}
+
+	return env, nil
+}

--- a/cmd/easyss/sysproxy_env_linux_test.go
+++ b/cmd/easyss/sysproxy_env_linux_test.go
@@ -1,0 +1,324 @@
+//go:build linux && !headless
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+)
+
+const sysProxyEnvDump = `LANG=en_US.UTF-8
+http_proxy=http://old.example:1234
+NO_PROXY=example.com
+PATH=/usr/bin
+`
+
+type recordedProxyEnvCmd struct {
+	name string
+	args []string
+}
+
+// installProxyEnvExec replaces the command runner for the duration of the test
+// and collects every command that is issued.
+func installProxyEnvExec(t *testing.T, run func(name string, args []string) (string, error)) *[]recordedProxyEnvCmd {
+	t.Helper()
+
+	cmds := &[]recordedProxyEnvCmd{}
+
+	original := proxyEnvExec
+	t.Cleanup(func() { proxyEnvExec = original })
+
+	proxyEnvExec = func(name string, args ...string) (string, error) {
+		*cmds = append(*cmds, recordedProxyEnvCmd{name: name, args: slices.Clone(args)})
+		return run(name, args)
+	}
+
+	return cmds
+}
+
+// stubProxyEnvExec succeeds for every command, serving dump for
+// `systemctl --user show-environment`; fail makes every command fail instead.
+func stubProxyEnvExec(t *testing.T, dump string, fail bool) *[]recordedProxyEnvCmd {
+	t.Helper()
+
+	return installProxyEnvExec(t, func(name string, args []string) (string, error) {
+		if fail {
+			return "", fmt.Errorf("%s: unavailable", name)
+		}
+		if name == "systemctl" && slices.Contains(args, "show-environment") {
+			return dump, nil
+		}
+		return "", nil
+	})
+}
+
+// stubFailingCommand lets only failName fail, so that the fallback to the other
+// environment store can be exercised.
+func stubFailingCommand(t *testing.T, failName string) *[]recordedProxyEnvCmd {
+	t.Helper()
+
+	return installProxyEnvExec(t, func(name string, args []string) (string, error) {
+		if name == "systemctl" && slices.Contains(args, "show-environment") {
+			return sysProxyEnvDump, nil
+		}
+		if name == failName {
+			return "", fmt.Errorf("%s: unavailable", name)
+		}
+		return "", nil
+	})
+}
+
+func resetSysProxyEnvState(t *testing.T) {
+	t.Helper()
+
+	sysProxyEnv.mu.Lock()
+	defer sysProxyEnv.mu.Unlock()
+
+	sysProxyEnv.previous = nil
+	sysProxyEnv.store = proxyEnvStoreNone
+}
+
+func sysProxyAssignments(port int) []string {
+	values := sysProxyEnvValues(port)
+
+	assignments := make([]string, 0, len(sysProxyEnvKeys))
+	for _, key := range sysProxyEnvKeys {
+		assignments = append(assignments, key+"="+values[key])
+	}
+	return assignments
+}
+
+// findProxyEnvCmd returns the arguments of the recorded command whose name
+// matches and whose arguments contain every wanted element.
+func findProxyEnvCmd(cmds []recordedProxyEnvCmd, name string, wanted ...string) []string {
+	for _, cmd := range cmds {
+		if cmd.name != name {
+			continue
+		}
+		hasAll := true
+		for _, want := range wanted {
+			if !slices.Contains(cmd.args, want) {
+				hasAll = false
+				break
+			}
+		}
+		if hasAll {
+			return cmd.args
+		}
+	}
+	return nil
+}
+
+// assertNoDBusSystemdFlag guards the split between the two environment stores:
+// passing --systemd to dbus-update-activation-environment makes it write to the
+// systemd user manager as well, where it would re-create the variables that
+// `systemctl unset-environment` just removed.
+func assertNoDBusSystemdFlag(t *testing.T, cmds []recordedProxyEnvCmd) {
+	t.Helper()
+
+	for _, cmd := range cmds {
+		if cmd.name == "dbus-update-activation-environment" && slices.Contains(cmd.args, "--systemd") {
+			t.Fatalf("dbus-update-activation-environment must not use --systemd, got %v", cmd.args)
+		}
+	}
+}
+
+func TestSysProxyEnvValuesCoverEveryKey(t *testing.T) {
+	values := sysProxyEnvValues(5080)
+
+	if len(values) != len(sysProxyEnvKeys) {
+		t.Fatalf("values cover %d keys, sysProxyEnvKeys lists %d", len(values), len(sysProxyEnvKeys))
+	}
+	for _, key := range sysProxyEnvKeys {
+		if _, ok := values[key]; !ok {
+			t.Fatalf("no value for key %q", key)
+		}
+	}
+
+	const addr = "http://127.0.0.1:5080"
+	for _, key := range []string{"http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"} {
+		if values[key] != addr {
+			t.Fatalf("%s = %q, want %q", key, values[key], addr)
+		}
+	}
+	for _, key := range []string{"no_proxy", "NO_PROXY"} {
+		if values[key] != sysProxyNoProxy {
+			t.Fatalf("%s = %q, want %q", key, values[key], sysProxyNoProxy)
+		}
+	}
+}
+
+func TestSetSysProxyEnvPublishesToSystemdUserManager(t *testing.T) {
+	resetSysProxyEnvState(t)
+	cmds := stubProxyEnvExec(t, sysProxyEnvDump, false)
+
+	applied, err := setSysProxyEnv(5080)
+	if err != nil {
+		t.Fatalf("setSysProxyEnv: %v", err)
+	}
+	if !applied {
+		t.Fatal("setSysProxyEnv reported that nothing was applied")
+	}
+
+	wanted := append([]string{"--user", "set-environment"}, sysProxyAssignments(5080)...)
+	if args := findProxyEnvCmd(*cmds, "systemctl", wanted...); args == nil {
+		t.Fatalf("systemd user manager not updated, commands: %v", *cmds)
+	}
+
+	// One store is enough: publishing to D-Bus as well would duplicate the work
+	// and, with dbus-broker, target the very same environment.
+	if args := findProxyEnvCmd(*cmds, "dbus-update-activation-environment"); args != nil {
+		t.Fatalf("D-Bus activation environment updated although systemd worked: %v", args)
+	}
+}
+
+func TestUnsetSysProxyEnvRestoresPreviousValues(t *testing.T) {
+	resetSysProxyEnvState(t)
+	cmds := stubProxyEnvExec(t, sysProxyEnvDump, false)
+
+	if _, err := setSysProxyEnv(5080); err != nil {
+		t.Fatalf("setSysProxyEnv: %v", err)
+	}
+	*cmds = nil
+
+	applied, err := unsetSysProxyEnv()
+	if err != nil {
+		t.Fatalf("unsetSysProxyEnv: %v", err)
+	}
+	if !applied {
+		t.Fatal("unsetSysProxyEnv reported that nothing was restored")
+	}
+
+	// The variables that existed before easyss started are put back.
+	restored := []string{"http_proxy=http://old.example:1234", "NO_PROXY=example.com"}
+	if args := findProxyEnvCmd(*cmds, "systemctl", append([]string{"--user", "set-environment"}, restored...)...); args == nil {
+		t.Fatalf("previous values not restored, commands: %v", *cmds)
+	}
+
+	// The ones easyss introduced are removed again.
+	unsetArgs := findProxyEnvCmd(*cmds, "systemctl", "--user", "unset-environment")
+	if unsetArgs == nil {
+		t.Fatalf("variables not unset, commands: %v", *cmds)
+	}
+	for _, key := range []string{"https_proxy", "no_proxy", "HTTP_PROXY", "HTTPS_PROXY"} {
+		if !slices.Contains(unsetArgs, key) {
+			t.Fatalf("%s not unset, got %v", key, unsetArgs)
+		}
+	}
+	for _, key := range []string{"http_proxy", "NO_PROXY"} {
+		if slices.Contains(unsetArgs, key) {
+			t.Fatalf("%s was unset even though it existed before, got %v", key, unsetArgs)
+		}
+	}
+
+	if args := findProxyEnvCmd(*cmds, "dbus-update-activation-environment"); args != nil {
+		t.Fatalf("D-Bus activation environment touched although systemd was used: %v", args)
+	}
+	assertNoDBusSystemdFlag(t, *cmds)
+}
+
+func TestSetSysProxyEnvFallsBackToDBus(t *testing.T) {
+	resetSysProxyEnvState(t)
+	cmds := stubFailingCommand(t, "systemctl")
+
+	applied, err := setSysProxyEnv(5080)
+	if err != nil {
+		t.Fatalf("setSysProxyEnv: %v", err)
+	}
+	if !applied {
+		t.Fatal("setSysProxyEnv did not fall back to the D-Bus activation environment")
+	}
+
+	if args := findProxyEnvCmd(*cmds, "dbus-update-activation-environment", sysProxyAssignments(5080)...); args == nil {
+		t.Fatalf("D-Bus activation environment not updated, commands: %v", *cmds)
+	}
+	assertNoDBusSystemdFlag(t, *cmds)
+
+	*cmds = nil
+
+	if _, err := unsetSysProxyEnv(); err != nil {
+		t.Fatalf("unsetSysProxyEnv: %v", err)
+	}
+
+	// dbus-daemon cannot remove a variable, so the pre-existing value is put
+	// back and the ones easyss added are emptied instead.
+	wanted := []string{"http_proxy=http://old.example:1234", "https_proxy=", "NO_PROXY=example.com"}
+	if args := findProxyEnvCmd(*cmds, "dbus-update-activation-environment", wanted...); args == nil {
+		t.Fatalf("D-Bus activation environment not restored, commands: %v", *cmds)
+	}
+	if args := findProxyEnvCmd(*cmds, "systemctl", "--user", "unset-environment"); args != nil {
+		t.Fatalf("systemd was updated although the D-Bus store was used: %v", args)
+	}
+}
+
+func TestUnsetSysProxyEnvWithoutApplyIsNoop(t *testing.T) {
+	resetSysProxyEnvState(t)
+	cmds := stubProxyEnvExec(t, sysProxyEnvDump, false)
+
+	applied, err := unsetSysProxyEnv()
+	if err != nil {
+		t.Fatalf("unsetSysProxyEnv: %v", err)
+	}
+	if applied {
+		t.Fatal("unsetSysProxyEnv claimed to restore something without a preceding set")
+	}
+	if len(*cmds) != 0 {
+		t.Fatalf("unexpected commands: %v", *cmds)
+	}
+}
+
+func TestSetSysProxyEnvReportsFailureWhenNoStoreIsReachable(t *testing.T) {
+	resetSysProxyEnvState(t)
+	stubProxyEnvExec(t, sysProxyEnvDump, true)
+
+	applied, err := setSysProxyEnv(5080)
+	if applied {
+		t.Fatal("setSysProxyEnv reported success although every command failed")
+	}
+	if err == nil {
+		t.Fatal("expected an error when no environment store could be updated")
+	}
+
+	// A failed set must not make a later unset believe it has something to do.
+	unsetApplied, unsetErr := unsetSysProxyEnv()
+	if unsetApplied || unsetErr != nil {
+		t.Fatalf("unsetSysProxyEnv = (%v, %v), want (false, nil)", unsetApplied, unsetErr)
+	}
+}
+
+func TestUnsetSysProxyEnvKeepsStateWhenRestoreFails(t *testing.T) {
+	resetSysProxyEnvState(t)
+
+	failSystemd := false
+	installProxyEnvExec(t, func(name string, args []string) (string, error) {
+		if name == "systemctl" && slices.Contains(args, "show-environment") {
+			return sysProxyEnvDump, nil
+		}
+		if name == "systemctl" && failSystemd {
+			return "", errors.New("systemd gone")
+		}
+		return "", nil
+	})
+
+	if _, err := setSysProxyEnv(5080); err != nil {
+		t.Fatalf("setSysProxyEnv: %v", err)
+	}
+
+	failSystemd = true
+	if applied, err := unsetSysProxyEnv(); applied || err == nil {
+		t.Fatalf("unsetSysProxyEnv = (%v, %v), want a failure", applied, err)
+	}
+
+	// The snapshot survives the failure, so a retry -- the tray reverts its
+	// checkmark and lets the user click again -- can still restore the values.
+	failSystemd = false
+	applied, err := unsetSysProxyEnv()
+	if err != nil {
+		t.Fatalf("retry of unsetSysProxyEnv: %v", err)
+	}
+	if !applied {
+		t.Fatal("retry of unsetSysProxyEnv restored nothing")
+	}
+}

--- a/cmd/easyss/sysproxy_env_other.go
+++ b/cmd/easyss/sysproxy_env_other.go
@@ -1,0 +1,14 @@
+//go:build !linux && !headless
+
+package main
+
+// setSysProxyEnv is a no-op outside Linux: macOS and Windows have a real
+// system-wide proxy configuration, which the sysproxy package already updates
+// and which the browsers there actually honour.
+func setSysProxyEnv(_ int) (bool, error) {
+	return false, nil
+}
+
+func unsetSysProxyEnv() (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
## 背景

Linux 上 easyss 通过 `wzshiming/sysproxy` 设置"系统代理"，而该库在 Linux 上只写 GNOME 的
`org.gnome.system.proxy` gsettings。Chromium 只在自己识别为 GNOME 系（GNOME/Unity/Cinnamon/
Deepin/Pantheon/UKUI/Cosmic）或 KDE 系桌面时才去读系统设置，其它桌面（Hyprland、sway…）会完全
跳过系统设置、只认 `http_proxy`/`https_proxy` 环境变量。这些变量此前没有任何人设置，于是在
Hyprland 上浏览器始终直连：网页打不开，easyss 侧一个请求都收不到，而日志却照常打印
`[SYSPROXY] proxy enabled` —— 一个完全静默的失败。

## 改动

除桌面设置外，同时把代理发布到会话环境：

- 新增 `cmd/easyss/sysproxy_env_linux.go`：写入 6 个变量（`http_proxy`/`https_proxy`/`no_proxy`
  及大写变体）到 systemd user manager，并在退出时**还原原有值**而不是一律清空。
  `no_proxy=localhost,127.0.0.1,::1` 避免访问本地端口时绕回 easyss 自身形成自环。
- 只使用**一个** store，优先 systemd user manager，因为它能真正删除变量。两个都写是错的：
  在 dbus-broker 会话上激活环境**就是** systemd user manager 环境，
  `dbus-update-activation-environment` 会把 `systemctl unset-environment` 刚删掉的变量以空值
  重新灌回，留下残留。
- systemd user manager 不可用时退回 D-Bus 激活环境；`dbus-daemon` 无法删除变量，因此那里只能
  把 easyss 新增的变量置空（Chromium、curl 等把空值等同于未设置）。
- 错误处理保持尽力而为：两个机制任一成功即视为成功，保证退出路径一定会撤销已生效的部分；
  单个 store 失败只记日志，且快照在还原失败时保留，使重试仍能恢复原值。
- macOS / Windows 行为不变：stub 返回"未应用"，`networksetup` / 注册表写入失败仍照旧报错。

## 验证

- 新增 7 个单测，覆盖发布、还原、D-Bus 回退、失败重试、key 集合一致性
- `make lint` 0 issues；`go test ./...` 22 个包全部通过
- Linux / headless / darwin-arm64 / windows-amd64 四种构建均通过
- 真机（Omarchy + Hyprland）：
  - 经 `systemd-run` 启动的 chromium 解析出 `PROXY 127.0.0.1:5080` 并成功打开 google.com
  - easyss 退出后 systemd user 环境完全干净，无空值残留
  - 启动前预设的 `http_proxy` 被正确还原，无关变量不受影响

## 已知限制

对于「登录时快照了环境、之后长期运行」的启动器所派生的应用（例如 Omarchy shell 通过
`uwsm-app` 启动的浏览器），设置环境变量无法触达 —— 应用继承的是启动器登录时的环境快照。
这类场景仍需浏览器侧机制（Chromium flags / 托管策略）或 TUN 全局代理。

本 PR 解决的是由 systemd 直接启动的进程（`systemd-run`、user 服务、`xdg-open` 等）拿不到
代理的问题，并让"浏览器(设置系统代理)"在 GNOME/KDE 之外的桌面上至少不再是静默失败。