### PR TITLE
fix: frame proxied dns answers with the address the client queried

### DIFF
--- a/client/proxy/udp.go
+++ b/client/proxy/udp.go
@@ -197,16 +197,23 @@ func (s *Socks5Server) exchangeDirectDNS(ctx context.Context, msg *dns.Msg, addr
 }
 
 func (s *Socks5Server) proxyDNSQuery(srv *socks5.Server, clientAddr *net.UDPAddr, d *socks5.Datagram, msg *dns.Msg, domain string) error {
-	dst := config.ProxyDNSServer
-	key := clientAddr.String() + "_" + dst
+	// upstream is where this proxy resolves the query; the client asked
+	// whichever server its own resolver is configured with, and that is the
+	// address the answer has to be sent from (d.Address()), like every other
+	// DNS branch does. Framing the answer with the upstream instead makes a
+	// transparent NAT (tun2socks) drop it: the flow is keyed by the client's
+	// target, so a datagram claiming to come from a different server never
+	// matches and the query looks unanswered.
+	upstream := config.ProxyDNSServer
+	key := clientAddr.String() + "_" + upstream
 
-	ue, created, err := s.getOrCreateUDPExchange(context.Background(), key, dst, d.Data)
+	ue, created, err := s.getOrCreateUDPExchange(context.Background(), key, upstream, d.Data)
 	if err != nil {
-		log.Error("[UDP_PROXY] open exchange", "dst", dst, "err", err)
+		log.Error("[UDP_PROXY] open exchange", "dst", upstream, "err", err)
 		return err
 	}
 	if created {
-		go s.receiveLoop(ue, srv, clientAddr, dst, key, s.dnsRespTimeout)
+		go s.receiveLoop(ue, srv, clientAddr, d.Address(), key, s.dnsRespTimeout)
 		return nil // first payload already sent in handshake
 	}
 

--- a/client/proxy/udp_reply_test.go
+++ b/client/proxy/udp_reply_test.go
@@ -1,0 +1,62 @@
+package proxy
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/txthinking/socks5"
+)
+
+// TestSendToClientFramesReplyFromClientTarget pins the invariant every DNS
+// branch depends on: an answer is framed with the address the client sent its
+// query to, never with the upstream this proxy resolved through. A transparent
+// NAT in front (tun2socks) keys its UDP flows by that address in symmetric NAT
+// mode and drops any datagram whose source differs from it, so a reply framed
+// with the upstream made the query look unanswered — for every proxied query
+// whose upstream (config.ProxyDNSServer, 8.8.8.8:53) differed from the
+// resolver the client asked (e.g. the 223.5.5.5 configured for TUN mode).
+func TestSendToClientFramesReplyFromClientTarget(t *testing.T) {
+	clientConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("listen client socket: %v", err)
+	}
+	t.Cleanup(func() { clientConn.Close() }) //nolint:errcheck
+
+	serverConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("listen server socket: %v", err)
+	}
+	t.Cleanup(func() { serverConn.Close() }) //nolint:errcheck
+
+	// The SOCKS5 side only touches srv.UDPConn here, so a bare server is
+	// enough: no listener, handler or transport is involved.
+	clientAddr := clientConn.LocalAddr().(*net.UDPAddr)
+	s := &Socks5Server{}
+	s.sendToClient(&socks5.Server{UDPConn: serverConn}, clientAddr, []byte("answer"), "223.5.5.5:53")
+
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 512)
+	n, _, err := clientConn.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	if n < 4 {
+		t.Fatalf("reply is %d bytes, too short for a SOCKS5 UDP header", n)
+	}
+
+	// Parse with the same framing the peer (tun2socks) reads: the address in
+	// the header is the source it matches the reply against.
+	d, err := socks5.NewDatagramFromBytes(buf[:n])
+	if err != nil {
+		t.Fatalf("parse reply datagram: %v", err)
+	}
+	if got := d.Address(); got != "223.5.5.5:53" {
+		t.Errorf("reply source = %s, want the client's target 223.5.5.5:53", got)
+	}
+	if got := string(d.Data); got != "answer" {
+		t.Errorf("payload = %q, want %q", got, "answer")
+	}
+}


### PR DESCRIPTION
## 现象

TUN 模式下日志被大量这类警告刷屏（tun2socks 自己的 logger，JSON 格式）：

```
{"level":"warn","ts":…,"caller":"tunnel/udp.go:109","msg":"[UDP] symmetric NAT 198.18.0.1:51801->223.5.5.5:53: drop packet from 8.8.8.8:53"}
```

## 根因

`client/proxy/udp.go` 的 `[DNS_PROXY]` 分支（`proxyDNSQuery`）在把应答回给客户端时，用的是**上游地址** `config.ProxyDNSServer`（`client/config/config.go:21` = `8.8.8.8:53`）作为回包源地址：

```go
dst := config.ProxyDNSServer
…
go s.receiveLoop(ue, srv, clientAddr, dst, key, s.dnsRespTimeout)   // ← 回包用 dst 当"源"
```

而客户端当初是向**它自己配置的解析器**发起查询的（TUN 模式钉进隧道的路径下就是 `223.5.5.5:53`）。tun2socks 的 UDP NAT 按 `(客户端, 目标)` 匹配流，在 symmetric NAT 模式下看到"`223.5.5.5:53` 的流收到来自 `8.8.8.8:53` 的包"就直接丢弃 —— 这正是日志那一行。

**其余三条 DNS 分支都是正确的**（用客户端原始目标 `d.Address()`）：`[DNS_BLOCK]`、`[DNS_CACHE] hit`、`[DNS_DIRECT] result`；只有 `[DNS_PROXY]` 这条不一致。

影响：发往系统解析器（223.5.5.5:53）的查询回包被丢，resolved 只能靠超时重试、或回落到 `FallbackDNS`（其中恰好含 `8.8.8.8`，源地址与上游一致才被接受），于是"网页能开但慢、日志刷警告"。此前不出现，是因为解析查询被"钉"在物理网卡上、根本不进隧道；#157 把解析钉进隧道后这条路径才被大量走到。

## 改动

- `client/proxy`：回包改用 `d.Address()`（客户端查询的目标地址）；`config.ProxyDNSServer` 仅保留"这条查询去哪个上游解析"的语义，并加注释说明两个地址不可混用。
- `client/proxy`：新增单测 `TestSendToClientFramesReplyFromClientTarget`——真实 UDP socket 对 + 用对端（tun2socks）同款 `socks5.NewDatagramFromBytes` 解析回包，固定"回包源地址 = 客户端目标"这一契约。

## 验证

- `go test ./client/proxy/` 通过、`go build ./...` OK、`make lint` 0 issues。
- 现场验证（重启客户端后）：`[UDP] symmetric NAT … drop packet from 8.8.8.8:53` 警告应消失；`resolvectl query --cache=no www.google.com` 的耗时/结果不再依赖回落，`grep "symmetric NAT" bin/easyss.log | wc -l` 增量应为 0。
