### PR TITLE
fix: harden tun route install and keep the local gateway outside the tunnel

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -55,7 +55,7 @@ type boundIface struct {
 // 0.0.0.0/0 default route from the routing table (skipping the easyss TUN
 // device, which owns its own default route there while TUN is active). On
 // darwin and linux it probes 0.0.0.1, which the easyss TUN routes (starting
-// at 1.0.0.0/7 on every platform) never cover, so the lookup yields the
+// at 1.0.0.0/8 on every platform) never cover, so the lookup yields the
 // physical default interface even while TUN routes are active — binding to
 // the easyss TUN device itself would create a routing loop. Windows cannot
 // use the probe: its route lookup rejects 0.0.0.0/8 destinations outright.
@@ -87,7 +87,7 @@ var detectDialIface = func() (*net.Interface, error) {
 }
 
 // probeDialIface finds the default-route interface by probing a destination
-// in 0.0.0.0/8, which the easyss TUN routes (starting at 1.0.0.0/7 on every
+// in 0.0.0.0/8, which the easyss TUN routes (starting at 1.0.0.0/8 on every
 // platform) never cover.
 func probeDialIface() (*net.Interface, error) {
 	r, err := netroute.New()

--- a/client/tun/icmp.go
+++ b/client/tun/icmp.go
@@ -45,20 +45,63 @@ func (h *ICMPHandler) HandlePacket(pkt adapter.Packet) bool {
 	id := pkt.ID()
 	dstAddr := id.LocalAddress.String()
 
+	// Only echo requests carry a routing decision worth an INFO line: the
+	// other ICMP types (echo replies, errors, neighbour discovery) are never
+	// proxied and tun2socks' default forwarder drops them anyway, so
+	// classifying them explains nothing and floods the log. A LAN gateway
+	// probing this host every second is enough to produce a handful of such
+	// lines per second, because the kernel's replies to those probes are
+	// routed into the TUN device (see the route notes in create_tun_dev.sh).
+	icmpType, echoRequest := icmpEchoRequest(pkt)
+	if !echoRequest {
+		log.Debug("[ICMP_DROP]", "dst", dstAddr, "type", icmpType, "reason", "non-echo")
+		return false
+	}
+
 	rule := h.router.MatchHostRule(dstAddr)
 
 	switch rule {
 	case router.HostRuleDirect:
-		log.Info("[ICMP_DIRECT]", "dst", dstAddr)
+		log.Info("[ICMP_DIRECT]", "dst", dstAddr, "type", icmpType)
 		return false
 	case router.HostRuleBlock:
-		log.Info("[ICMP_BLOCK] blocked", "dst", dstAddr)
+		log.Info("[ICMP_BLOCK] blocked", "dst", dstAddr, "type", icmpType)
 		return true
 	case router.HostRuleProxy:
-		log.Info("[ICMP_PROXY]", "dst", dstAddr)
+		log.Info("[ICMP_PROXY]", "dst", dstAddr, "type", icmpType)
 		return h.handleProxyICMP(pkt)
 	default:
+		log.Debug("[ICMP_DROP]", "dst", dstAddr, "type", icmpType, "reason", "no-rule")
 		return false
+	}
+}
+
+// icmpEchoRequest reports whether pkt is an ICMPv4/ICMPv6 echo request — the
+// only ICMP message this handler can route or proxy — and returns its ICMP
+// type for logging. Packets too short to carry an ICMP header count as
+// non-echo, mirroring the header checks in handleProxyICMP.
+func icmpEchoRequest(pkt adapter.Packet) (icmpType uint8, ok bool) {
+	buf := pkt.Buffer()
+	if buf == nil {
+		return 0, false
+	}
+
+	transHdr := buf.TransportHeader().Slice()
+	switch buf.NetworkProtocolNumber {
+	case ipv4.ProtocolNumber:
+		if len(transHdr) < header.ICMPv4MinimumSize {
+			return 0, false
+		}
+		t := header.ICMPv4(transHdr).Type()
+		return uint8(t), t == header.ICMPv4Echo
+	case header.IPv6ProtocolNumber:
+		if len(transHdr) < header.ICMPv6HeaderSize {
+			return 0, false
+		}
+		t := header.ICMPv6(transHdr).Type()
+		return uint8(t), t == header.ICMPv6EchoRequest
+	default:
+		return 0, false
 	}
 }
 

--- a/client/tun/icmp_test.go
+++ b/client/tun/icmp_test.go
@@ -1,0 +1,314 @@
+package tun
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/nange/easyss/v3/client/router"
+	"github.com/nange/easyss/v3/log"
+	"github.com/xjasonlyu/tun2socks/v2/core/adapter"
+	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// Addresses used by the handler tests: a LAN gateway and a host that the
+// auto rule set proxies.
+var (
+	lanGatewayAddr = tcpip.AddrFrom4([4]byte{192, 168, 3, 1})
+	proxiedAddr    = tcpip.AddrFrom4([4]byte{8, 8, 8, 8})
+)
+
+// testPacket is the adapter.Packet the tun2socks ICMP forwarder hands to the
+// handler: a packet buffer plus the transport endpoint ID the handler reads
+// the destination address from.
+type testPacket struct {
+	pkt *stack.PacketBuffer
+	id  stack.TransportEndpointID
+}
+
+func (p *testPacket) Buffer() *stack.PacketBuffer { return p.pkt }
+
+func (p *testPacket) Stack() *stack.Stack { return nil }
+
+func (p *testPacket) ID() stack.TransportEndpointID { return p.id }
+
+// newPacket builds a packet whose network header is netHdrLen bytes followed
+// by icmpMsg, in the order the stack parses an inbound packet. The header
+// contents do not matter: only the ICMP type byte is read.
+func newPacket(t *testing.T, netProto tcpip.NetworkProtocolNumber, netHdrLen int, icmpMsg []byte) *testPacket {
+	t.Helper()
+
+	raw := make([]byte, netHdrLen+len(icmpMsg))
+	copy(raw[netHdrLen:], icmpMsg)
+
+	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: buffer.MakeWithData(raw)})
+	t.Cleanup(pkt.DecRef)
+	pkt.NetworkProtocolNumber = netProto
+
+	if _, ok := pkt.NetworkHeader().Consume(netHdrLen); !ok {
+		t.Fatalf("consume %d-byte network header of a %d-byte packet", netHdrLen, len(raw))
+	}
+	if _, ok := pkt.TransportHeader().Consume(len(icmpMsg)); !ok {
+		t.Fatalf("consume %d-byte ICMP message", len(icmpMsg))
+	}
+	return &testPacket{pkt: pkt}
+}
+
+// icmpv4Msg and icmpv6Msg build a minimal ICMP message of the given type.
+func icmpv4Msg(typ header.ICMPv4Type) []byte {
+	msg := make([]byte, header.ICMPv4MinimumSize)
+	header.ICMPv4(msg).SetType(typ)
+	return msg
+}
+
+func icmpv6Msg(typ header.ICMPv6Type) []byte {
+	msg := make([]byte, header.ICMPv6MinimumSize)
+	header.ICMPv6(msg).SetType(typ)
+	return msg
+}
+
+func TestICMPEchoRequest(t *testing.T) {
+	cases := []struct {
+		name      string
+		netProto  tcpip.NetworkProtocolNumber
+		netHdrLen int
+		icmpMsg   []byte
+		wantType  uint8
+		wantEcho  bool
+	}{
+		{"ipv4 echo request", ipv4.ProtocolNumber, header.IPv4MinimumSize,
+			icmpv4Msg(header.ICMPv4Echo), uint8(header.ICMPv4Echo), true},
+		{"ipv4 echo reply", ipv4.ProtocolNumber, header.IPv4MinimumSize,
+			icmpv4Msg(header.ICMPv4EchoReply), uint8(header.ICMPv4EchoReply), false},
+		{"ipv4 destination unreachable", ipv4.ProtocolNumber, header.IPv4MinimumSize,
+			icmpv4Msg(header.ICMPv4DstUnreachable), uint8(header.ICMPv4DstUnreachable), false},
+		{"ipv6 echo request", header.IPv6ProtocolNumber, header.IPv6MinimumSize,
+			icmpv6Msg(header.ICMPv6EchoRequest), uint8(header.ICMPv6EchoRequest), true},
+		{"ipv6 echo reply", header.IPv6ProtocolNumber, header.IPv6MinimumSize,
+			icmpv6Msg(header.ICMPv6EchoReply), uint8(header.ICMPv6EchoReply), false},
+		{"ipv6 neighbour solicitation", header.IPv6ProtocolNumber, header.IPv6MinimumSize,
+			icmpv6Msg(header.ICMPv6NeighborSolicit), uint8(header.ICMPv6NeighborSolicit), false},
+		{"unknown network protocol", 99, header.IPv4MinimumSize,
+			icmpv4Msg(header.ICMPv4Echo), 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, gotEcho := icmpEchoRequest(newPacket(t, tc.netProto, tc.netHdrLen, tc.icmpMsg))
+			if gotEcho != tc.wantEcho || gotType != tc.wantType {
+				t.Errorf("icmpEchoRequest() = (%d, %v), want (%d, %v)",
+					gotType, gotEcho, tc.wantType, tc.wantEcho)
+			}
+		})
+	}
+}
+
+func TestICMPEchoRequestMalformed(t *testing.T) {
+	// A packet too short to hold an ICMP header (a truncated capture) must be
+	// reported as non-echo instead of panicking.
+	t.Run("empty transport header", func(t *testing.T) {
+		pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+			Payload: buffer.MakeWithData([]byte{0x45, 0x00, 0x00, 0x00}),
+		})
+		t.Cleanup(pkt.DecRef)
+		pkt.NetworkProtocolNumber = ipv4.ProtocolNumber
+
+		if typ, ok := icmpEchoRequest(&testPacket{pkt: pkt}); ok || typ != 0 {
+			t.Errorf("icmpEchoRequest() = (%d, %v), want (0, false)", typ, ok)
+		}
+	})
+
+	t.Run("nil buffer", func(t *testing.T) {
+		if typ, ok := icmpEchoRequest(&testPacket{}); ok || typ != 0 {
+			t.Errorf("icmpEchoRequest() = (%d, %v), want (0, false)", typ, ok)
+		}
+	})
+}
+
+// TestHandlePacketLogsOnlyEchoRequests is the regression test for the INFO
+// flood this handler used to produce: a LAN gateway probes every host on its
+// network, the kernel replies to each probe, and once the gateway address is
+// routed into the TUN device those replies (ICMP type 0) arrive here. Logging
+// them at INFO produced several lines per second forever, so only echo
+// requests — the messages that actually carry a routing decision — may reach
+// the INFO log; every other type belongs to the debug log.
+func TestHandlePacketLogsOnlyEchoRequests(t *testing.T) {
+	// Build the router before swapping the logger: router.New logs the rule
+	// files it loads and that output is not part of what this test asserts.
+	rt, err := router.New(router.Config{ProxyRule: router.ProxyRuleAuto})
+	if err != nil {
+		t.Fatalf("router.New: %v", err)
+	}
+
+	rec := &recordingHandler{}
+	prev := log.Logger()
+	log.SetLogger(slog.New(rec))
+	t.Cleanup(func() { log.SetLogger(prev) })
+
+	h := NewICMPHandler(rt)
+
+	cases := []struct {
+		name     string
+		typ      header.ICMPv4Type
+		dst      tcpip.Address
+		wantInfo []string
+	}{
+		{
+			name:     "echo request to the lan gateway",
+			typ:      header.ICMPv4Echo,
+			dst:      lanGatewayAddr,
+			wantInfo: []string{"[ICMP_DIRECT]"},
+		},
+		{
+			name:     "echo request to a proxied host",
+			typ:      header.ICMPv4Echo,
+			dst:      proxiedAddr,
+			wantInfo: []string{"[ICMP_PROXY]"},
+		},
+		{
+			name:     "echo reply from the lan gateway",
+			typ:      header.ICMPv4EchoReply,
+			dst:      lanGatewayAddr,
+			wantInfo: nil,
+		},
+		{
+			name:     "destination unreachable from the lan gateway",
+			typ:      header.ICMPv4DstUnreachable,
+			dst:      lanGatewayAddr,
+			wantInfo: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec.reset()
+
+			pkt := newPacket(t, ipv4.ProtocolNumber, header.IPv4MinimumSize, icmpv4Msg(tc.typ))
+			pkt.id = stack.TransportEndpointID{LocalAddress: tc.dst}
+
+			// No proxied exchange can complete in this test, so every case
+			// ends with the packet left to the default forwarder.
+			if got := h.HandlePacket(pkt); got {
+				t.Errorf("HandlePacket() = true, want false")
+			}
+
+			if infos := rec.infoMessages(); !slices.Equal(infos, tc.wantInfo) {
+				t.Errorf("INFO logs = %v, want %v (all levels: %v)", infos, tc.wantInfo, rec.messages())
+			}
+
+			if len(tc.wantInfo) == 0 {
+				if !rec.hasMessage("[ICMP_DROP]") {
+					t.Errorf("non-echo packet logged no [ICMP_DROP] record: %v", rec.messages())
+				}
+				return
+			}
+
+			r, ok := rec.findRecord(slog.LevelInfo, tc.wantInfo[0])
+			if !ok {
+				t.Fatalf("no INFO record %q", tc.wantInfo[0])
+			}
+			got, ok := attrValue(r, "type")
+			if !ok {
+				t.Fatalf("record %q has no type attribute", tc.wantInfo[0])
+			}
+			if want := strconv.Itoa(int(tc.typ)); got.String() != want {
+				t.Errorf("type attribute = %q, want %q", got.String(), want)
+			}
+		})
+	}
+}
+
+// recordingHandler captures every record the log package emits so tests can
+// assert which levels a code path logs at.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *recordingHandler) WithGroup(string) slog.Handler { return h }
+
+func (h *recordingHandler) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = nil
+}
+
+// infoMessages returns the messages of every record logged at INFO or above.
+func (h *recordingHandler) infoMessages() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var msgs []string
+	for _, r := range h.records {
+		if r.Level >= slog.LevelInfo {
+			msgs = append(msgs, r.Message)
+		}
+	}
+	return msgs
+}
+
+func (h *recordingHandler) hasMessage(msg string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return slices.ContainsFunc(h.records, func(r slog.Record) bool { return r.Message == msg })
+}
+
+func (h *recordingHandler) findRecord(level slog.Level, msg string) (slog.Record, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, r := range h.records {
+		if r.Level == level && r.Message == msg {
+			return r, true
+		}
+	}
+	return slog.Record{}, false
+}
+
+// messages renders "level message" for every record, for failure output.
+func (h *recordingHandler) messages() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	msgs := make([]string, 0, len(h.records))
+	for _, r := range h.records {
+		msgs = append(msgs, r.Level.String()+" "+r.Message)
+	}
+	return msgs
+}
+
+func attrValue(r slog.Record, key string) (slog.Value, bool) {
+	var (
+		val   slog.Value
+		found bool
+	)
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			val, found = a.Value, true
+			return false
+		}
+		return true
+	})
+	return val, found
+}
+
+var _ adapter.Packet = (*testPacket)(nil)

--- a/cmd/easyss/tun_helper_darwin.go
+++ b/cmd/easyss/tun_helper_darwin.go
@@ -122,9 +122,11 @@ func ensureTunRoutes(device string, cfg *proxy.TunConfig) error {
 	}
 
 	if !needCreate {
-		routeOut, err := util.Command("route", "-n", "get", tunRouteProbe)
-		if err != nil || !strings.Contains(routeOut, "interface: "+device) {
-			log.Warn("[TUN-HELPER] route check failed", "device", device, "probe", tunRouteProbe, "err", err, "output", routeOut)
+		routeOut, err := probeRoutedViaDevice(tunRouteProbes, func(probe string) (string, error) {
+			return util.Command("route", "-n", "get", probe)
+		}, "interface: "+device)
+		if err != nil {
+			log.Warn("[TUN-HELPER] route check failed", "device", device, "probe", tunRouteProbes, "err", err, "output", routeOut)
 			needCreate = true
 		}
 	}

--- a/cmd/easyss/tun_helper_linux.go
+++ b/cmd/easyss/tun_helper_linux.go
@@ -116,9 +116,11 @@ func ensureTunRoutes(device string, cfg *proxy.TunConfig) error {
 	}
 
 	if !needCreate {
-		routeOut, err := util.Command("ip", "route", "get", tunRouteProbe)
-		if err != nil || !strings.Contains(routeOut, "dev "+device) {
-			log.Warn("[TUN-HELPER] route check failed", "device", device, "probe", tunRouteProbe, "err", err, "output", routeOut)
+		routeOut, err := probeRoutedViaDevice(tunRouteProbes, func(probe string) (string, error) {
+			return util.Command("ip", "route", "get", probe)
+		}, "dev "+device)
+		if err != nil {
+			log.Warn("[TUN-HELPER] route check failed", "device", device, "probe", tunRouteProbes, "err", err, "output", routeOut)
 			needCreate = true
 		}
 	}

--- a/cmd/easyss/tun_helper_linux_test.go
+++ b/cmd/easyss/tun_helper_linux_test.go
@@ -22,14 +22,21 @@ const (
 	testTunDevice = "tun-easyss"
 	testTunIPSub  = "198.18.0.1/16"
 	testTunGW     = "198.18.0.1"
-	// testRoutedGateway is the local gateway the script routes through the TUN
-	// device: a LAN router whose own subnet is not connected in the test, so
-	// the only route that can match it is the TUN one.
+	// testRoutedGateway is the local gateway of the simulated LAN. It must stay
+	// outside the TUN routes (see testExcludedAddrs): the create script used to
+	// install it as a host route through the TUN device, which swallowed the
+	// kernel's ICMP replies to the gateway's own liveness probes.
 	testRoutedGateway = "192.168.3.1"
-	// testPhysAddr/testPhysGateway describe the simulated physical interface
-	// (its default route keeps 0.0.0.0/8 interesting for the negative probe).
+	// testPhysDevice/testPhysAddr/testPhysGateway describe the simulated
+	// physical interface: its default route keeps 0.0.0.0/8 interesting for the
+	// negative probe, and testPhysLANAddr gives it a connected route on the
+	// gateway's own subnet, exactly like a real LAN interface. That connected
+	// route is what keeps the gateway (and the kernel's ICMP replies to it) off
+	// the TUN's 128.0.0.0/1 route.
+	testPhysDevice  = "phys0"
 	testPhysAddr    = "192.168.9.93/24"
 	testPhysGateway = "192.168.9.1"
+	testPhysLANAddr = "192.168.3.93/24"
 )
 
 // testCoveredAddrs are destinations that must resolve through the TUN device
@@ -37,10 +44,16 @@ const (
 // route block family.
 var testCoveredAddrs = []string{"1.1.1.1", "8.8.8.8", "223.5.5.5", "100.64.0.1"}
 
-// testExcludedAddr must stay outside the TUN routes: 0.0.0.0/8 is deliberately
-// not routed to the TUN device, because the direct dialer probes it to find
-// the physical default interface.
-const testExcludedAddr = "0.0.0.1"
+// testExcludedAddrs must stay outside the TUN routes. 0.0.0.0/8 is deliberately
+// not routed to the TUN device, because the direct dialer probes it to find the
+// physical default interface. The local gateway belongs there too: once it is
+// routed into the TUN device every packet addressed to it enters the tunnel,
+// and tun2socks' default ICMP forwarder only answers echo requests — the
+// kernel's replies to the gateway's liveness probes would be discarded, so the
+// gateway would keep probing forever (several [ICMP_DIRECT] log lines per
+// second) and `ping <gateway>` would only ever see a synthetic reply. darwin
+// dropped that route in 91bb4c6; linux followed.
+var testExcludedAddrs = []string{"0.0.0.1", testRoutedGateway}
 
 // TestTunRouteBlocksAreCanonical is the regression test for the broken
 // "ip route add 1.0.0.0/7" line: 1.0.0.0/7 is not aligned with its own mask
@@ -91,6 +104,34 @@ func TestTunRouteProbeCoveredByScripts(t *testing.T) {
 	}
 }
 
+// TestCreateScriptsKeepGatewayOutsideTun is the regression test for routing the
+// local gateway into the TUN device. The linux script used to install it as a
+// bare "ip route replace $local_gateway" host route, which beat the physical
+// interface's connected route for the LAN: every packet addressed to the
+// gateway entered the tunnel, including the kernel's ICMP replies to the
+// gateway's liveness probes. tun2socks' default ICMP forwarder answers echo
+// requests only and drops every other type, so the gateway never saw a reply
+// and kept probing (several [ICMP_DIRECT] log lines per second), while
+// `ping <gateway>` only ever reported a synthetic sub-millisecond reply.
+// darwin dropped the same route in 91bb4c6; no create script may add it back.
+func TestCreateScriptsKeepGatewayOutsideTun(t *testing.T) {
+	for _, platform := range createScripts() {
+		t.Run(platform.name, func(t *testing.T) {
+			for line := range strings.SplitSeq(string(platform.source), "\n") {
+				line = strings.TrimSpace(strings.TrimRight(strings.TrimSpace(line), "\r"))
+				if line == "" || strings.HasPrefix(line, "#") ||
+					strings.HasPrefix(strings.ToLower(line), "rem ") {
+					continue
+				}
+				if !strings.Contains(line, "local_gateway") || !addsRoute(line) {
+					continue
+				}
+				t.Errorf("%s: %s routes the local gateway into the TUN device", platform.name, line)
+			}
+		})
+	}
+}
+
 // TestCreateTunScriptRoutesThroughTun runs the real create script in a
 // throwaway network namespace and asserts what the keep-alive needs: every
 // intended route is installed, the probes resolve through the TUN device, the
@@ -110,13 +151,14 @@ func TestCreateTunScriptRoutesThroughTun(t *testing.T) {
 	// like the helper right after it opened the device.
 	create := runCreateTunScript(scriptPath)
 	tunSetup := `ip link add "` + testTunDevice + `" type dummy && ip link set dev lo up`
-	// The simulated physical interface sits on a subnet of its own so that the
-	// local gateway the script routes has no competing connected route; its
-	// default route is what makes the negative probe meaningful (0.0.0.1 must
-	// resolve, just not through the TUN device).
-	physSetup := fmt.Sprintf(`ip link add phys0 type dummy && ip addr add %s dev phys0`+
-		` && ip link set phys0 up && ip route add default via %s dev phys0`,
-		testPhysAddr, testPhysGateway)
+	// The simulated physical interface carries the LAN address as well as a
+	// subnet of its own: the LAN connected route is what a real interface has,
+	// and the extra subnet's default route keeps 0.0.0.0/8 interesting for the
+	// negative probe (0.0.0.1 must resolve, just not through the TUN device).
+	physSetup := fmt.Sprintf(`ip link add %s type dummy && ip addr add %s dev %s`+
+		` && ip addr add %s dev %s && ip link set %s up && ip route add default via %s dev %s`,
+		testPhysDevice, testPhysAddr, testPhysDevice, testPhysLANAddr, testPhysDevice,
+		testPhysDevice, testPhysGateway, testPhysDevice)
 	setup := tunSetup + "\n" + physSetup
 
 	t.Run("routes installed", func(t *testing.T) {
@@ -142,7 +184,7 @@ func TestCreateTunScriptRoutesThroughTun(t *testing.T) {
 func routesAndProbes() string {
 	var b strings.Builder
 	b.WriteString("ip route show | grep -v '^default'\n")
-	for _, addr := range append(slices.Clone(testCoveredAddrs), testExcludedAddr) {
+	for _, addr := range append(slices.Clone(testCoveredAddrs), testExcludedAddrs...) {
 		fmt.Fprintf(&b, "echo '%s %s' \"$(ip route get %s 2>&1 | head -1)\"\n",
 			probeMarker, addr, addr)
 	}
@@ -159,7 +201,7 @@ func requireRoutesThroughTun(t *testing.T, out string) {
 	table := routesTable(out)
 	for _, cidr := range []string{
 		"1.0.0.0/8", "4.0.0.0/6", "8.0.0.0/5", "16.0.0.0/4",
-		"32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/1", testRoutedGateway + "/32",
+		"32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/1",
 	} {
 		// Compare masked prefixes: the kernel prints a host route as its bare
 		// address ("192.168.3.1"), which parses to 192.168.3.1/32, while the
@@ -180,8 +222,18 @@ func requireRoutesThroughTun(t *testing.T, out string) {
 		}
 	}
 
-	if got := probeOutput(out, testExcludedAddr); strings.Contains(got, "dev "+testTunDevice) {
-		t.Errorf("ip route get %s = %q, want it to stay outside the TUN routes", testExcludedAddr, got)
+	for _, addr := range testExcludedAddrs {
+		if got := probeOutput(out, addr); strings.Contains(got, "dev "+testTunDevice) {
+			t.Errorf("ip route get %s = %q, want it to stay outside the TUN routes", addr, got)
+		}
+	}
+
+	// The gateway keeps resolving (through the physical interface's default
+	// route), so its own liveness probes reach this host and its ICMP replies
+	// leave through the physical interface.
+	if got := probeOutput(out, testRoutedGateway); !strings.Contains(got, "dev "+testPhysDevice) {
+		t.Errorf("ip route get %s = %q, want it to resolve through %s",
+			testRoutedGateway, got, testPhysDevice)
 	}
 }
 
@@ -342,6 +394,20 @@ func staticRouteBlocks(t *testing.T, script []byte) []routeBlock {
 		}
 	}
 	return blocks
+}
+
+// routeArgs returns the fields following the add/replace verb of a route
+// command, reporting false for lines that neither add a route nor refer to a
+// addsRoute reports whether line is a route command that adds or replaces a
+// route, in any of the dialects the create scripts are written in
+// ("ip route add|replace ...", "route add ...").
+func addsRoute(line string) bool {
+	fields := strings.Fields(line)
+	// The linux script wraps its ip calls in the run_idem shell helper.
+	if idx := slices.IndexFunc(fields, func(f string) bool { return f == "ip" || f == "route" }); idx > 0 {
+		fields = fields[idx:]
+	}
+	return slices.ContainsFunc(fields, func(f string) bool { return f == "add" || f == "replace" })
 }
 
 // routeArgs returns the fields following the add/replace verb of a route

--- a/cmd/easyss/tun_helper_linux_test.go
+++ b/cmd/easyss/tun_helper_linux_test.go
@@ -1,0 +1,416 @@
+//go:build linux && !headless
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/nange/easyss/v3/scripts"
+)
+
+// Values used by the netns integration test below. They mirror the TUN
+// defaults: the TUN gateway sits in the 198.18.0.0/15 subnet and the local
+// gateway is an ordinary LAN address outside it.
+const (
+	testTunDevice = "tun-easyss"
+	testTunIPSub  = "198.18.0.1/16"
+	testTunGW     = "198.18.0.1"
+	// testRoutedGateway is the local gateway the script routes through the TUN
+	// device: a LAN router whose own subnet is not connected in the test, so
+	// the only route that can match it is the TUN one.
+	testRoutedGateway = "192.168.3.1"
+	// testPhysAddr/testPhysGateway describe the simulated physical interface
+	// (its default route keeps 0.0.0.0/8 interesting for the negative probe).
+	testPhysAddr    = "192.168.9.93/24"
+	testPhysGateway = "192.168.9.1"
+)
+
+// testCoveredAddrs are destinations that must resolve through the TUN device
+// once its routes are installed: the keep-alive probes plus one address per
+// route block family.
+var testCoveredAddrs = []string{"1.1.1.1", "8.8.8.8", "223.5.5.5", "100.64.0.1"}
+
+// testExcludedAddr must stay outside the TUN routes: 0.0.0.0/8 is deliberately
+// not routed to the TUN device, because the direct dialer probes it to find
+// the physical default interface.
+const testExcludedAddr = "0.0.0.1"
+
+// TestTunRouteBlocksAreCanonical is the regression test for the broken
+// "ip route add 1.0.0.0/7" line: 1.0.0.0/7 is not aligned with its own mask
+// (it normalizes to 0.0.0.0/7), so iproute2 rejected it outright. Nothing
+// surfaced the failure — the route was never installed, 1.0.0.0/8 silently
+// leaked outside the tunnel, and the keep-alive reported "route check failed"
+// every 10s.
+//
+// Every static prefix of every create script must therefore be canonical: a
+// prefix with bits set below its mask cannot be installed by any platform's
+// route command, no matter how it is spelled.
+func TestTunRouteBlocksAreCanonical(t *testing.T) {
+	for _, platform := range createScripts() {
+		t.Run(platform.name, func(t *testing.T) {
+			blocks := staticRouteBlocks(t, platform.source)
+			if len(blocks) == 0 {
+				t.Fatal("no static route block found: the parser and the script drifted apart")
+			}
+			for _, block := range blocks {
+				if !block.prefix.IsValid() {
+					t.Errorf("%s: unparsable route block %q", platform.name, block.raw)
+					continue
+				}
+				if block.prefix.Masked() != block.prefix {
+					t.Errorf("%s: %s is not aligned, it normalizes to %s and cannot be installed",
+						platform.name, block.raw, block.prefix.Masked())
+				}
+			}
+		})
+	}
+}
+
+// TestTunRouteProbeCoveredByScripts ties the keep-alive probes to the routes
+// the create scripts install: a probe outside every route block can never
+// resolve through the TUN device, so the keep-alive would report a failure and
+// recreate the very same routes every 10 seconds, forever.
+func TestTunRouteProbeCoveredByScripts(t *testing.T) {
+	for _, platform := range createScripts() {
+		t.Run(platform.name, func(t *testing.T) {
+			blocks := staticRouteBlocks(t, platform.source)
+			for _, probe := range tunRouteProbes {
+				if !routedBy(blocks, probe) {
+					t.Errorf("%s: keep-alive probe %s is outside every route block %v",
+						platform.name, probe, blocks)
+				}
+			}
+		})
+	}
+}
+
+// TestCreateTunScriptRoutesThroughTun runs the real create script in a
+// throwaway network namespace and asserts what the keep-alive needs: every
+// intended route is installed, the probes resolve through the TUN device, the
+// 0.0.0.0/8 exclusion is preserved, and re-running the script (what the
+// keep-alive does after sleep/wake) stays silent and idempotent.
+//
+// The device is a dummy interface because /dev/net/tun is usually unavailable
+// inside an unprivileged user namespace; the ip commands the script issues are
+// identical for both device types. No root privileges are needed.
+func TestCreateTunScriptRoutesThroughTun(t *testing.T) {
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", scripts.CreateTunFilename))
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+
+	// The first invocation creates the device and adds the addresses, exactly
+	// like the helper right after it opened the device.
+	create := runCreateTunScript(scriptPath)
+	tunSetup := `ip link add "` + testTunDevice + `" type dummy && ip link set dev lo up`
+	// The simulated physical interface sits on a subnet of its own so that the
+	// local gateway the script routes has no competing connected route; its
+	// default route is what makes the negative probe meaningful (0.0.0.1 must
+	// resolve, just not through the TUN device).
+	physSetup := fmt.Sprintf(`ip link add phys0 type dummy && ip addr add %s dev phys0`+
+		` && ip link set phys0 up && ip route add default via %s dev phys0`,
+		testPhysAddr, testPhysGateway)
+	setup := tunSetup + "\n" + physSetup
+
+	t.Run("routes installed", func(t *testing.T) {
+		out := inNetns(t, setup+"\n"+create+"\n"+routesAndProbes())
+		requireRoutesThroughTun(t, out)
+	})
+
+	t.Run("re-run is idempotent", func(t *testing.T) {
+		out := inNetns(t, setup+"\n"+create+"\n"+create+"\n"+routesAndProbes())
+		requireRoutesThroughTun(t, out)
+
+		if n := strings.Count(out, "1.0.0.0/8"); n != 1 {
+			t.Errorf("1.0.0.0/8 appears %d times after a re-run, want 1:\n%s", n, out)
+		}
+	})
+}
+
+// routesAndProbes dumps the resulting routing table and one marked "ip route
+// get" result per probe address. The kernel answers the lookups, so a route
+// block that is spelled in a way which does not route (as 1.0.0.0/7 was)
+// cannot pass by matching text, and the probes are emitted only once the table
+// is final.
+func routesAndProbes() string {
+	var b strings.Builder
+	b.WriteString("ip route show | grep -v '^default'\n")
+	for _, addr := range append(slices.Clone(testCoveredAddrs), testExcludedAddr) {
+		fmt.Fprintf(&b, "echo '%s %s' \"$(ip route get %s 2>&1 | head -1)\"\n",
+			probeMarker, addr, addr)
+	}
+	return b.String()
+}
+
+// probeMarker prefixes every probe result line in the captured output.
+const probeMarker = "PROBE"
+
+// requireRoutesThroughTun asserts the routing state the TUN helper relies on.
+func requireRoutesThroughTun(t *testing.T, out string) {
+	t.Helper()
+
+	table := routesTable(out)
+	for _, cidr := range []string{
+		"1.0.0.0/8", "4.0.0.0/6", "8.0.0.0/5", "16.0.0.0/4",
+		"32.0.0.0/3", "64.0.0.0/2", "128.0.0.0/1", testRoutedGateway + "/32",
+	} {
+		// Compare masked prefixes: the kernel prints a host route as its bare
+		// address ("192.168.3.1"), which parses to 192.168.3.1/32, while the
+		// expected value above is spelled with the same host in the network.
+		want := netip.MustParsePrefix(cidr).Masked()
+		found := slices.ContainsFunc(strings.Split(table, "\n"), func(line string) bool {
+			prefix, ok := routedPrefix(line)
+			return ok && prefix.Masked() == want
+		})
+		if !found {
+			t.Errorf("route %s via %s dev %s is missing:\n%s", cidr, testTunGW, testTunDevice, table)
+		}
+	}
+
+	for _, addr := range testCoveredAddrs {
+		if got := probeOutput(out, addr); !strings.Contains(got, "dev "+testTunDevice) {
+			t.Errorf("ip route get %s = %q, want it to resolve through %s", addr, got, testTunDevice)
+		}
+	}
+
+	if got := probeOutput(out, testExcludedAddr); strings.Contains(got, "dev "+testTunDevice) {
+		t.Errorf("ip route get %s = %q, want it to stay outside the TUN routes", testExcludedAddr, got)
+	}
+}
+
+// probeOutput returns the captured lookup result for addr.
+func probeOutput(out, addr string) string {
+	for line := range strings.SplitSeq(out, "\n") {
+		rest, ok := strings.CutPrefix(line, probeMarker+" "+addr+" ")
+		if ok {
+			return rest
+		}
+	}
+	return ""
+}
+
+// routesTable returns the "ip route show" portion of the captured output, i.e.
+// every line that starts with a route prefix.
+func routesTable(out string) string {
+	var table []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if _, ok := routedPrefix(line); ok {
+			table = append(table, line)
+		}
+	}
+	return strings.Join(table, "\n")
+}
+
+// inNetns runs body with bash inside a throwaway unprivileged network
+// namespace and returns its combined output. It skips when the environment
+// does not support unprivileged user namespaces (rootless containers without
+// CLONE_NEWUSER), so the suite stays green there.
+func inNetns(t *testing.T, body string) string {
+	t.Helper()
+
+	cmd := exec.Command("unshare", "-Urn", "bash", "-c", body)
+	cmd.Env = append(cmd.Environ(), "LC_ALL=C")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		res := string(out)
+		if strings.Contains(res, "Operation not permitted") ||
+			strings.Contains(res, "unshare:") ||
+			strings.Contains(res, "executable file not found") {
+			t.Skipf("unshare is unavailable in this environment: %v\n%s", err, res)
+		}
+		t.Fatalf("netns body failed: %v\n%s", err, res)
+	}
+	if res := string(out); strings.Contains(res, "[create_tun_dev]") {
+		t.Errorf("the create script reported a non-idempotent error:\n%s", res)
+	}
+	return string(out)
+}
+
+// runCreateTunScript returns the shell snippet that executes the create script
+// with the same arguments the client passes on Linux.
+func runCreateTunScript(scriptPath string) string {
+	return fmt.Sprintf("bash %s %s %s %s %s",
+		scriptPath, testTunDevice, testTunIPSub, testTunGW, testRoutedGateway)
+}
+
+// createScripts returns the create scripts of every platform, parseable from
+// any host because they are embedded.
+func createScripts() []struct {
+	name   string
+	source []byte
+} {
+	return []struct {
+		name   string
+		source []byte
+	}{
+		{"linux", scripts.CreateTunDevSh},
+		{"darwin", scripts.CreateTunDevDarwinSh},
+		{"windows", scripts.CreateTunDevBat},
+	}
+}
+
+// routedPrefix extracts the destination prefix from a line of "ip route show"
+// output ("4.0.0.0/6 via 198.18.0.1 dev tun-easyss"). A bare address is a host
+// route.
+func routedPrefix(line string) (netip.Prefix, bool) {
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) == 0 {
+		return netip.Prefix{}, false
+	}
+	if prefix, err := netip.ParsePrefix(fields[0]); err == nil {
+		return prefix, true
+	}
+	if addr, err := netip.ParseAddr(fields[0]); err == nil {
+		return netip.PrefixFrom(addr, addr.BitLen()), true
+	}
+	return netip.Prefix{}, false
+}
+
+// routeBlock is one IPv4 route a create script installs. prefix is invalid
+// when the script spells a non-canonical prefix (for example 1.0.0.0/7, which
+// normalizes to 0.0.0.0/7), so callers can report it verbatim.
+type routeBlock struct {
+	raw    string
+	prefix netip.Prefix
+}
+
+// routedBy reports whether addr is a destination covered by any of the blocks,
+// i.e. whether a lookup in that routing state resolves through the TUN device.
+func routedBy(blocks []routeBlock, addr string) bool {
+	ip, err := netip.ParseAddr(addr)
+	if err != nil {
+		return false
+	}
+	for _, block := range blocks {
+		if block.prefix.IsValid() && block.prefix.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// staticRouteBlocks parses the IPv4 route destinations a create script
+// installs, in every dialect the scripts are written in: "ip route
+// add|replace <prefix>" (linux), "route add -net <prefix>" (darwin) and
+// "route add <addr> mask <mask>" (windows). Routes built from shell variables
+// (the local gateway) and IPv6 lines are skipped.
+func staticRouteBlocks(t *testing.T, script []byte) []routeBlock {
+	t.Helper()
+
+	var blocks []routeBlock
+	for line := range strings.SplitSeq(string(script), "\n") {
+		line = strings.TrimSpace(strings.TrimRight(strings.TrimSpace(line), "\r"))
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(strings.ToLower(line), "rem ") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		// The linux script wraps its ip calls in the run_idem shell helper.
+		if idx := slices.IndexFunc(fields, func(f string) bool { return f == "ip" || f == "route" }); idx > 0 {
+			fields = fields[idx:]
+		}
+		switch fields[0] {
+		case "ip":
+			// linux: ip route replace 1.0.0.0/8 via "$tun_gw" dev "$tun_device"
+			args, ok := routeArgs(fields[1:])
+			if !ok {
+				continue
+			}
+			appendStaticBlock(t, &blocks, args[0])
+		case "route":
+			// windows: route add 1.0.0.0 mask 254.0.0.0 %tun_gw% metric 5
+			// darwin:  route add -net 1.0.0.0/8 "$tun_gw"
+			args, ok := routeArgs(fields[1:])
+			if !ok {
+				continue
+			}
+			switch {
+			case args[0] == "-net" && len(args) >= 2: // darwin
+				appendStaticBlock(t, &blocks, args[1])
+			case len(args) >= 3 && args[1] == "mask": // windows
+				appendStaticBlock(t, &blocks, args[0]+" "+args[2])
+			default:
+				t.Fatalf("unrecognized route line: %q", line)
+			}
+		}
+	}
+	return blocks
+}
+
+// routeArgs returns the fields following the add/replace verb of a route
+// command, reporting false for lines that neither add a route nor refer to a
+// static destination.
+func routeArgs(fields []string) ([]string, bool) {
+	idx := slices.IndexFunc(fields, func(f string) bool { return f == "add" || f == "replace" })
+	if idx < 0 || idx+1 >= len(fields) {
+		return nil, false
+	}
+	args := fields[idx+1:]
+	// Dynamic destinations (the local gateway) and IPv6 lines are not part of
+	// the static IPv4 route set this test checks.
+	if strings.Contains(args[0], "$") || strings.Contains(args[0], "%") ||
+		slices.Contains(fields, "-inet6") || strings.Contains(args[0], ":") {
+		return nil, false
+	}
+	return args, true
+}
+
+// appendStaticBlock records a static route destination, ignoring dynamic
+// (shell/batch variable) destinations.
+func appendStaticBlock(t *testing.T, blocks *[]routeBlock, raw string) {
+	t.Helper()
+
+	if strings.Contains(raw, "$") || strings.Contains(raw, "%") {
+		return
+	}
+	block := newRouteBlock(t, raw)
+	if block.prefix.IsValid() && !block.prefix.Addr().Is4() {
+		return // IPv6 blocks are not covered by the IPv4 probes
+	}
+	*blocks = append(*blocks, block)
+}
+
+// newRouteBlock builds a routeBlock from an "address/prefixlen" pair or from
+// an "address mask" pair. An unrecognized or malformed input yields an invalid
+// prefix, so callers report it instead of silently dropping the route.
+func newRouteBlock(t *testing.T, raw string) routeBlock {
+	t.Helper()
+
+	parts := strings.Fields(raw)
+	switch len(parts) {
+	case 1:
+		prefix, err := netip.ParsePrefix(parts[0])
+		if err != nil {
+			return routeBlock{raw: raw}
+		}
+		return routeBlock{raw: raw, prefix: prefix}
+	case 2:
+		addr, err := netip.ParseAddr(parts[0])
+		if err != nil {
+			t.Fatalf("route block %q: %v", raw, err)
+		}
+		mask := net.ParseIP(parts[1]).To4()
+		if mask == nil {
+			return routeBlock{raw: raw}
+		}
+		ones, bits := net.IPMask(mask).Size()
+		if bits != 32 {
+			return routeBlock{raw: raw}
+		}
+		prefix, err := addr.Prefix(ones)
+		if err != nil {
+			return routeBlock{raw: raw}
+		}
+		return routeBlock{raw: raw, prefix: prefix}
+	default:
+		t.Fatalf("unrecognized route block %q", raw)
+		return routeBlock{raw: raw}
+	}
+}

--- a/cmd/easyss/tun_helper_unix.go
+++ b/cmd/easyss/tun_helper_unix.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/nange/easyss/v3/client/proxy"
@@ -152,10 +153,40 @@ func runTunHelper(httpAddr, fdSocketPath, logFilePath, logLevel string) int {
 	}
 }
 
-// tunRouteProbe is a destination covered by the TUN routes (the darwin/linux
-// create scripts start at 1.0.0.0/8), used to verify the routes are still
-// present after sleep/wake or network changes.
-const tunRouteProbe = "1.1.1.1"
+// tunRouteProbes are destinations that must be covered by the TUN routes,
+// used to verify the routes are still present after sleep/wake or network
+// changes. The darwin/linux/Windows create scripts route 1.0.0.0/8 (and
+// everything up to 128.0.0.0/1) through the TUN device, so 1.1.1.1 — a real,
+// widely used DNS/HTTPS destination — has to resolve to it. If these probes
+// and the scripts ever drift apart, the keep-alive would report a failure
+// forever, so tun_helper_linux_test.go asserts that every probe falls inside
+// a route block defined by the create scripts.
+var tunRouteProbes = []string{"1.1.1.1"}
+
+// probeRoutedViaDevice looks every address in probe up with cmd and reports
+// whether any of them resolves through the TUN device: a covered address
+// resolves to the TUN device while TUN routes are in place, never to the
+// physical default route, so the lookup output must contain marker (the
+// device name). The last lookup's output and error are returned so the caller
+// can log why the check failed.
+func probeRoutedViaDevice(probe []string, cmd func(string) (string, error), marker string) (string, error) {
+	var (
+		out      string
+		err      error
+		lastAddr string
+	)
+	for _, addr := range probe {
+		out, err = cmd(addr)
+		if err == nil && strings.Contains(out, marker) {
+			return out, nil
+		}
+		lastAddr = addr
+	}
+	if err == nil {
+		err = fmt.Errorf("no probe resolved via %q (last %s)", marker, lastAddr)
+	}
+	return out, err
+}
 
 // fetchTunConfig retrieves the TUN configuration from the main process via
 // GET /tun. It retries with backoff for up to 10 seconds in case the HTTP

--- a/scripts/close_tun_dev_darwin.sh
+++ b/scripts/close_tun_dev_darwin.sh
@@ -16,10 +16,16 @@ route delete -net 64.0.0.0/2 "$tun_gw"
 route delete -net 128.0.0.0/1 "$tun_gw"
 route delete -net 198.18.0.0/15 "$tun_gw"
 
+# The create script no longer routes the local gateway into the TUN device: a
+# host route to it swallowed the kernel's ICMP replies to the gateway's own
+# liveness probes (see scripts/create_tun_dev.sh). The delete stays because
+# darwin keeps routes in the table across restarts, so it cleans up the route
+# older versions installed.
 route delete -net "$local_gateway" "$tun_gw"
 
 if [ -n "$server_ip_v6" ]; then
   route delete -inet6 -net ::/0 -gateway "$tun_gw_v6"
 
+  # Same as the IPv4 gateway route above: stale routes only.
   route delete -inet6 -net "$local_gateway_v6" -gateway "$tun_gw_v6"
 fi

--- a/scripts/create_tun_dev.sh
+++ b/scripts/create_tun_dev.sh
@@ -8,30 +8,46 @@ tun_gw_v6=$6
 server_ip_v6=$7
 local_gateway_v6=$8
 
-ip addr add "$tun_ip_sub" dev "$tun_device"  # add ipv4 addr to device
+# run_idem runs an idempotent ip command, tolerating the errors that
+# re-applying an already configured address produces (this script is re-run by
+# the TUN helper keep-alive after sleep/wake; replace/route replace are
+# no-ops that exit 0). Any other failure is echoed to stderr instead of being
+# swallowed silently: a rejected route (e.g. a non-canonical prefix) used to
+# leave the tunnel half configured with no trace at all.
+run_idem() {
+  local out
+  out="$("$@" 2>&1)" || case "$out" in
+    *"File exists"* | *"already assigned"*) ;;
+    *) echo "[create_tun_dev] $*: $out" >&2 ;;
+  esac
+}
+
+run_idem ip addr replace "$tun_ip_sub" dev "$tun_device"  # add ipv4 addr to device
 if [ -n "$server_ip_v6" ]; then  # check if server_ip_v6 is not empty
-  ip -6 addr add "$tun_ip_sub_v6" dev "$tun_device"  # add ipv6 addr to device
+  run_idem ip -6 addr replace "$tun_ip_sub_v6" dev "$tun_device"  # add ipv6 addr to device
 fi
 
-ip link set dev "$tun_device" up  # enable tun device
+run_idem ip link set dev "$tun_device" up  # enable tun device
 
 # Route everything except 0.0.0.0/8 through the TUN device, mirroring the
 # darwin script. 0.0.0.1 (used to probe the physical default interface)
-# must stay outside the TUN routes.
-ip route add 1.0.0.0/7 via "$tun_gw" dev "$tun_device"
-ip route add 4.0.0.0/6 via "$tun_gw" dev "$tun_device"
-ip route add 8.0.0.0/5 via "$tun_gw" dev "$tun_device"
-ip route add 16.0.0.0/4 via "$tun_gw" dev "$tun_device"
-ip route add 32.0.0.0/3 via "$tun_gw" dev "$tun_device"
-ip route add 64.0.0.0/2 via "$tun_gw" dev "$tun_device"
-ip route add 128.0.0.0/1 via "$tun_gw" dev "$tun_device"
-ip route add "$local_gateway" via "$tun_gw" dev "$tun_device"
+# must stay outside the TUN routes. Keep every prefix canonical (aligned with
+# its own mask): 1.0.0.0/7 normalizes to 0.0.0.0/7 and is rejected outright,
+# which used to leave 1.0.0.0/8 leaking outside the tunnel.
+run_idem ip route replace 1.0.0.0/8 via "$tun_gw" dev "$tun_device"
+run_idem ip route replace 4.0.0.0/6 via "$tun_gw" dev "$tun_device"
+run_idem ip route replace 8.0.0.0/5 via "$tun_gw" dev "$tun_device"
+run_idem ip route replace 16.0.0.0/4 via "$tun_gw" dev "$tun_device"
+run_idem ip route replace 32.0.0.0/3 via "$tun_gw" dev "$tun_device"
+run_idem ip route replace 64.0.0.0/2 via "$tun_gw" dev "$tun_device"
+run_idem ip route replace 128.0.0.0/1 via "$tun_gw" dev "$tun_device"
+run_idem ip route replace "$local_gateway" via "$tun_gw" dev "$tun_device"
 
 # add ipv6 ip route
 if [ -n "$server_ip_v6" ]; then  # check if server_ip_v6 is not empty
-  ip -6 route add ::/1 via "$tun_gw_v6" dev "$tun_device"
-  ip -6 route add 8000::/1 via "$tun_gw_v6" dev "$tun_device"
+  run_idem ip -6 route replace ::/1 via "$tun_gw_v6" dev "$tun_device"
+  run_idem ip -6 route replace 8000::/1 via "$tun_gw_v6" dev "$tun_device"
   if [ -n "$local_gateway_v6" ]; then
-    ip -6 route add "$local_gateway_v6" via "$tun_gw_v6" dev "$tun_device"
+    run_idem ip -6 route replace "$local_gateway_v6" via "$tun_gw_v6" dev "$tun_device"
   fi
 fi

--- a/scripts/create_tun_dev.sh
+++ b/scripts/create_tun_dev.sh
@@ -41,13 +41,22 @@ run_idem ip route replace 16.0.0.0/4 via "$tun_gw" dev "$tun_device"
 run_idem ip route replace 32.0.0.0/3 via "$tun_gw" dev "$tun_device"
 run_idem ip route replace 64.0.0.0/2 via "$tun_gw" dev "$tun_device"
 run_idem ip route replace 128.0.0.0/1 via "$tun_gw" dev "$tun_device"
-run_idem ip route replace "$local_gateway" via "$tun_gw" dev "$tun_device"
+
+# The local gateway ($local_gateway and $local_gateway_v6) is deliberately NOT
+# routed into the TUN device. A bare address is installed as a /32 host route,
+# so it would beat the physical interface's on-link connected route (e.g.
+# 192.168.3.0/24) and pull every packet addressed to the gateway into the
+# tunnel — including the kernel's ICMP echo replies to the gateway's own
+# liveness probes. tun2socks' default ICMP forwarder only answers echo
+# requests (type 8) and drops every other type, so those replies never reach
+# the gateway: it keeps probing forever (observed as several [ICMP_DIRECT]
+# log lines per second) and `ping <gateway>` only ever reports a synthetic
+# sub-millisecond reply. The gateway must therefore stay on the physical
+# interface, exactly like the darwin script, which dropped the same route in
+# 91bb4c6 ("fix: ip route on darwin when enable tun2socks").
 
 # add ipv6 ip route
 if [ -n "$server_ip_v6" ]; then  # check if server_ip_v6 is not empty
   run_idem ip -6 route replace ::/1 via "$tun_gw_v6" dev "$tun_device"
   run_idem ip -6 route replace 8000::/1 via "$tun_gw_v6" dev "$tun_device"
-  if [ -n "$local_gateway_v6" ]; then
-    run_idem ip -6 route replace "$local_gateway_v6" via "$tun_gw_v6" dev "$tun_device"
-  fi
 fi

--- a/util/sys.go
+++ b/util/sys.go
@@ -85,7 +85,7 @@ var errUnsupportedPlatform = errors.New("unsupported platform")
 // own default route when netsh configures the static gateway); the easyss TUN
 // interface is skipped so the physical interface is returned. On darwin and
 // linux the caller probes 0.0.0.1 instead — the easyss TUN routes start at
-// 1.0.0.0/7 on every platform, so 0.0.0.1 always resolves to the physical
+// 1.0.0.0/8 on every platform, so 0.0.0.1 always resolves to the physical
 // default interface (Windows cannot use the probe: its route lookup rejects
 // 0.0.0.0/8 destinations outright).
 func SysDefaultRoute() (iface *net.Interface, gateway net.IP, err error) {
@@ -117,7 +117,7 @@ func SysGatewayAndDevice() (gw string, dev string, err error) {
 	}
 
 	// Fallback (darwin, linux and other platforms): probe 0.0.0.1, which the
-	// easyss TUN routes (starting at 1.0.0.0/7 on every platform) never cover.
+	// easyss TUN routes (starting at 1.0.0.0/8 on every platform) never cover.
 	r, _ := netroute.New()
 	iface, gateway, _, err = r.Route(net.IPv4(0, 0, 0, 1))
 	if err != nil {

--- a/util/sys_windows_test.go
+++ b/util/sys_windows_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 func TestDefaultRouteCandidates(t *testing.T) {
-	// easyss TUN routes (1.0.0.0/7 … and the netsh-added 0.0.0.0/0 on the
-	// TUN device) plus two physical default routes with different metrics.
+	// easyss TUN routes (1.0.0.0/8 …, plus 1.0.0.0/7 left behind by an older
+	// Linux script, and the netsh-added 0.0.0.0/0 on the TUN device) plus two
+	// physical default routes with different metrics.
 	rows := []mibIpforwardrow{
-		{dest: 0x01000000, mask: 0xFE000000, ifIndex: 10, metric1: 5},                      // TUN 1.0.0.0/7
+		{dest: 0x01000000, mask: 0xFE000000, ifIndex: 10, metric1: 5},                      // stale TUN 1.0.0.0/7
 		{dest: 0x80000000, mask: 0x80000000, ifIndex: 10, metric1: 5},                      // TUN 128.0.0.0/1
 		{dest: 0x00000000, mask: 0x00000000, ifIndex: 10, metric1: 6, nextHop: 0x010214AC}, // TUN default (netsh)
 		{dest: 0x00000000, mask: 0x00000000, ifIndex: 5, metric1: 35, nextHop: 0xC0A80101}, // physical default


### PR DESCRIPTION
## 背景

客户端开启 TUN 后，日志每秒刷出数条 `[ICMP_DIRECT] dst=<网关>`（实测 1435 秒中有 1405 秒恰好 6 条/秒，约 50 万行/天）。这不是单纯的日志噪音：它意味着**网关 ping 本机的回包被吞掉，网关一直在重试**。

10 秒窗口的现场测量（数字一一对应）：

| 指标 | 增量 |
| --- | --- |
| 日志 `[ICMP_DIRECT]` | 36 |
| `InEchos`（本机收到 echo 请求 = 网关探测） | 36 |
| `OutEchoReps`（内核发出 echo 回包） | 36 |
| `OutEchos`（本机主动 ping） | 0 |

链路：Linux 创建脚本用裸地址执行 `ip route replace "$local_gateway"`，iproute2 把它当作 **/32 主机路由**，比物理网卡的 /24 直连路由更具体 —— 于是所有发往网关的报文（包括内核对网关探测的 ICMP 回包）都进入 TUN；tun2socks 默认 ICMP 转发器只应答 echo 请求（type 8），`type 0` 等一律丢弃 —— 网关永远收不到回包，只能持续探测。副作用是 `ping 网关` 只返回 tun2socks 伪造的 0.3ms 延迟，无法用来判断局域网质量。

macOS 已在 `91bb4c6` 删掉同样的路由，Linux 属于漏改。

## 改动

**提交 1 `fix: install tun routes idempotently and probe every route block`**
- `scripts/create_tun_dev.sh`：安装 `1.0.0.0/8` 取代无法安装的 `1.0.0.0/7`（非规范前缀被 iproute2 拒绝，导致 1.0.0.0/8 静默泄漏在隧道外、保活每 10s 报一次 "route check failed"）；`ip` 调用统一包进 `run_idem`，重复执行不再误报失败，其它错误回显到 stderr。
- `cmd/easyss`：新增 `probeRoutedViaDevice`，对 `tunRouteProbes` 里的每个地址做路由探测，全部不匹配时报告最后一次查询结果，并在日志中输出完整探测列表。
- `client`、`util`：注释与 Windows 路由测试跟上 `1.0.0.0/8`（保留一行遗留的 `1.0.0.0/7` 作为覆盖）。
- 新增 `cmd/easyss/tun_helper_linux_test.go`：解析各平台创建脚本的路由块、断言保活探测都落在其中，并在临时 netns 里真跑 Linux 脚本，校验路由、`0.0.0.0/8` 排除与幂等重复执行。

**提交 2 `fix: keep the local gateway outside the tun routes`**
- `scripts/create_tun_dev.sh`：不再把 `$local_gateway` / `$local_gateway_v6` 路由进 TUN，并写明原因。
- `client/tun/icmp.go`：只有 echo 请求（真正能路由/代理的报文）记 INFO；回包、ICMP 错误、邻居发现等改为 Debug 并带上 `type` —— 这些报文本来也会被默认转发器丢弃，分类日志没有意义却会刷屏。INFO 日志同时追加 `type` 属性便于排查。
- 测试：netns 断言改为「网关必须走物理网卡」，并新增跨平台回归测试，禁止任何创建脚本再把本地网关路由进 TUN。

## 验证

- `go test ./...` 全绿、`make lint` 0 issues；**两个提交各自都能通过**（提交 1 的树单独验证过）。
- 回归测试有效性：把网关路由临时加回脚本，`TestCreateScriptsKeepGatewayOutsideTun` 与 netns 断言立即失败。
- 重启 TUN 后的预期：`ip route get <网关>` 显示物理网卡、`ping 网关` 恢复真实 RTT、`[ICMP_DIRECT]` 刷屏消失、`InEchos` 增速回落。
- 说明：`scripts/close_tun_dev_darwin.sh` 中两条 `route delete` 保留（darwin 的路由会跨进程保留，它们用于清理旧版本留下的残留），本次只补注释。
