### PR TITLE
fix: open the tray log viewer on wayland sessions

### DIFF
--- a/cmd/easyss/root_linux.go
+++ b/cmd/easyss/root_linux.go
@@ -37,9 +37,11 @@ func RunMeElevated(extraArgs ...string) error {
 		fmt.Fprintf(&argsBuilder, "'%s' ", strings.ReplaceAll(arg, "'", "'\\''"))
 	}
 
-	// Capture necessary environment variables for GUI
+	// Capture necessary environment variables for GUI. XDG_RUNTIME_DIR carries
+	// the Wayland socket path and TERMINAL the user's terminal preference —
+	// both are required by the elevated tray to open the log viewer.
 	envMap := make(map[string]string)
-	envVars := []string{"DISPLAY", "XAUTHORITY", "WAYLAND_DISPLAY", "HOME", "DBUS_SESSION_BUS_ADDRESS"}
+	envVars := []string{"DISPLAY", "XAUTHORITY", "WAYLAND_DISPLAY", "XDG_RUNTIME_DIR", "TERMINAL", "HOME", "DBUS_SESSION_BUS_ADDRESS"}
 
 	for _, key := range envVars {
 		if val := os.Getenv(key); val != "" {

--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/user"
 	"runtime"
 	"strings"
 	"sync"
@@ -26,7 +25,6 @@ import (
 	"github.com/nange/easyss/v3/log"
 	"github.com/nange/easyss/v3/protocol"
 	"github.com/nange/easyss/v3/selfupdate"
-	"github.com/nange/easyss/v3/util"
 )
 
 type TrayApp struct {
@@ -215,6 +213,24 @@ func friendlyStartupError(err error) string {
 // 转换为用户友好的中文提示。
 func friendlyStartupWarning(err error) string {
 	return "启动警告：" + err.Error()
+}
+
+// friendlyCatLogError 将「查看日志」失败转换为用户友好的中文提示。
+func friendlyCatLogError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, errLogFileNotConfigured):
+		return "日志文件未配置：请在 config.json 中设置 log.file_path，日志才会写入文件。"
+	case errors.Is(err, errNoTerminalEmulator):
+		return "未找到可用的终端模拟器：请安装 xdg-terminal-exec、alacritty、foot 等终端，或设置 $TERMINAL 环境变量。"
+	case errors.Is(err, fs.ErrNotExist):
+		return "日志文件不存在：" + err.Error()
+	case errors.Is(err, fs.ErrPermission):
+		return "没有权限读取日志文件：" + err.Error()
+	default:
+		return "打开日志失败：" + err.Error()
+	}
 }
 
 // isAddrInUse 判断错误是否为"端口已被占用"的绑定失败（Unix 走 errno，
@@ -477,18 +493,18 @@ func (a *TrayApp) changeLogLevel(level string) {
 	}
 }
 
+// catLogs opens the log file from the tray menu (see tray_log.go). Failures
+// used to be written to the log file only, which left the menu entry looking
+// dead, so every one of them is surfaced as a notification too.
 func (a *TrayApp) catLogs() {
-	if err := a.catLog(); err != nil {
+	fallback, err := openLogFile(a.cfg.Log.FilePath)
+	switch {
+	case err != nil:
 		log.Error("[SYSTRAY] cat log", "err", err)
+		a.tray.ShowNotification("Easyss", friendlyCatLogError(err))
+	case fallback:
+		a.tray.ShowNotification("Easyss", "未找到终端模拟器，已在默认程序中打开日志快照（最近 500 行）")
 	}
-}
-
-func (a *TrayApp) catLog() error {
-	filePath := a.cfg.Log.FilePath
-	if filePath == "" {
-		return fmt.Errorf("log file path is empty, please configure log.file_path in config.json")
-	}
-	return catLogFile(filePath)
 }
 
 func (a *TrayApp) toggleAutoStart() {
@@ -697,68 +713,6 @@ func (a *TrayApp) startLocalService() {
 		if a.TunMenu() != nil {
 			a.TunMenu().SetChecked(true)
 		}
-	}
-}
-
-func catLogFile(filePath string) error {
-	var linuxCmd []string
-
-	switch runtime.GOOS {
-	case "linux":
-		title := "View Easyss Logs"
-		switch {
-		case util.SysSupportXTerminalEmulator():
-			linuxCmd = []string{"x-terminal-emulator", "-e", "tail", "-50f", filePath}
-		case util.SysSupportGnomeTerminal():
-			linuxCmd = []string{"gnome-terminal", "--hide-menubar", "--title", title, "--", "tail", "-50f", filePath}
-		case util.SysSupportMateTerminal():
-			linuxCmd = []string{"mate-terminal", "--hide-menubar", "--title", title, "--", "tail", "-50f", filePath}
-		case util.SysSupportKonsole():
-			linuxCmd = []string{"konsole", "--hide-menubar", "-e", "tail", "-50f", filePath}
-		case util.SysSupportXfce4Terminal():
-			linuxCmd = []string{"xfce4-terminal", "--hide-menubar", "--hide-toolbar", "--title", title, "--command", fmt.Sprintf("tail -50f %s", filePath)}
-		case util.SysSupportLxterminal():
-			linuxCmd = []string{"lxterminal", "--title", title, "--command", fmt.Sprintf("tail -50f %s", filePath)}
-		case util.SysSupportTerminator():
-			linuxCmd = []string{"terminator", "--title", title, "--command", fmt.Sprintf("tail -50f %s", filePath)}
-		}
-
-		if len(linuxCmd) > 0 && IsRoot() {
-			username := ""
-			if uid := os.Getenv("PKEXEC_UID"); uid != "" {
-				if u, err := user.LookupId(uid); err == nil {
-					username = u.Username
-				}
-			}
-			if username == "" {
-				if u := os.Getenv("SUDO_USER"); u != "" {
-					username = u
-				}
-			}
-			if username != "" {
-				newCmd := []string{"runuser", "-u", username, "--"}
-				if dbusAddr := os.Getenv("DBUS_SESSION_BUS_ADDRESS"); dbusAddr != "" {
-					newCmd = append(newCmd, "env", fmt.Sprintf("DBUS_SESSION_BUS_ADDRESS=%s", dbusAddr))
-				}
-				newCmd = append(newCmd, linuxCmd...)
-				linuxCmd = newCmd
-				log.Info("[SYSTRAY] cat log: switching to user", "user", username, "cmd", linuxCmd)
-			}
-		}
-		if len(linuxCmd) == 0 {
-			return fmt.Errorf("no supported terminal emulator found")
-		}
-		_, err := util.Command(linuxCmd[0], linuxCmd[1:]...)
-		return err
-	case "windows":
-		_, err := util.Command("cmd", "/c", "start", "powershell", "-NoExit", "-Command",
-			fmt.Sprintf("Get-Content -Wait -Tail 100 '%s'", filePath))
-		return err
-	case "darwin":
-		_, err := util.Command("osascript", "-e", fmt.Sprintf(`tell application "Terminal" to do script "tail -f \"%s\""`, filePath), "-e", `tell application "Terminal" to activate`)
-		return err
-	default:
-		return fmt.Errorf("unsupported os: %s", runtime.GOOS)
 	}
 }
 

--- a/cmd/easyss/tray_log.go
+++ b/cmd/easyss/tray_log.go
@@ -1,0 +1,440 @@
+//go:build !headless
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nange/easyss/v3/log"
+	"github.com/nange/easyss/v3/util"
+)
+
+const (
+	// logTailLines is the number of trailing lines shown by the terminal.
+	logTailLines = 50
+
+	// logSnapshotLines bounds the snapshot written for the last-resort
+	// fallback, so that a huge log file never reaches a GUI editor whole.
+	logSnapshotLines = 500
+
+	// logSnapshotTimeout bounds the tail command used for the snapshot.
+	logSnapshotTimeout = 5 * time.Second
+)
+
+// Sentinel errors of the "view log" flow. They let the tray turn a technical
+// failure into a user-facing Chinese message (see friendlyCatLogError).
+var (
+	errLogFileNotConfigured = errors.New("log file path is empty, configure log.file_path in config.json")
+	errNoTerminalEmulator   = errors.New("no supported terminal emulator found")
+)
+
+// termCmdStyle describes how a terminal emulator is told which command to run.
+type termCmdStyle int
+
+const (
+	// termStyleArgs appends the command as separate arguments,
+	// e.g. `alacritty -e tail -n 50 -f /path/to/easyss.log`.
+	termStyleArgs termCmdStyle = iota
+	// termStyleString appends the command as one shell string,
+	// e.g. `xfce4-terminal --command "tail -n 50 -f '/path/to/easyss.log'"`.
+	termStyleString
+)
+
+// termLauncher is one entry of the terminal emulator table.
+type termLauncher struct {
+	bin   string
+	args  []string
+	style termCmdStyle
+}
+
+// termLaunchers is the ordered terminal emulator preference list, used when
+// $TERMINAL does not name a usable terminal. The order puts the XDG default
+// terminal launcher and the Wayland-native terminals first: on a modern
+// Wayland session (Hyprland, sway, ...) none of the X11 era terminals below
+// them is installed.
+var termLaunchers = []termLauncher{
+	// Default Terminal Execution Specification (Arch, Omarchy, ...).
+	{"xdg-terminal-exec", []string{"--"}, termStyleArgs},
+	{"foot", []string{"-e"}, termStyleArgs},
+	{"alacritty", []string{"-e"}, termStyleArgs},
+	// kitty takes the program to run without a separating flag.
+	{"kitty", nil, termStyleArgs},
+	{"ghostty", []string{"-e"}, termStyleArgs},
+	{"wezterm", []string{"start", "--"}, termStyleArgs},
+	{"x-terminal-emulator", []string{"-e"}, termStyleArgs},
+	{"gnome-terminal", []string{"--"}, termStyleArgs},
+	{"mate-terminal", []string{"--"}, termStyleArgs},
+	{"konsole", []string{"-e"}, termStyleArgs},
+	{"xfce4-terminal", []string{"--command"}, termStyleString},
+	{"lxterminal", []string{"--command"}, termStyleString},
+	{"terminator", []string{"--command"}, termStyleString},
+	{"tilix", []string{"-e"}, termStyleArgs},
+	{"qterminal", []string{"-e"}, termStyleArgs},
+	{"xterm", []string{"-e"}, termStyleArgs},
+	{"urxvt", []string{"-e"}, termStyleArgs},
+	{"st", []string{"-e"}, termStyleArgs},
+}
+
+// lookPath is exec.LookPath, kept in a variable so that tests can resolve the
+// table against a simulated set of installed terminals.
+var lookPath = exec.LookPath
+
+// openWithDefaultApp opens a file in the desktop's default application. It is
+// a variable so that tests can exercise the fallback without spawning a GUI
+// window.
+var openWithDefaultApp = func(path string) error {
+	argv := sessionLaunch([]string{"xdg-open", path})
+
+	return startDetached(argv)
+}
+
+// openLogFile opens the log file for the user: in a terminal emulator tailing
+// it, or — when no terminal emulator is available — as a snapshot in the
+// desktop's default application.
+//
+// fallback reports that the snapshot path was taken, so the caller can tell
+// the user why the log is not live.
+func openLogFile(filePath string) (fallback bool, err error) {
+	if strings.TrimSpace(filePath) == "" {
+		return false, errLogFileNotConfigured
+	}
+
+	// A log file that does not exist yet would only make the terminal flash
+	// and close again, so it is reported instead.
+	if _, statErr := os.Stat(filePath); statErr != nil {
+		return false, fmt.Errorf("log file %s: %w", filePath, statErr)
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return openLogFileLinux(filePath)
+	case "windows":
+		argv := []string{"cmd", "/c", "start", "powershell", "-NoExit", "-Command",
+			fmt.Sprintf("Get-Content -Wait -Tail 100 '%s'", filePath)}
+		return false, startDetached(argv)
+	case "darwin":
+		argv := []string{"osascript",
+			"-e", fmt.Sprintf(`tell application "Terminal" to do script "tail -f \"%s\""`, filePath),
+			"-e", `tell application "Terminal" to activate`}
+		return false, startDetached(argv)
+	default:
+		return false, fmt.Errorf("unsupported os: %s", runtime.GOOS)
+	}
+}
+
+// openLogFileLinux tails the log in a terminal emulator. When no terminal
+// emulator can be found it falls back to the snapshot viewer, so that the
+// menu entry still shows something on a minimal desktop.
+func openLogFileLinux(filePath string) (fallback bool, err error) {
+	argv, resolveErr := logViewerArgv(filePath)
+	if resolveErr == nil {
+		argv = sessionLaunch(argv)
+		startErr := startDetached(argv)
+		if startErr == nil {
+			log.Info("[SYSTRAY] log opened", "cmd", argv)
+			return false, nil
+		}
+		resolveErr = startErr
+	}
+	log.Warn("[SYSTRAY] cannot open the log in a terminal", "err", resolveErr)
+
+	if snapshotErr := openLogSnapshot(filePath); snapshotErr != nil {
+		return false, errors.Join(resolveErr, snapshotErr)
+	}
+
+	return true, nil
+}
+
+// logViewerArgv returns the command that tails filePath in a terminal
+// emulator: $TERMINAL when it is usable, otherwise the first installed entry
+// of termLaunchers.
+func logViewerArgv(filePath string) ([]string, error) {
+	viewer := []string{"tail", "-n", strconv.Itoa(logTailLines), "-f", filePath}
+
+	if argv, ok := terminalFromEnv(viewer); ok {
+		return argv, nil
+	}
+
+	checked := make([]string, 0, len(termLaunchers))
+	for _, l := range termLaunchers {
+		checked = append(checked, l.bin)
+		bin, err := lookPath(l.bin)
+		if err != nil {
+			continue
+		}
+		return launcherArgv(bin, l, viewer), nil
+	}
+
+	return nil, fmt.Errorf("%w (tried $TERMINAL and %s)", errNoTerminalEmulator, strings.Join(checked, ", "))
+}
+
+// terminalFromEnv resolves the terminal named by $TERMINAL. A known terminal
+// keeps the argument style of its table entry (extra words after the binary
+// name are dropped, as they would land after the command separator); an
+// unknown one is passed the command with the xterm style -e convention.
+func terminalFromEnv(viewer []string) ([]string, bool) {
+	term := strings.TrimSpace(os.Getenv("TERMINAL"))
+	if term == "" {
+		return nil, false
+	}
+
+	fields := strings.Fields(term)
+	base := filepath.Base(fields[0])
+
+	known := false
+	for _, l := range termLaunchers {
+		if l.bin != base {
+			continue
+		}
+		known = true
+		if bin, err := lookPath(fields[0]); err == nil {
+			return launcherArgv(bin, l, viewer), true
+		}
+		break
+	}
+
+	if !known {
+		if bin, err := lookPath(fields[0]); err == nil {
+			generic := termLauncher{args: []string{"-e"}, style: termStyleArgs}
+			return launcherArgv(bin, generic, viewer), true
+		}
+	}
+
+	log.Warn("[SYSTRAY] $TERMINAL is not usable, falling back to the built-in terminal list", "terminal", term)
+	return nil, false
+}
+
+// launcherArgv builds the full argv for one terminal emulator.
+func launcherArgv(bin string, l termLauncher, viewer []string) []string {
+	argv := make([]string, 0, 1+len(l.args)+len(viewer))
+	argv = append(argv, bin)
+	argv = append(argv, l.args...)
+	if l.style == termStyleString {
+		return append(argv, shellJoin(viewer))
+	}
+
+	return append(argv, viewer...)
+}
+
+// shellJoin quotes every argument so that the result can be handed to a
+// terminal emulator that expects one shell command string.
+func shellJoin(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+
+	return strings.Join(quoted, " ")
+}
+
+// shellQuote quotes a single argument for the shell. Arguments without any
+// character the shell treats specially are left untouched.
+func shellQuote(s string) string {
+	const specials = " \t\n\"'\\$`&|;<>()*?[]{}~#!"
+
+	if s != "" && !strings.ContainsAny(s, specials) {
+		return s
+	}
+
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// startDetached starts a command and returns as soon as it has been spawned:
+// an interactive terminal stays in the foreground for as long as the user
+// keeps the window open, so waiting for it — as util.Command does — would
+// block the caller for the whole session. The process is reaped in the
+// background to avoid leaving a zombie behind.
+func startDetached(argv []string) error {
+	if len(argv) == 0 {
+		return errors.New("empty command")
+	}
+
+	cmd := exec.Command(argv[0], argv[1:]...)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		_ = cmd.Wait()
+	}()
+
+	return nil
+}
+
+// sessionLaunch hands the command to the desktop user when easyss runs as
+// root (pkexec/sudo elevation, e.g. with TUN enabled), together with the
+// session environment the elevation dropped. Without XDG_RUNTIME_DIR a
+// Wayland terminal cannot reach the compositor at all. The command is
+// returned unchanged when the user cannot be determined.
+func sessionLaunch(argv []string) []string {
+	if runtime.GOOS != "linux" || !IsRoot() {
+		return argv
+	}
+
+	username, uid, ok := sessionUser()
+	if !ok {
+		log.Warn("[SYSTRAY] cannot determine the desktop user, launching as root")
+		return argv
+	}
+
+	launch := []string{"runuser", "-u", username, "--", "env"}
+	launch = append(launch, sessionEnv(username, uid)...)
+
+	return append(launch, argv...)
+}
+
+// sessionUser returns the desktop user that invoked the elevated easyss:
+// pkexec exports PKEXEC_UID, sudo exports SUDO_UID/SUDO_USER.
+func sessionUser() (username string, uid int, ok bool) {
+	candidates := []struct{ uid, name string }{
+		{os.Getenv("PKEXEC_UID"), ""},
+		{os.Getenv("SUDO_UID"), os.Getenv("SUDO_USER")},
+	}
+
+	for _, candidate := range candidates {
+		if candidate.uid == "" {
+			continue
+		}
+		id, err := strconv.Atoi(candidate.uid)
+		if err != nil {
+			continue
+		}
+		name := candidate.name
+		if u, err := user.LookupId(candidate.uid); err == nil {
+			name = u.Username
+		}
+		if name != "" {
+			return name, id, true
+		}
+	}
+
+	if name := os.Getenv("SUDO_USER"); name != "" {
+		if u, err := user.Lookup(name); err == nil {
+			if id, err := strconv.Atoi(u.Uid); err == nil {
+				return u.Username, id, true
+			}
+		}
+	}
+
+	return "", 0, false
+}
+
+// sessionEnv builds the KEY=VALUE assignments of the desktop session, using
+// the standard locations under /run/user/<uid> for anything the elevated
+// process did not inherit.
+func sessionEnv(username string, uid int) []string {
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir == "" {
+		runtimeDir = fmt.Sprintf("/run/user/%d", uid)
+	}
+
+	home := ""
+	if u, err := user.Lookup(username); err == nil {
+		home = u.HomeDir
+	}
+	if home == "" {
+		home = os.Getenv("HOME")
+	}
+
+	env := []string{"XDG_RUNTIME_DIR=" + runtimeDir}
+	if home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	waylandDisplay := os.Getenv("WAYLAND_DISPLAY")
+	if waylandDisplay == "" {
+		waylandDisplay = firstWaylandDisplay(runtimeDir)
+	}
+	if waylandDisplay != "" {
+		env = append(env, "WAYLAND_DISPLAY="+waylandDisplay)
+	}
+
+	dbusAddr := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
+	if dbusAddr == "" {
+		busPath := filepath.Join(runtimeDir, "bus")
+		if _, err := os.Stat(busPath); err == nil {
+			dbusAddr = "unix:path=" + busPath
+		}
+	}
+	if dbusAddr != "" {
+		env = append(env, "DBUS_SESSION_BUS_ADDRESS="+dbusAddr)
+	}
+
+	if xauthority := os.Getenv("XAUTHORITY"); xauthority != "" {
+		env = append(env, "XAUTHORITY="+xauthority)
+	} else if home != "" {
+		xauthority = filepath.Join(home, ".Xauthority")
+		if _, err := os.Stat(xauthority); err == nil {
+			env = append(env, "XAUTHORITY="+xauthority)
+		}
+	}
+
+	for _, key := range []string{"DISPLAY", "TERMINAL", "XDG_CURRENT_DESKTOP", "HYPRLAND_INSTANCE_SIGNATURE"} {
+		if value := os.Getenv(key); value != "" {
+			env = append(env, key+"="+value)
+		}
+	}
+
+	return env
+}
+
+// firstWaylandDisplay returns the name of the first Wayland socket in the
+// runtime directory, i.e. the WAYLAND_DISPLAY value a session would use.
+func firstWaylandDisplay(runtimeDir string) string {
+	matches, err := filepath.Glob(filepath.Join(runtimeDir, "wayland-*"))
+	if err != nil {
+		return ""
+	}
+
+	for _, match := range matches {
+		if info, err := os.Stat(match); err == nil && info.Mode()&os.ModeSocket != 0 {
+			return filepath.Base(match)
+		}
+	}
+
+	return ""
+}
+
+// openLogSnapshot writes the last logSnapshotLines lines of the log to a
+// temporary file and opens it in the desktop's default application. It is the
+// last resort when no terminal emulator is available.
+func openLogSnapshot(filePath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), logSnapshotTimeout)
+	defer cancel()
+
+	content, err := util.CommandContext(ctx, "tail", "-n", strconv.Itoa(logSnapshotLines), filePath)
+	if err != nil {
+		return fmt.Errorf("read log tail: %w", err)
+	}
+
+	f, err := os.CreateTemp("", "easyss-log-*.log")
+	if err != nil {
+		return fmt.Errorf("create log snapshot: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, content); err != nil {
+		return fmt.Errorf("write log snapshot: %w", err)
+	}
+	// The tray may run as root, while the application opening the snapshot
+	// runs as the desktop user.
+	if err := os.Chmod(f.Name(), 0o644); err != nil {
+		return fmt.Errorf("chmod log snapshot: %w", err)
+	}
+
+	if err := openWithDefaultApp(f.Name()); err != nil {
+		return fmt.Errorf("open %s: %w", f.Name(), err)
+	}
+	log.Info("[SYSTRAY] log snapshot opened", "file", f.Name())
+
+	return nil
+}

--- a/cmd/easyss/tray_log_test.go
+++ b/cmd/easyss/tray_log_test.go
@@ -1,0 +1,416 @@
+//go:build !headless
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// fakeBin is the executable path fakeLookPath reports, and the one every
+// expectation below is written with. It stays POSIX style on every platform:
+// the terminal table it feeds is used on linux only.
+func fakeBin(name string) string {
+	return "/usr/bin/" + name
+}
+
+// binName strips the directory from a path, treating the POSIX and the
+// Windows separator alike so that the fake below behaves the same everywhere.
+func binName(path string) string {
+	return path[strings.LastIndexAny(path, `/\`)+1:]
+}
+
+// fakeLookPath simulates a PATH holding exactly the given executables.
+func fakeLookPath(installed ...string) func(string) (string, error) {
+	available := make(map[string]bool, len(installed))
+	for _, bin := range installed {
+		available[binName(bin)] = true
+	}
+
+	return func(name string) (string, error) {
+		if available[binName(name)] {
+			return fakeBin(binName(name)), nil
+		}
+		return "", exec.ErrNotFound
+	}
+}
+
+func TestBinName(t *testing.T) {
+	// The fakes have to resolve the same executable on every platform, which
+	// is why the separator handling is asserted here instead of relying on
+	// filepath, whose Windows build also accepts backslashes.
+	cases := map[string]string{
+		"foot":                      "foot",
+		"/usr/bin/foot":             "foot",
+		`\usr\bin\foot`:             "foot",
+		`C:\Program Files\foot.exe`: "foot.exe",
+		"":                          "",
+	}
+
+	for in, want := range cases {
+		if got := binName(in); got != want {
+			t.Fatalf("binName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func withLookPath(t *testing.T, lookup func(string) (string, error)) {
+	t.Helper()
+
+	previous := lookPath
+	lookPath = lookup
+	t.Cleanup(func() { lookPath = previous })
+}
+
+func TestLogViewerArgv(t *testing.T) {
+	const logPath = "/home/nange/Easyss/easyss.log"
+	tailArgv := []string{"tail", "-n", "50", "-f", logPath}
+
+	cases := []struct {
+		name      string
+		terminal  string
+		installed []string
+		want      []string
+	}{
+		{
+			name:      "omarchy: TERMINAL points at the xdg launcher",
+			terminal:  "xdg-terminal-exec",
+			installed: []string{"xdg-terminal-exec", "alacritty"},
+			want:      append([]string{fakeBin("xdg-terminal-exec"), "--"}, tailArgv...),
+		},
+		{
+			// The XDG launcher is preferred over the Wayland terminals below
+			// it: it is what the session itself would use.
+			name:      "xdg launcher wins without TERMINAL",
+			installed: []string{"xdg-terminal-exec", "alacritty", "foot"},
+			want:      append([]string{fakeBin("xdg-terminal-exec"), "--"}, tailArgv...),
+		},
+		{
+			name:      "TERMINAL=foot",
+			terminal:  "foot",
+			installed: []string{"foot", "alacritty"},
+			want:      append([]string{fakeBin("foot"), "-e"}, tailArgv...),
+		},
+		{
+			name:      "TERMINAL given as an absolute path",
+			terminal:  fakeBin("foot"),
+			installed: []string{"foot"},
+			want:      append([]string{fakeBin("foot"), "-e"}, tailArgv...),
+		},
+		{
+			name:      "unknown TERMINAL falls back to the xterm -e convention",
+			terminal:  "myterm",
+			installed: []string{"myterm"},
+			want:      append([]string{fakeBin("myterm"), "-e"}, tailArgv...),
+		},
+		{
+			name:      "known TERMINAL that is not installed falls back to the table",
+			terminal:  "kitty",
+			installed: []string{"alacritty"},
+			want:      append([]string{fakeBin("alacritty"), "-e"}, tailArgv...),
+		},
+		{
+			name:      "unknown TERMINAL that is not installed falls back to the table",
+			terminal:  "ghostty-ng",
+			installed: []string{"foot"},
+			want:      append([]string{fakeBin("foot"), "-e"}, tailArgv...),
+		},
+		{
+			name:      "wayland terminals come before the x11 ones",
+			installed: []string{"alacritty", "gnome-terminal"},
+			want:      append([]string{fakeBin("alacritty"), "-e"}, tailArgv...),
+		},
+		{
+			name:      "gnome-terminal keeps its -- separator",
+			installed: []string{"gnome-terminal"},
+			want:      append([]string{fakeBin("gnome-terminal"), "--"}, tailArgv...),
+		},
+		{
+			name:      "kitty takes the command without a separator",
+			installed: []string{"kitty"},
+			want:      append([]string{fakeBin("kitty")}, tailArgv...),
+		},
+		{
+			name:      "wezterm",
+			installed: []string{"wezterm"},
+			want:      append([]string{fakeBin("wezterm"), "start", "--"}, tailArgv...),
+		},
+		{
+			// Terminals that only take one shell string get the command
+			// joined and quoted.
+			name:      "xfce4-terminal takes a shell string",
+			installed: []string{"xfce4-terminal"},
+			want:      []string{fakeBin("xfce4-terminal"), "--command", "tail -n 50 -f " + logPath},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("TERMINAL", c.terminal)
+			withLookPath(t, fakeLookPath(c.installed...))
+
+			got, err := logViewerArgv(logPath)
+			if err != nil {
+				t.Fatalf("logViewerArgv returned an error: %v", err)
+			}
+			if !slices.Equal(got, c.want) {
+				t.Fatalf("unexpected argv:\n got: %q\nwant: %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestLogViewerArgvQuotesPathsInShellStrings(t *testing.T) {
+	t.Setenv("TERMINAL", "")
+	withLookPath(t, fakeLookPath("xfce4-terminal"))
+
+	const logPath = "/home/nange/Easyss dir/it's.log"
+	got, err := logViewerArgv(logPath)
+	if err != nil {
+		t.Fatalf("logViewerArgv returned an error: %v", err)
+	}
+
+	want := []string{fakeBin("xfce4-terminal"), "--command", `tail -n 50 -f '/home/nange/Easyss dir/it'\''s.log'`}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected argv:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestLogViewerArgvWithoutTerminal(t *testing.T) {
+	t.Setenv("TERMINAL", "")
+	withLookPath(t, fakeLookPath())
+
+	_, err := logViewerArgv("/tmp/easyss.log")
+	if !errors.Is(err, errNoTerminalEmulator) {
+		t.Fatalf("expected errNoTerminalEmulator, got %v", err)
+	}
+	// The message has to name what was probed: the previous version only
+	// reported "no supported terminal emulator found", which gave no hint
+	// about why the log viewer refused to open.
+	for _, bin := range []string{"xdg-terminal-exec", "alacritty", "foot", "gnome-terminal"} {
+		if !strings.Contains(err.Error(), bin) {
+			t.Fatalf("error %q should list the probed terminal %q", err, bin)
+		}
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"/home/nange/Easyss/easyss.log", "/home/nange/Easyss/easyss.log"},
+		{"", "''"},
+		{"/tmp/a b.log", "'/tmp/a b.log'"},
+		{"/tmp/it's.log", `'/tmp/it'\''s.log'`},
+		{"/tmp/$HOME.log", "'/tmp/$HOME.log'"},
+		{"/tmp/back\\slash.log", "'/tmp/back\\slash.log'"},
+	}
+
+	for _, c := range cases {
+		if got := shellQuote(c.in); got != c.want {
+			t.Fatalf("shellQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestShellJoin(t *testing.T) {
+	got := shellJoin([]string{"tail", "-n", "50", "-f", "/tmp/a b.log"})
+	if want := "tail -n 50 -f '/tmp/a b.log'"; got != want {
+		t.Fatalf("shellJoin = %q, want %q", got, want)
+	}
+}
+
+func TestOpenLogFileErrors(t *testing.T) {
+	for _, filePath := range []string{"", "   "} {
+		if _, err := openLogFile(filePath); !errors.Is(err, errLogFileNotConfigured) {
+			t.Fatalf("expected errLogFileNotConfigured for %q, got %v", filePath, err)
+		}
+	}
+
+	missing := filepath.Join(t.TempDir(), "not-there.log")
+	if _, err := openLogFile(missing); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected fs.ErrNotExist for a missing log file, got %v", err)
+	}
+}
+
+// writeTestLog writes a log file with lines "line 1" .. "line N".
+func writeTestLog(t *testing.T, lines int) string {
+	t.Helper()
+
+	filePath := filepath.Join(t.TempDir(), "easyss.log")
+	content := make([]string, 0, lines)
+	for i := 1; i <= lines; i++ {
+		content = append(content, fmt.Sprintf("line %d", i))
+	}
+	if err := os.WriteFile(filePath, []byte(strings.Join(content, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write test log: %v", err)
+	}
+
+	return filePath
+}
+
+// stubDefaultApp captures the path handed to the desktop's default
+// application instead of opening a window.
+func stubDefaultApp(t *testing.T) *string {
+	t.Helper()
+
+	opened := new(string)
+	previous := openWithDefaultApp
+	openWithDefaultApp = func(path string) error {
+		*opened = path
+		return nil
+	}
+	t.Cleanup(func() { openWithDefaultApp = previous })
+
+	return opened
+}
+
+func TestOpenLogSnapshot(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the snapshot fallback is used on linux only")
+	}
+
+	const totalLines = logSnapshotLines + 50
+	logPath := writeTestLog(t, totalLines)
+	opened := stubDefaultApp(t)
+
+	if err := openLogSnapshot(logPath); err != nil {
+		t.Fatalf("openLogSnapshot failed: %v", err)
+	}
+	if *opened == "" {
+		t.Fatal("expected the snapshot to be handed to the default application")
+	}
+	t.Cleanup(func() { _ = os.Remove(*opened) })
+
+	info, err := os.Stat(*opened)
+	if err != nil {
+		t.Fatalf("snapshot not found: %v", err)
+	}
+	// The tray may run as root, so the snapshot has to be readable by the
+	// desktop user that opens it.
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("snapshot mode = %o, want 644", got)
+	}
+
+	data, err := os.ReadFile(*opened)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	content := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(content) != logSnapshotLines {
+		t.Fatalf("snapshot has %d lines, want %d", len(content), logSnapshotLines)
+	}
+	if content[0] != fmt.Sprintf("line %d", totalLines-logSnapshotLines+1) {
+		t.Fatalf("snapshot starts at %q, want the tail of the log", content[0])
+	}
+	if last := content[len(content)-1]; last != fmt.Sprintf("line %d", totalLines) {
+		t.Fatalf("snapshot ends at %q, want line %d", last, totalLines)
+	}
+}
+
+// TestOpenLogFileFallsBackWithoutTerminal covers the whole flow on a desktop
+// without any of the supported terminal emulators: the log is opened as a
+// snapshot instead of failing.
+func TestOpenLogFileFallsBackWithoutTerminal(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the terminal table is used on linux only")
+	}
+
+	logPath := writeTestLog(t, 5)
+	t.Setenv("TERMINAL", "")
+	withLookPath(t, fakeLookPath())
+	opened := stubDefaultApp(t)
+
+	fallback, err := openLogFile(logPath)
+	if err != nil {
+		t.Fatalf("openLogFile failed: %v", err)
+	}
+	if !fallback {
+		t.Fatal("expected the snapshot fallback to be reported")
+	}
+	if *opened == "" {
+		t.Fatal("expected the snapshot to be handed to the default application")
+	}
+	t.Cleanup(func() { _ = os.Remove(*opened) })
+}
+
+func TestStartDetached(t *testing.T) {
+	if err := startDetached(nil); err == nil {
+		t.Fatal("expected an error for an empty command")
+	}
+	if err := startDetached([]string{filepath.Join(t.TempDir(), "does-not-exist")}); err == nil {
+		t.Fatal("expected an error for a missing executable")
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("the true(1) helper is not available on windows")
+	}
+	trueBin, err := exec.LookPath("true")
+	if err != nil {
+		t.Skipf("true not found: %v", err)
+	}
+	// Must return without waiting for the child.
+	if err := startDetached([]string{trueBin}); err != nil {
+		t.Fatalf("startDetached failed: %v", err)
+	}
+}
+
+// TestLogViewerArgvOnHost resolves the table against the real PATH of the
+// machine running the tests, which is what the tray does at runtime. It is
+// skipped on a host without any terminal emulator.
+func TestLogViewerArgvOnHost(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the terminal table is used on linux only")
+	}
+
+	const logPath = "/tmp/easyss.log"
+	argv, err := logViewerArgv(logPath)
+	if err != nil {
+		t.Skipf("no terminal emulator available on this host: %v", err)
+	}
+
+	if term := strings.TrimSpace(os.Getenv("TERMINAL")); term != "" {
+		if bin, lookErr := exec.LookPath(strings.Fields(term)[0]); lookErr == nil && argv[0] != bin {
+			t.Fatalf("$TERMINAL=%q should win, got %q", term, argv[0])
+		}
+	}
+
+	joined := strings.Join(argv, " ")
+	if !strings.Contains(joined, "tail -n 50 -f") || !strings.Contains(joined, logPath) {
+		t.Fatalf("argv %q does not tail %s", argv, logPath)
+	}
+	if _, err := os.Stat(argv[0]); err != nil {
+		t.Fatalf("resolved terminal %q is not executable: %v", argv[0], err)
+	}
+
+	t.Logf("resolved terminal argv: %q (TERMINAL=%q)", argv, os.Getenv("TERMINAL"))
+}
+
+func TestFriendlyCatLogError(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{nil, ""},
+		{errLogFileNotConfigured, "日志文件未配置：请在 config.json 中设置 log.file_path，日志才会写入文件。"},
+		{errNoTerminalEmulator, "未找到可用的终端模拟器：请安装 xdg-terminal-exec、alacritty、foot 等终端，或设置 $TERMINAL 环境变量。"},
+		{fs.ErrNotExist, "日志文件不存在：" + fs.ErrNotExist.Error()},
+		{fs.ErrPermission, "没有权限读取日志文件：" + fs.ErrPermission.Error()},
+		{errors.New("boom"), "打开日志失败：boom"},
+	}
+
+	for _, c := range cases {
+		if got := friendlyCatLogError(c.err); got != c.want {
+			t.Fatalf("friendlyCatLogError(%v) = %q, want %q", c.err, got, c.want)
+		}
+	}
+}

--- a/util/sys.go
+++ b/util/sys.go
@@ -56,34 +56,6 @@ func SysSupportPowershell() bool {
 	return SysSupport("powershell")
 }
 
-func SysSupportXTerminalEmulator() bool {
-	return SysSupport("x-terminal-emulator")
-}
-
-func SysSupportGnomeTerminal() bool {
-	return SysSupport("gnome-terminal")
-}
-
-func SysSupportKonsole() bool {
-	return SysSupport("konsole")
-}
-
-func SysSupportXfce4Terminal() bool {
-	return SysSupport("xfce4-terminal")
-}
-
-func SysSupportLxterminal() bool {
-	return SysSupport("lxterminal")
-}
-
-func SysSupportMateTerminal() bool {
-	return SysSupport("mate-terminal")
-}
-
-func SysSupportTerminator() bool {
-	return SysSupport("terminator")
-}
-
 func SysSupport(bin string) bool {
 	lp, err := exec.LookPath(bin)
 	if lp != "" && err == nil {


### PR DESCRIPTION
## 背景

托盘菜单「查看日志」在现代 Wayland 桌面上完全失效，而且是**静默失败**：`catLogFile` 只探测 X11
时代的终端（x-terminal-emulator / gnome-terminal / mate-terminal / konsole / xfce4-terminal /
lxterminal / terminator），而 Omarchy/Hyprland 上一个都没装（会话自带的是 xdg-terminal-exec、
alacritty、foot）。点击后唯一的痕迹是日志文件里的一行：

```
level=ERROR source=tray.go:482 msg="[SYSTRAY] cat log" err="no supported terminal emulator found"
```

菜单本身看起来毫无反应，用户无从判断是点击没生效还是功能坏了。

## 改动

- 新增 `cmd/easyss/tray_log.go`：把硬编码的探测链换成有序终端表 —— `$TERMINAL`（可用时优先）→
  `xdg-terminal-exec` → foot/alacritty/kitty/ghostty/wezterm → 原有 X11 终端（行为保持）。
  每个表项声明命令的传递方式（独立 argv，或单条 shell 字符串，后者用 `shellQuote` 对含空格、
  单引号的路径转义，修掉原先 `fmt.Sprintf("tail -50f %s", path)` 的断链）。
- 用 `Start` + 后台 `Wait` 启动终端，替代 `util.Command`：终端窗口会一直开到用户关闭，原实现
  的 `CombinedOutput` 会让调用方 goroutine 一直阻塞且不回收子进程。Windows/macOS 命令不变。
- 找不到任何终端时兜底：把最近 500 行写成临时快照（0644，提权运行时桌面用户也能读）并用
  `xdg-open` 打开，同时通知说明这不是实时 tail。
- 所有失败都改为托盘系统通知，且错误文本带上探测过的终端列表；失败不再只写进日志文件。
- root（runuser）路径补齐提权时丢失的会话环境：`XDG_RUNTIME_DIR`、`WAYLAND_DISPLAY`（缺失时在
  `/run/user/<uid>` 下自动发现 `wayland-*` socket）、D-Bus 会话总线、`XAUTHORITY`、`TERMINAL`、
  `HYPRLAND_INSTANCE_SIGNATURE` 等；`root_linux.go` 的 pkexec 白名单补上 `XDG_RUNTIME_DIR` 与
  `TERMINAL`（没有 `XDG_RUNTIME_DIR`，root 下的 Wayland 终端连不上 compositor）。
- `util`：删除 7 个已无引用的终端探测包装函数。

## 验证

- 真机（Omarchy + Hyprland，只有 xdg-terminal-exec / alacritty / foot）解析结果为
  `xdg-terminal-exec -- tail -n 50 -f <log>`，实际执行确认弹出 alacritty 并实时 tail 日志
- 新增 8 组单测：解析优先级（`$TERMINAL` 绝对路径 / 未知终端 / 已装与未装）、shell 引号转义、
  空路径与文件不存在的错误、快照兜底的 500 行与 0644 权限、真实 PATH 探测、中文通知文案
- `make lint` 0 issues；`go test ./...` 全部通过
- linux / headless / darwin-arm64 / windows-amd64 构建均通过

## 已知限制

- 终端表覆盖主流终端，冷门终端仍可通过设置 `$TERMINAL` 使用；`$TERMINAL` 带额外参数时只取
  其可执行文件（额外参数会被丢弃，避免落到命令分隔符之后）。
- 未加 `--hold`/`sh -c` 包装：日志文件被轮转删除的极端情况下终端窗口会直接关闭，主要场景已由
  打开前的 `os.Stat` 检查覆盖（此时改为系统通知）。
