### PR TITLE
fix: clear the tun interface and its routes when tun stops

### DIFF
--- a/cmd/easyss/tray.go
+++ b/cmd/easyss/tray.go
@@ -576,19 +576,25 @@ func (a *TrayApp) closeTun2socks() error {
 	a.tunHelperMu.Lock()
 	defer a.tunHelperMu.Unlock()
 
-	// 1. Signal the helper to shut down by closing the FIFO.
+	// 1. Stop the tun2socks engine first: it closes the TUN fd that the helper
+	//    passed to this process. The helper's close script deletes the
+	//    interface, and iproute2 cannot delete a device that is still attached
+	//    to a fd — it fails with "device or resource busy" and leaves the
+	//    interface behind, together with every TUN route (they are bound to
+	//    it). Traffic then keeps entering a device nothing reads from, which
+	//    looks like "the network is down" after TUN is stopped.
+	if a.tunMgr != nil {
+		log.Info("[SYSTRAY] closeTun2socks: stopping tun2socks engine")
+		a.tunMgr.Stop()
+		a.tunMgr = nil
+	}
+
+	// 2. Signal the helper to shut down by closing the FIFO.
 	//    The helper detects EOF on stdin, cleans up routes/DNS, and exits.
 	if a.tunHelperStdin != nil {
 		log.Info("[SYSTRAY] closeTun2socks: closing helper FIFO")
 		a.tunHelperStdin.Close() //nolint:errcheck
 		a.tunHelperStdin = nil
-	}
-
-	// 2. Stop the tun2socks engine (no route/DNS cleanup — helper handles it).
-	if a.tunMgr != nil {
-		log.Info("[SYSTRAY] closeTun2socks: stopping tun2socks engine")
-		a.tunMgr.Stop()
-		a.tunMgr = nil
 	}
 
 	// 3. The helper coordinates with any previous instance via a file lock

--- a/cmd/easyss/tun_helper_darwin.go
+++ b/cmd/easyss/tun_helper_darwin.go
@@ -108,6 +108,16 @@ func runCloseScript(device, tunGW, localGateway, tunGWV6, serverIPV6, localGatew
 	return nil
 }
 
+// removeLeftoverDevice reports a TUN interface that survived the close script.
+// The routes themselves are deleted by prefix in the close script, and a utun
+// interface disappears with the last fd that holds it, so there is nothing to
+// force here: the check only makes a lingering interface visible.
+func removeLeftoverDevice(device string) {
+	if _, err := util.Command("ifconfig", device); err == nil {
+		log.Warn("[TUN-HELPER] tun device survived cleanup", "device", device)
+	}
+}
+
 // ensureTunRoutes verifies the TUN interface is still up and the TUN routes
 // are still present, re-running the create script when macOS cleared them
 // (sleep/wake or network changes). Errors from re-applying existing

--- a/cmd/easyss/tun_helper_linux.go
+++ b/cmd/easyss/tun_helper_linux.go
@@ -59,6 +59,18 @@ func openTunDevice(name string) (int, string, error) {
 	}
 	actualName := string(ifr.name[:namelen])
 
+	// The interface may already exist as a *persistent* TUN device: older
+	// easyss versions created it with "ip tuntap add mode tun" from the create
+	// script, and TUNSETIFF above happily re-attaches to such a device without
+	// touching the flag. A persistent device outlives the fds that hold it, so
+	// a failed delete at shutdown (see removeLeftoverDevice) leaves the
+	// interface and every TUN route in the routing table forever. Clearing the
+	// flag makes the device disappear with the last fd again, which is what
+	// the fd-passing helper design expects.
+	if err := unix.IoctlSetInt(fd, unix.TUNSETPERSIST, 0); err != nil {
+		log.Warn("[TUN-HELPER] clear tun persist flag", "device", actualName, "err", err)
+	}
+
 	return fd, actualName, nil
 }
 
@@ -99,6 +111,27 @@ func runCloseScript(device, tunGW, localGateway, tunGWV6, serverIPV6, localGatew
 
 	_, _ = util.Command("bash", namePath, device, tunGW, localGateway, tunGWV6, serverIPV6, localGatewayV6)
 	return nil
+}
+
+// removeLeftoverDevice deletes the TUN interface when it survived the close
+// script. Deleting the interface is what takes the TUN routes with it, and the
+// close script's own "ip tuntap del" cannot do that while a process still
+// holds the device open: iproute2 attaches through TUNSETIFF, and the kernel
+// refuses a second attach to a device that is already attached ("device or
+// resource busy"). The client closes its fd concurrently with the close
+// script, so that delete used to fail and leave the interface plus every split
+// route in the routing table: all traffic then entered a device nothing reads
+// from, which looks like "the network is down" after stopping TUN. "ip link
+// del" tears the interface down regardless of open fds.
+func removeLeftoverDevice(device string) {
+	if _, err := util.Command("ip", "link", "show", device); err != nil {
+		return // the close script already deleted it
+	}
+
+	log.Warn("[TUN-HELPER] tun device survived cleanup, deleting it", "device", device)
+	if _, err := util.Command("ip", "link", "del", device); err != nil {
+		log.Error("[TUN-HELPER] delete tun device failed", "device", device, "err", err)
+	}
 }
 
 // ensureTunRoutes verifies the TUN interface is still up and the TUN routes

--- a/cmd/easyss/tun_helper_linux_test.go
+++ b/cmd/easyss/tun_helper_linux_test.go
@@ -142,24 +142,10 @@ func TestCreateScriptsKeepGatewayOutsideTun(t *testing.T) {
 // inside an unprivileged user namespace; the ip commands the script issues are
 // identical for both device types. No root privileges are needed.
 func TestCreateTunScriptRoutesThroughTun(t *testing.T) {
-	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", scripts.CreateTunFilename))
-	if err != nil {
-		t.Fatalf("resolve script path: %v", err)
-	}
-
 	// The first invocation creates the device and adds the addresses, exactly
 	// like the helper right after it opened the device.
-	create := runCreateTunScript(scriptPath)
-	tunSetup := `ip link add "` + testTunDevice + `" type dummy && ip link set dev lo up`
-	// The simulated physical interface carries the LAN address as well as a
-	// subnet of its own: the LAN connected route is what a real interface has,
-	// and the extra subnet's default route keeps 0.0.0.0/8 interesting for the
-	// negative probe (0.0.0.1 must resolve, just not through the TUN device).
-	physSetup := fmt.Sprintf(`ip link add %s type dummy && ip addr add %s dev %s`+
-		` && ip addr add %s dev %s && ip link set %s up && ip route add default via %s dev %s`,
-		testPhysDevice, testPhysAddr, testPhysDevice, testPhysLANAddr, testPhysDevice,
-		testPhysDevice, testPhysGateway, testPhysDevice)
-	setup := tunSetup + "\n" + physSetup
+	create := runCreateTunScript(tunScriptPath(t, scripts.CreateTunFilename))
+	setup := tunIfaceSetup() + "\n" + physIfaceSetup()
 
 	t.Run("routes installed", func(t *testing.T) {
 		out := inNetns(t, setup+"\n"+create+"\n"+routesAndProbes())
@@ -174,6 +160,78 @@ func TestCreateTunScriptRoutesThroughTun(t *testing.T) {
 			t.Errorf("1.0.0.0/8 appears %d times after a re-run, want 1:\n%s", n, out)
 		}
 	})
+}
+
+// TestCloseTunScriptFlushesRoutes is the regression test for the TUN routes
+// that survived stopping TUN and black-holed every connection. Deleting the
+// interface is what removes its routes, but that delete fails with "device or
+// resource busy" while a process still holds the TUN device open (the client
+// closes its fd concurrently with the close script), so the close script has
+// to delete the routes itself.
+//
+// The device is a dummy interface, which "ip tuntap del" cannot delete either
+// — the very condition this test needs: the routes can only disappear through
+// the flush.
+func TestCloseTunScriptFlushesRoutes(t *testing.T) {
+	closeTun := fmt.Sprintf("bash %s %s",
+		tunScriptPath(t, scripts.CloseTunFilename), testTunDevice)
+
+	// The device surviving the close script is what makes this test
+	// meaningful: assert it stayed, otherwise the routes could just as well
+	// have gone down with it.
+	const keptMarker = "DEVICE_KEPT"
+
+	body := strings.Join([]string{
+		tunIfaceSetup(),
+		physIfaceSetup(),
+		runCreateTunScript(tunScriptPath(t, scripts.CreateTunFilename)),
+		closeTun,
+		"ip link show " + testTunDevice + " >/dev/null 2>&1 && echo " + keptMarker,
+		routesAndProbes(),
+	}, "\n")
+
+	out := inNetns(t, body)
+
+	if !strings.Contains(out, keptMarker) {
+		t.Fatalf("the simulated device is gone, the route assertions below prove nothing:\n%s", out)
+	}
+	if table := routesTable(out); strings.Contains(table, "dev "+testTunDevice) {
+		t.Errorf("the close script left TUN routes behind:\n%s", table)
+	}
+	for _, addr := range testCoveredAddrs {
+		if got := probeOutput(out, addr); strings.Contains(got, "dev "+testTunDevice) {
+			t.Errorf("ip route get %s = %q, want it to leave the TUN device", addr, got)
+		}
+	}
+}
+
+// tunScriptPath returns the absolute path of an embedded script, so a test
+// runs the same file the helper executes.
+func tunScriptPath(t *testing.T, name string) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("..", "..", "scripts", name))
+	if err != nil {
+		t.Fatalf("resolve %s: %v", name, err)
+	}
+	return path
+}
+
+// tunIfaceSetup creates the dummy interface that stands in for the TUN device.
+func tunIfaceSetup() string {
+	return `ip link add "` + testTunDevice + `" type dummy && ip link set dev lo up`
+}
+
+// physIfaceSetup creates the simulated physical interface. It carries the LAN
+// address as well as a subnet of its own: the LAN connected route is what a
+// real interface has, and the extra subnet's default route keeps 0.0.0.0/8
+// interesting for the negative probe (0.0.0.1 must resolve, just not through
+// the TUN device).
+func physIfaceSetup() string {
+	return fmt.Sprintf(`ip link add %s type dummy && ip addr add %s dev %s`+
+		` && ip addr add %s dev %s && ip link set %s up && ip route add default via %s dev %s`,
+		testPhysDevice, testPhysAddr, testPhysDevice, testPhysLANAddr, testPhysDevice,
+		testPhysDevice, testPhysGateway, testPhysDevice)
 }
 
 // routesAndProbes dumps the resulting routing table and one marked "ip route

--- a/cmd/easyss/tun_helper_unix.go
+++ b/cmd/easyss/tun_helper_unix.go
@@ -77,6 +77,7 @@ func runTunHelper(httpAddr, fdSocketPath, logFilePath, logLevel string) int {
 		log.Info("[TUN-HELPER] cleaning up routes and DNS")
 		_ = runCloseScript(actualDevice, cfg.TunGW, cfg.LocalGateway,
 			cfg.TunGWV6, cfg.ServerIPV6, cfg.LocalGatewayV6)
+		removeLeftoverDevice(actualDevice)
 		_ = restoreDNS(originDNS)
 		log.Info("[TUN-HELPER] cleanup done")
 	}()
@@ -389,6 +390,12 @@ func ReceiveFd(listener net.Listener) (int, error) {
 			recvErr = fmt.Errorf("no fd received")
 			return
 		}
+
+		// Keep the TUN fd out of any child process: the client execs pkexec
+		// (which execs the next helper) while it may still hold this fd, and
+		// an inherited copy keeps the interface attached, so the helper's
+		// cleanup and the next start fail with "device or resource busy".
+		unix.CloseOnExec(fds[0])
 
 		result = fds[0]
 	})

--- a/scripts/close_tun_dev.sh
+++ b/scripts/close_tun_dev.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 tun_device=$1
 
+# Flush the TUN routes before deleting the interface. Deleting the interface
+# drops them too, but that delete fails with "device or resource busy" while a
+# process still holds the TUN fd open (iproute2 attaches through TUNSETIFF, and
+# the client closes its fd concurrently with this script), and the split routes
+# then survive: every connection addressed to them enters an interface that
+# nothing reads from, which looks like "the network is down" after stopping
+# TUN. Best effort and silent when the interface is already gone.
+ip route flush dev "$tun_device" >/dev/null 2>&1
+ip -6 route flush dev "$tun_device" >/dev/null 2>&1
+
 ip tuntap del mode tun dev "$tun_device"


### PR DESCRIPTION
## 现象

启动 TUN 后再关闭 TUN（或退出客户端），**接口的路由没有被删除**：`1.0.0.0/8 … 128.0.0.0/1` 依然在路由表里指向 `tun-easyss`，所有流量进入一个没人读的设备 —— 表现为"网络不通"，只能手动删路由恢复。

## 现场证据

```
20:23:14.490  [SYSTRAY] closeTun2socks: closing helper FIFO      ← 先关助手 FIFO
20:23:14.490  [TUN-HELPER] cleaning up routes and DNS            ← 助手立刻执行 ip tuntap del
20:23:14.490  [TUN] Stop: calling engine.Stop                    ← 此刻客户端仍持有 TUN fd
20:23:14.501  [TUN-HELPER] cleanup done                          ← 脚本"成功"，实际什么都没删掉
20:24:35.791  [TUN-HELPER] open tun device err="ioctl(TUNSETIFF): device or resource busy"
```

第二次开启时的 `device or resource busy` 证明接口当时仍被 fd 占用：iproute2 删除接口时走 TUNSETIFF 再附加一次，而内核拒绝第二次附加已附加的设备。助手忽略该错误，于是接口、以及以接口为宿主的路由全部留存。如果接口本身还是**持久设备**（老版本 create 脚本用过 `ip tuntap add`，见 `d6f10e8`，`ad6e581` 才移除），那么退出客户端、fd 全部释放后接口依然存在，路由自然也不会消失。

## 根因（三层，互相叠加）

1. **顺序竞态**：`closeTun2socks()` 先关助手 FIFO、再停 engine；助手收到 EOF 立即删接口，而客户端的 TUN fd 还没关 → `ip tuntap del` 必然失败。
2. **持久设备**：老版本 `ip tuntap add` 建立的接口不随 fd 消失，一次删除失败就永久残留。
3. **fd 继承**：`ReceiveFd` 收到的 fd 没有 close-on-exec，客户端后续 exec 的 pkexec / 下一个助手会继承它，既让设备保持占用，又导致下一次开启 EBUSY。

## 改动

- `cmd/easyss/tray.go`：先停 engine（关闭 TUN fd）再关助手 FIFO，消除竞态。
- `scripts/close_tun_dev.sh`：删接口前先 `ip route flush dev` / `ip -6 route flush dev`，即使接口删不掉也能清掉路由（darwin 脚本本来就是按前缀删路由）。
- `cmd/easyss/tun_helper_linux.go`：打开设备后显式清除 `TUNSETPERSIST`，让接口重新随最后一个 fd 消失；新增 `removeLeftoverDevice`，清理后若接口仍在则用 `ip link del` 强制拆除（该命令不受 fd 占用限制）。
- `cmd/easyss/tun_helper_darwin.go`：对应函数只做检查与告警（utun 随 fd 消失，路由由 close 脚本按前缀删除）。
- `cmd/easyss/tun_helper_unix.go`：`ReceiveFd` 对收到的 fd 设置 close-on-exec（darwin 无 `MSG_CMSG_CLOEXEC`，故用 `unix.CloseOnExec`）。
- `cmd/easyss/tun_helper_linux_test.go`：新增 `TestCloseTunScriptFlushesRoutes`，在 netns 里用 dummy 接口（`ip tuntap del` 同样删不掉它）跑真实 close 脚本，断言路由被清空。

## 与上一个 PR 无关

`git diff 17fd35b 5f7e4b2 --name-only` 显示 #155 未触碰 `tray.go`、`close_tun_dev.sh`（仅 darwin close 加注释）、`openTunDevice` 与 fd 传递路径；这条"先关 FIFO 再停 engine"的顺序自 #103 起就存在。日志里更早的两次关闭（18:50、20:14）都是**退出整个客户端**，进程退出释放 fd、非持久接口随之消失，因此没暴露出来；20:23 是第一次"只关 TUN、客户端继续运行"。

## 验证

- `TestCloseTunScriptFlushesRoutes`：**去掉 flush 两行，测试立即失败**并打印 `1.1.1.1 dev tun-easyss ...`（正是断网状态）；加回后通过。
- `go test ./...` 全绿、`make lint` 0 issues、`go build ./...` 与 darwin/arm64、windows/amd64 交叉编译通过。
- 现场实测（Linux，两次开关 TUN 循环）：
  - 新顺序生效：`[TUN] Stop: engine.Stop done` 先于 `closing helper FIFO` 与助手清理；
  - 无 `clear tun persist flag` 告警 → `TUNSETPERSIST 0` 成功；
  - 无 `tun device survived cleanup` 告警 → close 脚本本身就删掉了接口，强制删除仅作兜底；
  - 立刻再次开启 TUN 正常（不再 `device or resource busy`），路由已被清除。

## 排查小贴士

`ip -d link show <tun>` **无条件**打印 `persist %s` 关键字，所以 `grep -c persist` 恒为 1，不能用来判断持久位；要看值请用：

```bash
ip -d link show tun-easyss | grep -o 'persist [a-z]*'   # persist off
```
