### PR TITLE
fix: pin the resolver to the tun device while tun mode is active

### DIFF
--- a/client/tun/tun.go
+++ b/client/tun/tun.go
@@ -423,7 +423,11 @@ func (m *Manager) saveAndSetDNS() error {
 
 	if m.cfg.DNSServer != "" {
 		if runtime.GOOS == "linux" {
-			return util.SetSysDNS([]string{m.cfg.DNSServer})
+			// Linux also has to pin the resolver to the TUN device: a DNS
+			// server configured for the physical link only is queried with
+			// the socket bound to that link, so its lookups leave through the
+			// physical NIC and bypass the tunnel (see util.SetSysDNSForTun).
+			return util.SetSysDNSForTun(m.dev.Device, []string{m.cfg.DNSServer})
 		}
 		// Darwin: only override DNS when the system has no custom DNS
 		// configured (i.e. using DHCP-provided DNS). If the user has
@@ -436,6 +440,10 @@ func (m *Manager) saveAndSetDNS() error {
 }
 
 func (m *Manager) restoreDNS() error {
+	if runtime.GOOS == "linux" {
+		return util.RestoreSysDNSForTun(m.dev.Device, m.originDNS)
+	}
+
 	if len(m.originDNS) == 0 {
 		return setSysDNSWithElevation([]string{"empty"})
 	}

--- a/cmd/easyss/tun_helper_unix.go
+++ b/cmd/easyss/tun_helper_unix.go
@@ -78,7 +78,7 @@ func runTunHelper(httpAddr, fdSocketPath, logFilePath, logLevel string) int {
 		_ = runCloseScript(actualDevice, cfg.TunGW, cfg.LocalGateway,
 			cfg.TunGWV6, cfg.ServerIPV6, cfg.LocalGatewayV6)
 		removeLeftoverDevice(actualDevice)
-		_ = restoreDNS(originDNS)
+		_ = util.RestoreSysDNSForTun(actualDevice, originDNS)
 		log.Info("[TUN-HELPER] cleanup done")
 	}()
 
@@ -104,7 +104,7 @@ func runTunHelper(httpAddr, fdSocketPath, logFilePath, logLevel string) int {
 	// 8. Set system DNS.
 	if cfg.DNSAddr != "" {
 		log.Info("[TUN-HELPER] setting system dns", "dns", cfg.DNSAddr)
-		if err := util.SetSysDNS([]string{cfg.DNSAddr}); err != nil {
+		if err := util.SetSysDNSForTun(actualDevice, []string{cfg.DNSAddr}); err != nil {
 			log.Warn("[TUN-HELPER] set dns", "err", err)
 		}
 	}
@@ -149,6 +149,14 @@ func runTunHelper(httpAddr, fdSocketPath, logFilePath, logLevel string) int {
 		case <-ticker.C:
 			if err := ensureTunRoutes(actualDevice, cfg); err != nil {
 				log.Warn("[TUN-HELPER] route keep-alive check failed", "device", actualDevice, "err", err)
+			}
+			// NetworkManager rewrites the link DNS settings when the connection
+			// changes and can hand the DNS default route back to the physical
+			// link, which lets resolution bypass the tunnel again.
+			if cfg.DNSAddr != "" {
+				if err := util.EnsureSysDNSForTun(actualDevice, []string{cfg.DNSAddr}); err != nil {
+					log.Warn("[TUN-HELPER] dns keep-alive check failed", "device", actualDevice, "err", err)
+				}
 			}
 		}
 	}
@@ -267,33 +275,6 @@ func sendFdToParent(socketPath string, tunFd int) error {
 
 	log.Info("[TUN-HELPER] fd sent via unix socket", "socket", socketPath)
 	return nil
-}
-
-// restoreDNS restores the system DNS to the original servers.
-func restoreDNS(originDNS []string) error {
-	if len(originDNS) == 0 {
-		return util.SetSysDNS([]string{"empty"})
-	}
-	curr, err := util.SysDNS()
-	if err != nil {
-		return err
-	}
-	if !stringSliceEqual(originDNS, curr) {
-		return util.SetSysDNS(originDNS)
-	}
-	return nil
-}
-
-func stringSliceEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // flockWait acquires an exclusive lock on f, retrying until the lock is

--- a/util/sysdns_linux.go
+++ b/util/sysdns_linux.go
@@ -5,9 +5,11 @@ package util
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -98,4 +100,111 @@ func SysDNSViaOSAScript() ([]string, error) {
 
 func SetSysDNSViaOSAScript(servers []string) error {
 	return fmt.Errorf("SetSysDNSViaOSAScript is only supported on macOS")
+}
+
+// tunDNSCommand runs the resolvectl invocations of the TUN DNS setup. It is a
+// variable so that tests can assert the issued commands without touching the
+// resolver of the machine running them.
+var tunDNSCommand = func(name string, args ...string) (string, error) {
+	return Command(name, args...)
+}
+
+// SetSysDNSForTun configures DNS resolution for TUN mode: the TUN device
+// becomes the DNS default-route link with the resolver of its own, and the
+// physical link stops being one.
+//
+// The per-link part is what makes resolution usable at all. systemd-resolved
+// queries the resolver of a link with the socket pinned to that link's device,
+// so the physical link's resolver sends its queries out of the physical NIC
+// and therefore past the TUN routes: a public resolver cannot answer for a
+// blocked domain, and the client then connects to whatever address the
+// polluted path returned. Pinned to the TUN device, exactly the same query
+// enters the tunnel instead, where easyss routes it by domain — direct for CN
+// names, through the server for everything else.
+func SetSysDNSForTun(tunDevice string, v []string) error {
+	// The system DNS below is what programs that read /etc/resolv.conf or ask
+	// for the link configuration keep using; it is best-effort like before.
+	return errors.Join(setTunLinkDNS(tunDevice, v), SetSysDNS(v))
+}
+
+// EnsureSysDNSForTun re-asserts the TUN DNS state. NetworkManager rewrites a
+// link's DNS settings when the connection changes (roaming, DHCP renew), and
+// one of those rewrites makes the physical link the DNS default route again,
+// which is the state that lets resolution bypass the tunnel.
+func EnsureSysDNSForTun(tunDevice string, v []string) error {
+	iface, err := defaultInterface()
+	if err != nil {
+		return fmt.Errorf("find default interface: %w", err)
+	}
+
+	out, err := tunDNSCommand("resolvectl", "default-route", iface)
+	if err == nil && resolvectlBool(out) == "no" {
+		return nil
+	}
+	return setTunLinkDNS(tunDevice, v)
+}
+
+// RestoreSysDNSForTun undoes SetSysDNSForTun. The TUN link's own settings
+// disappear with the interface, so only the physical link has to be handed
+// back to the resolver, besides restoring the servers the caller saved.
+func RestoreSysDNSForTun(tunDevice string, origin []string) error {
+	var errs []error
+
+	// Best-effort: the interface is usually gone by now, which also drops the
+	// per-link state below.
+	if _, err := tunDNSCommand("resolvectl", "revert", tunDevice); err != nil {
+		errs = append(errs, fmt.Errorf("resolvectl revert %s: %w", tunDevice, err))
+	}
+	if iface, err := defaultInterface(); err == nil {
+		if _, err := tunDNSCommand("resolvectl", "default-route", iface, "yes"); err != nil {
+			errs = append(errs, fmt.Errorf("resolvectl default-route %s yes: %w", iface, err))
+		}
+	}
+
+	if len(origin) == 0 {
+		return errors.Join(append(errs, SetSysDNS([]string{"empty"}))...)
+	}
+	curr, err := SysDNS()
+	if err != nil {
+		return errors.Join(append(errs, err)...)
+	}
+	if slices.Equal(curr, origin) {
+		return errors.Join(errs...)
+	}
+	return errors.Join(append(errs, SetSysDNS(origin))...)
+}
+
+// setTunLinkDNS pins the resolver to the TUN device and keeps the physical
+// link out of the DNS default route.
+func setTunLinkDNS(tunDevice string, v []string) error {
+	iface, err := defaultInterface()
+	if err != nil {
+		return fmt.Errorf("find default interface: %w", err)
+	}
+
+	args := append([]string{"dns", tunDevice}, v...)
+	if _, err := tunDNSCommand("resolvectl", args...); err != nil {
+		return fmt.Errorf("resolvectl dns %s: %w", tunDevice, err)
+	}
+
+	for _, cmd := range [][]string{
+		{"domain", tunDevice, "~."},
+		{"default-route", tunDevice, "yes"},
+		{"default-route", iface, "no"},
+	} {
+		if _, err := tunDNSCommand("resolvectl", cmd...); err != nil {
+			return fmt.Errorf("resolvectl %s: %w", strings.Join(cmd, " "), err)
+		}
+	}
+	return nil
+}
+
+// resolvectlBool returns the trailing "yes"/"no" of a resolvectl setting
+// output such as "Link 2 (eno1): no", so that a link name never matches.
+func resolvectlBool(out string) string {
+	idx := strings.LastIndex(out, ":")
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(out[idx+1:])
 }

--- a/util/sysdns_linux_test.go
+++ b/util/sysdns_linux_test.go
@@ -1,0 +1,111 @@
+//go:build linux
+
+package util
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// recordingTunDNS replaces tunDNSCommand so the DNS setup can be asserted
+// without touching the resolver of the machine running the test.
+type recordingTunDNS struct {
+	commands [][]string
+	replies  map[string]string
+}
+
+func (r *recordingTunDNS) run(name string, args ...string) (string, error) {
+	cmd := append([]string{name}, args...)
+	r.commands = append(r.commands, cmd)
+	return r.replies[strings.Join(cmd, " ")], nil
+}
+
+func (r *recordingTunDNS) install(t *testing.T) {
+	t.Helper()
+
+	restore := tunDNSCommand
+	tunDNSCommand = r.run
+	t.Cleanup(func() { tunDNSCommand = restore })
+}
+
+func TestSetTunLinkDNSPinsResolverToTun(t *testing.T) {
+	iface, err := defaultInterface()
+	if err != nil {
+		t.Skipf("no default interface in this environment: %v", err)
+	}
+
+	rec := &recordingTunDNS{}
+	rec.install(t)
+
+	if err := setTunLinkDNS("tun-easyss", []string{"223.5.5.5"}); err != nil {
+		t.Fatalf("setTunLinkDNS: %v", err)
+	}
+
+	want := [][]string{
+		{"resolvectl", "dns", "tun-easyss", "223.5.5.5"},
+		{"resolvectl", "domain", "tun-easyss", "~."},
+		{"resolvectl", "default-route", "tun-easyss", "yes"},
+		{"resolvectl", "default-route", iface, "no"},
+	}
+	if !reflect.DeepEqual(rec.commands, want) {
+		t.Errorf("commands = %v, want %v", rec.commands, want)
+	}
+}
+
+func TestEnsureSysDNSForTunReassertsState(t *testing.T) {
+	iface, err := defaultInterface()
+	if err != nil {
+		t.Skipf("no default interface in this environment: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		// reply is what the "resolvectl default-route <link>" lookup returns.
+		reply string
+		// wantCmds counts that lookup plus whatever had to be re-applied.
+		wantCmds int
+	}{
+		// The physical link is still out of the DNS default route: the TUN
+		// state survived and only the lookup was issued.
+		{"state in place", "Link 2 (" + iface + "): no", 1},
+		// NetworkManager handed the DNS default route back to the physical
+		// link: resolution would bypass the tunnel again, so the state is
+		// re-applied (lookup + four commands).
+		{"physical link took it back", "Link 2 (" + iface + "): yes", 5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingTunDNS{replies: map[string]string{
+				"resolvectl default-route " + iface: tc.reply,
+			}}
+			rec.install(t)
+
+			if err := EnsureSysDNSForTun("tun-easyss", []string{"223.5.5.5"}); err != nil {
+				t.Fatalf("EnsureSysDNSForTun: %v", err)
+			}
+			if len(rec.commands) != tc.wantCmds {
+				t.Errorf("issued %d commands (%v), want %d", len(rec.commands), rec.commands, tc.wantCmds)
+			}
+		})
+	}
+}
+
+func TestResolvectlBool(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Link 2 (wlp0s20f3): no", "no"},
+		{"Link 2 (wlp0s20f3): yes", "yes"},
+		// A link name must never be mistaken for the answer.
+		{"Link 2 (eno1): no", "no"},
+		{"Link 2 (eno1): yes", "yes"},
+		{"eno1", ""},
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		if got := resolvectlBool(tc.in); got != tc.want {
+			t.Errorf("resolvectlBool(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/util/sysdns_tun_other.go
+++ b/util/sysdns_tun_other.go
@@ -1,0 +1,35 @@
+//go:build !linux
+
+package util
+
+import "slices"
+
+// SetSysDNSForTun configures DNS resolution for TUN mode. Platforms other than
+// Linux keep their DNS configuration at the network-service or connection level
+// (networksetup on macOS, the registry on Windows) and resolve through the
+// routing table, so the TUN routes carry the lookups into the tunnel without
+// any per-link resolver state: the plain system DNS is all that is needed.
+func SetSysDNSForTun(_ string, v []string) error {
+	return SetSysDNS(v)
+}
+
+// EnsureSysDNSForTun reports nothing to re-assert on these platforms.
+func EnsureSysDNSForTun(_ string, _ []string) error {
+	return nil
+}
+
+// RestoreSysDNSForTun restores the servers captured before TUN started.
+func RestoreSysDNSForTun(_ string, origin []string) error {
+	if len(origin) == 0 {
+		return SetSysDNS([]string{"empty"})
+	}
+
+	curr, err := SysDNS()
+	if err != nil {
+		return err
+	}
+	if slices.Equal(curr, origin) {
+		return nil
+	}
+	return SetSysDNS(origin)
+}


### PR DESCRIPTION
## 现象

TUN 模式下被墙域名打不开（`curl https://www.google.com` 10s 超时），而走本地 HTTP 代理（`-x http://127.0.0.1:5080`）正常；未被墙站点经 TUN 都正常（debian/mozilla/python 200）。删掉 `chrome-flags.conf` 里的代理配置后暴露。

## 根因：DNS 查询被"钉"在物理网卡上，绕过隧道

`util.SetSysDNS` 用 `resolvectl dns <物理网卡> 223.5.5.5` 下发，语义是"**这个 DNS 服务器属于这条链路**"（`resolvectl(1)`：per-interface DNS configuration）。systemd-resolved 查询某条链路的解析器时，会把 socket **绑定到该链路的网卡**发出，于是**不查路由表**：

```
ip route get 223.5.5.5                    -> dev tun-easyss     ← 路由本身没问题
ip route get 223.5.5.5 from 192.168.3.93  -> dev tun-easyss     ← 带物理源地址也一样
```

于是 DNS 从 wlan0 直出，被墙域名拿到**污染应答**：`www.google.com` 的 A 记录实测返回 `69.171.235.22`（Facebook 段）、`104.244.42.197`（Twitter 段）、`157.240.7.20`（Facebook 段），AAAA 返回 `2001::1`。客户端随后连接的是这些**假 IP**，而 easyss 只能看到"目标是某个 IP 的连接"并忠实代理它 → 必然失败。

三条独立证据：

- easyss 日志里从来没有 `www.google.com qtype=A`，这些毒 IP 也从未由它返回 → 包**没进 TUN**；
- `resolvectl query --cache=no www.google.com` **9.2 ms** 返回毒 IP，而经隧道的 DNS 至少一个 RTT（同日志 `avg_rtt` 172–188 ms）→ 只能来自直连路径；
- 反证：easyss 写进 `/etc/resolv.conf` 的 `nameserver 223.5.5.5`（同样公网地址、但没有链路归属）→ 走路由表 → 进隧道，日志里就有 `[DNS_PROXY] domain=google.com qtype=AAAA`。

即：**决定行为的是作用域（会不会被钉在网卡上），不是地址**。文档依据：`resolved.conf(5)` 的 `DNS=`（与 per-link 是 *in parallel*）、`systemd-resolved.service(8)`（"…on local interfaces that have a DNS server configured…"）、`resolvectl(1)` 的 `default-route` 定义（*"whether the link may be used as default route for DNS lookups"*）。

## 改动

- `util`：新增 `SetSysDNSForTun` / `EnsureSysDNSForTun` / `RestoreSysDNSForTun`。Linux 上让 **TUN 设备成为携带解析器的 DNS default-route 链路**，同时把物理链路从 default-route 中摘掉；恢复时把 default-route 还给物理链路并清掉 TUN 链路状态（链路随接口消失）。同一个公网 DNS 值不变，只是把查询钉进隧道，由 easyss 按域名分流（CN 直连、其余走服务端）。
- `cmd/easyss`：helper 用新调用设置/恢复 TUN 会话的 DNS，并在 keep-alive（10s）里重新施加——NetworkManager 在连接变化/DHCP 续租时会重写链路 DNS，可能把 DNS default-route 还给物理链路。
- `client/tun`：非 helper 的 Linux 路径（root 模式）同样钉住解析器。
- 其它平台保持原样：macOS 用 `networksetup`（服务级 DNS），mDNSResponder 走路由表、TUN 路由本来就能把查询带进隧道，所以那边一直正常。

## 验证

- 单测覆盖下发的 resolvectl 命令序列，含"物理链路把 DNS default-route 抢回去"的探测；`go test ./...` 通过、`make lint` 0 issues、linux/darwin/windows 交叉编译通过。
- 现场验证清单（需要重启客户端让 helper 生效）：
  1. 开 TUN 后 `resolvectl status` → `Link … (tun-easyss)` 下应有 `DNS Servers: 223.5.5.5`、`Default Route: yes`；`resolvectl default-route` 里物理网卡应为 `no`；
  2. `resolvectl query --cache=no www.google.com` → 真实 `142.250.x/172.217.x`，耗时从 ~9ms 变为 ~190ms（说明进了隧道）；
  3. `curl -4 -sS -m 8 -o /dev/null -w '%{http_code}\n' https://www.google.com` → `200`；
  4. 日志出现 `[DNS_PROXY] domain=www.google.com qtype=A` 与 `answers=[142.250.x.x]`；
  5. 关 TUN 后 `resolvectl default-route` 里物理网卡回到 `yes`，DNS 恢复为 `192.168.3.1`。

## 备注

本地 `go test ./client/` 在 **TUN 开启**时会失败（`TestDialWithConfigRefreshesAndRetriesOnStaleError: network is down`）——已在未改动的 master 上复现，属于既有的环境相关问题，与本改动无关；CI（无 TUN）不受影响。
